### PR TITLE
Issue #284: Fix the bash completion

### DIFF
--- a/completion/git-machete.completion.bash
+++ b/completion/git-machete.completion.bash
@@ -61,7 +61,11 @@ _git_machete() {
       esac ;;
     *)
       if [[ $COMP_CWORD -eq 2 ]]; then
-        __gitcomp "$cmds"
+        if [[ $cmds =~ ^$cur ]] || [[ $cmds =~ ( $cur) ]]; then
+          __gitcomp "$cmds"
+        else
+          COMPREPLY=('')
+        fi
       else
         local prev=${COMP_WORDS[COMP_CWORD-1]}
         case $prev in


### PR DESCRIPTION
Fix the issue that bash completion scripts completes local paths for commands if no matching prefix has been found
![Screenshot 2021-10-20 at 14 35 23](https://user-images.githubusercontent.com/13608913/138093607-b3807d99-8aa8-4d74-985d-08259f1f7812.png)
.