### PR TITLE
Issue #289: Add github and is-managed commands to top-level help.

### DIFF
--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -31,7 +31,7 @@ alias_by_command: Dict[str, str] = {
 
 command_groups: List[Tuple[str, List[str]]] = [
     ("General topics",
-     ["file", "help", "hooks", "version"]),
+     ["file", "format", "help", "hooks", "version"]),
     ("Build, display and modify the tree of branch dependencies",
      ["add", "anno", "discover", "edit", "status"]),
     ("List, check out and delete branches",

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -30,7 +30,6 @@ alias_by_command: Dict[str, str] = {
 }
 
 command_groups: List[Tuple[str, List[str]]] = [
-    # 'is-managed' is mostly for scripting use and therefore skipped
     ("General topics",
      ["file", "help", "hooks", "version"]),
     ("Build, display and modify the tree of branch dependencies",
@@ -40,7 +39,9 @@ command_groups: List[Tuple[str, List[str]]] = [
     ("Determine changes specific to the given branch",
      ["diff", "fork-point", "log"]),
     ("Update git history in accordance with the tree of branch dependencies",
-     ["advance", "reapply", "slide-out", "squash", "traverse", "update"])
+     ["advance", "reapply", "slide-out", "squash", "traverse", "update"]),
+    ("Utilities",
+     ["github", "is-managed"])
 ]
 
 

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -35,13 +35,13 @@ command_groups: List[Tuple[str, List[str]]] = [
     ("Build, display and modify the tree of branch dependencies",
      ["add", "anno", "discover", "edit", "status"]),
     ("List, check out and delete branches",
-     ["delete-unmanaged", "go", "list", "show"]),
+     ["delete-unmanaged", "go", "is-managed", "list", "show"]),
     ("Determine changes specific to the given branch",
      ["diff", "fork-point", "log"]),
     ("Update git history in accordance with the tree of branch dependencies",
      ["advance", "reapply", "slide-out", "squash", "traverse", "update"]),
     ("Utilities",
-     ["github", "is-managed"])
+     ["github"])
 ]
 
 

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -40,7 +40,7 @@ command_groups: List[Tuple[str, List[str]]] = [
      ["diff", "fork-point", "log"]),
     ("Update git history in accordance with the tree of branch dependencies",
      ["advance", "reapply", "slide-out", "squash", "traverse", "update"]),
-    ("Utilities",
+    ("Integrate with third party tools",
      ["github"])
 ]
 


### PR DESCRIPTION
I've created new section `Utilities` and added both `github` and `is-managed` commands there.

![Screenshot 2021-10-21 at 13 36 36](https://user-images.githubusercontent.com/13608913/138269322-6a5d8ee3-da89-49dc-bef3-47f7e933fdda.png)