### PR TITLE
Prerelease fixes: Update tox envs dependencies and release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,9 +6,6 @@
 - added: documentation on readthedocs.io
 - fixed: documentation displayed with `help`/`-h`/`--help`
 - improved: content of git-machete project related blogs has been moved to this repo and updated
-
-## New in git-machete 3.3.1
-
 - removed: releases to Nixpkgs no longer happen directly from our CI pipeline
 
 ## New in git-machete 3.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,7 @@ whitelist_externals = tox
 commands = tox -e "mypy-py{36,37,38,39}"
 
 [testenv:mypy-py{36,37,38,39}]
+deps = mypy
 whitelist_externals = mypy
 commands =
   mypy --config-file mypy.ini git_machete

--- a/tox.ini
+++ b/tox.ini
@@ -55,6 +55,5 @@ commands = tox -e "mypy-py{36,37,38,39}"
 
 [testenv:mypy-py{36,37,38,39}]
 deps = mypy
-whitelist_externals = mypy
 commands =
   mypy --config-file mypy.ini git_machete


### PR DESCRIPTION
Add mypy dependency to tox environment mypy-py{36,37,38,39} and join release notes from 3.3.1 and 3.4.0 since there was no release 3.3.1.