### PR TITLE
If current branch has not been slid out, then `git machete slide-out` no longer switches the current branch

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 - fixed: incorrect `Could not determine base branch for PR` error messages when creating PRs from `git machete traverse -H`
 - fixed: `git bisect` is recognized as a separate repository state by `git machete status` and side-effecting operations
 - fixed: branches marked as `slide-out=no` are no longer slid out by `git machete slide-out --removed-from-remote`
+- fixed: if current branch hasn't been slid out, then `git machete slide-out` no longer switches the current branch
 
 ## New in git-machete 3.36.0
 

--- a/git_machete/client/slide_out.py
+++ b/git_machete/client/slide_out.py
@@ -85,7 +85,9 @@ class SlideOutMacheteClient(MacheteClient):
             slid_out_branch=branches_to_slide_out[-1],
             new_downstreams=new_downstreams)
 
-        self._git.checkout(new_upstream)
+        if self._git.get_current_branch_or_none() in branches_to_slide_out:
+            self._git.checkout(new_upstream)
+
         for new_downstream in new_downstreams:
             anno = self.annotations.get(new_downstream)
             use_merge = opt_merge or (anno and anno.qualifiers.update_with_merge)

--- a/tests/test_slide_out.py
+++ b/tests/test_slide_out.py
@@ -10,7 +10,7 @@ from .mockers import (assert_failure, assert_success,
                       set_file_executable, write_to_file)
 from .mockers_git_repository import (amend_commit, check_out, commit,
                                      create_repo, create_repo_with_remote,
-                                     delete_remote_branch,
+                                     delete_remote_branch, get_current_branch,
                                      get_current_commit_hash,
                                      get_local_branches, new_branch, push)
 
@@ -169,6 +169,27 @@ class TestSlideOut(BaseTest):
             o-child_b *
             """,
         )
+
+    def test_slide_out_branch_other_than_current(self) -> None:
+        create_repo()
+        new_branch('branch-0')
+        commit()
+        new_branch('branch-1')
+        commit()
+        new_branch('branch-2')
+        commit()
+
+        body: str = \
+            """
+            branch-0
+                branch-1
+                branch-2
+            """
+        rewrite_branch_layout_file(body)
+
+        launch_command("slide-out", "branch-1")
+        # Branch should not be changed by slide-out if the current branch has NOT been slid out
+        assert get_current_branch() == "branch-2"
 
     def test_slide_out_with_post_slide_out_hook(self) -> None:
         create_repo()


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1457

## Chain of upstream PRs as of 2025-07-03

* PR #1454:
  `develop` ← `fix/bisect-recognize`

  * PR #1455:
    `fix/bisect-recognize` ← `chore/close-github-milestone`

    * PR #1456:
      `chore/close-github-milestone` ← `docs/more-spacing`

      * PR #1457:
        `docs/more-spacing` ← `fix/slide-out-no-remove-from-remote`

        * **PR #1458 (THIS ONE)**:
          `fix/slide-out-no-remove-from-remote` ← `fix/slide-out-no-checkout-topmost`

<!-- end git-machete generated -->
