### PR TITLE
Move `validate_python_version` to `git-machete` file

### DIFF
--- a/ci/checks/enforce-indent-two-spaces-outside-python.sh
+++ b/ci/checks/enforce-indent-two-spaces-outside-python.sh
@@ -22,5 +22,5 @@ awk_script="$(cat <<'EOF'
 EOF
 )"
 
-git ls-files ':!/.circleci/config.yml' ':!*/Dockerfile' ':!graphics/setup-sandbox' ':!docs/*' ':!*.md' ':!*.py' ':!*.svg' ':!*.png' ':!git-machete' \
+git ls-files ':!/.circleci/config.yml' ':!*/Dockerfile' ':!docs/*' ':!graphics/setup-sandbox' ':!*.md' ':!*.png' ':!*.py' ':!*.svg' \
   | xargs awk "$awk_script"

--- a/ci/checks/enforce-indent-two-spaces-outside-python.sh
+++ b/ci/checks/enforce-indent-two-spaces-outside-python.sh
@@ -22,5 +22,5 @@ awk_script="$(cat <<'EOF'
 EOF
 )"
 
-git ls-files ':!/.circleci/config.yml' ':!*/Dockerfile' ':!graphics/setup-sandbox' ':!docs/*' ':!*.md' ':!*.py' ':!*.svg' ':!*.png' 'git-machete' \
+git ls-files ':!/.circleci/config.yml' ':!*/Dockerfile' ':!graphics/setup-sandbox' ':!docs/*' ':!*.md' ':!*.py' ':!*.svg' ':!*.png' ':!git-machete' \
   | xargs awk "$awk_script"

--- a/ci/checks/enforce-indent-two-spaces-outside-python.sh
+++ b/ci/checks/enforce-indent-two-spaces-outside-python.sh
@@ -22,5 +22,5 @@ awk_script="$(cat <<'EOF'
 EOF
 )"
 
-git ls-files ':!/.circleci/config.yml' ':!*/Dockerfile' ':!graphics/setup-sandbox' ':!docs/*' ':!*.md' ':!*.py' ':!*.svg' ':!*.png' \
+git ls-files ':!/.circleci/config.yml' ':!*/Dockerfile' ':!graphics/setup-sandbox' ':!docs/*' ':!*.md' ':!*.py' ':!*.svg' ':!*.png' 'git-machete' \
   | xargs awk "$awk_script"

--- a/git-machete
+++ b/git-machete
@@ -5,12 +5,12 @@ import sys
 # Check for correct python version
 # Since function below needs to be compatible with python 2, lets skip Mypy checks, cause type annotations were introduced in python 3.5
 def validate_python_version():  # type: ignore
-    if sys.version_info[:2] < (3, 6):
-        version_str = "{}.{}.{}".format(sys.version_info.major, sys.version_info.minor, sys.version_info.micro)
-        sys.stderr.write(
+  if sys.version_info[:2] < (3, 6):
+    version_str = "{}.{}.{}".format(sys.version_info.major, sys.version_info.minor, sys.version_info.micro)
+    sys.stderr.write(
             "Python {} is no longer supported. \n".format(version_str) +
             "Please switch to Python 3.6 or higher.\n")
-        sys.exit(1)
+    sys.exit(1)
 
 
 validate_python_version()  # type: ignore

--- a/git-machete
+++ b/git-machete
@@ -1,4 +1,19 @@
 #!/usr/bin/env python3
 
+import sys
+
+# Check for correct python version
+# Since function below needs to be compatible with python 2, lets skip Mypy checks, cause type annotations were introduced in python 3.5
+def validate_python_version():  # type: ignore
+    if sys.version_info[:2] < (3, 6):
+        version_str = "{}.{}.{}".format(sys.version_info.major, sys.version_info.minor, sys.version_info.micro)
+        sys.stderr.write(
+            "Python {} is no longer supported. \n".format(version_str) +
+            "Please switch to Python 3.6 or higher.\n")
+        sys.exit(1)
+
+
+validate_python_version()  # type: ignore
+
 from git_machete import cli
 cli.main()

--- a/git-machete
+++ b/git-machete
@@ -8,8 +8,8 @@ def validate_python_version():  # type: ignore
   if sys.version_info[:2] < (3, 6):
     version_str = "{}.{}.{}".format(sys.version_info.major, sys.version_info.minor, sys.version_info.micro)
     sys.stderr.write(
-            "Python {} is no longer supported. \n".format(version_str) +
-            "Please switch to Python 3.6 or higher.\n")
+      "Python {} is no longer supported. \n".format(version_str) +
+      "Please switch to Python 3.6 or higher.\n")
     sys.exit(1)
 
 

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -454,15 +454,6 @@ def set_utils_global_variables(
     utils.verbose_mode = cli_opts.opt_verbose
 
 
-def validate_python_version() -> None:
-    if sys.version_info[:2] < (3, 6):
-        version_str = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
-        sys.stderr.write(
-            f"Python {version_str} is no longer supported. "
-            "Please switch to Python 3.6 or higher.\n")
-        sys.exit(1)
-
-
 def get_branch_arg_or_current_branch(
         cli_opts: git_machete.options.CommandLineOptions, git_context: GitContext) -> str:
     return cli_opts.opt_branch or git_context.get_current_branch()
@@ -796,7 +787,6 @@ def launch(orig_args: List[str]) -> None:
 
 
 def main() -> None:
-    validate_python_version()
     launch(sys.argv[1:])
 
 


### PR DESCRIPTION
closes #285 
Solution to check python version before syntax error is raised.