### PR TITLE
Implement worktree support for traverse command

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## New in git-machete 3.37.1
 
+- improved: `traverse` now changes directory to the worktree where a branch is checked out, rather than failing (suggested by @lsierant)
 - fixed: use `simple` (rather than `none`) mode of squash merge detection in `git machete discover`, to keep parity with the IntelliJ plugin
 
 ## New in git-machete 3.37.0

--- a/docs/man/git-machete.1
+++ b/docs/man/git-machete.1
@@ -2143,6 +2143,8 @@ Operations like \fBgit machete github anno\-prs\fP (\fBgit machete gitlab anno\-
 and \fBgit machete github checkout\-prs\fP (\fBgit machete gitlab checkout\-mrs\fP) add \fBrebase=no push=no\fP branch qualifiers
 when the current user is NOT the author of the PR/MR associated with that branch.
 .sp
+\fBNote on git worktrees:\fP if a branch is already checked out in another worktree, \fBtraverse\fP will change directory to that worktree rather than failing.
+.sp
 \fBOptions:\fP
 .INDENT 0.0
 .TP

--- a/docs/source/cli/traverse.rst
+++ b/docs/source/cli/traverse.rst
@@ -91,6 +91,8 @@ Operations like ``git machete github anno-prs`` (``git machete gitlab anno-mrs``
 and ``git machete github checkout-prs`` (``git machete gitlab checkout-mrs``) add ``rebase=no push=no`` branch qualifiers
 when the current user is NOT the author of the PR/MR associated with that branch.
 
+**Note on git worktrees:** if a branch is already checked out in another worktree, ``traverse`` will change directory to that worktree rather than failing.
+
 **Options:**
 
 -F, --fetch                    Fetch the remotes of all managed branches at the beginning of traversal (no ``git pull`` involved, only ``git fetch``).

--- a/git_machete/generated_docs.py
+++ b/git_machete/generated_docs.py
@@ -1485,6 +1485,8 @@ long_docs: Dict[str, str] = {
         and `git machete github checkout-prs` (`git machete gitlab checkout-mrs`) add `rebase=no push=no` branch qualifiers
         when the current user is NOT the author of the PR/MR associated with that branch.
 
+        <b>Note on git worktrees:</b> if a branch is already checked out in another worktree, `traverse` will change directory to that worktree rather than failing.
+
         <b>Options:</b>
 
            <b>-F</b>, <b>--fetch</b>

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -219,6 +219,7 @@ class GitContext:
         self.owner: Optional[Any] = None
 
         self.__git_version: Optional[Tuple[int, int, int]] = None
+        self.__main_worktree_root_dir: Optional[str] = None
         self.__main_worktree_git_dir: Optional[str] = None
         self.__current_worktree_root_dir: Optional[str] = None
         self.__current_worktree_git_dir: Optional[str] = None
@@ -256,8 +257,13 @@ class GitContext:
         self.__short_commit_hash_by_revision_cached = {}
         self.__flush_current_worktree_caches()
 
+    def chdir(self, path: str) -> None:
+        os.chdir(path)
+        self.__flush_current_worktree_caches()
+
     def __flush_current_worktree_caches(self) -> None:
         self.__current_worktree_root_dir = None
+        self.__main_worktree_root_dir = None
 
     def _run_git(self, git_cmd: str, *args: str, flush_caches: bool, allow_non_zero: bool = False) -> int:
         exit_code = utils.run_cmd(*GIT_EXEC, git_cmd, *args)
@@ -572,6 +578,75 @@ class GitContext:
 
     def is_revert_in_progress(self) -> bool:
         return os.path.isfile(self.get_current_worktree_git_subpath("REVERT_HEAD"))
+
+    def get_worktree_root_dirs_by_branch(self) -> Dict[LocalBranchShortName, str]:
+        """
+        Returns a dict mapping branch names to their worktree paths.
+        The main worktree's current branch is included if it's on a branch.
+        Branches not checked out in any worktree are not in the dict.
+        Worktrees in detached HEAD state are not included (since they can't be looked up by branch name).
+        """
+        if self.get_git_version() < (2, 5):
+            # git worktree command was introduced in git 2.5
+            return {}
+
+        result = self._popen_git("worktree", "list", "--porcelain")
+        worktrees: Dict[LocalBranchShortName, str] = {}
+
+        current_worktree_path: Optional[str] = None
+        current_branch: Optional[LocalBranchShortName] = None
+        is_detached: bool = False
+
+        for line in result.stdout.strip().splitlines():
+            if line.startswith('worktree '):
+                current_worktree_path = line[len('worktree '):]
+            elif line.startswith('branch '):
+                # Format: "branch refs/heads/<branch-name>"
+                branch_ref = line[len('branch '):]
+                current_branch = LocalBranchFullName.of(branch_ref).to_short_name()
+                is_detached = False
+            elif line.startswith('detached'):
+                is_detached = True
+                current_branch = None
+            elif line == '':
+                # Empty line marks end of worktree entry
+                # Only add worktrees that have a branch (not in detached HEAD state)
+                if current_worktree_path and current_branch is not None and not is_detached:
+                    worktrees[current_branch] = current_worktree_path
+                current_worktree_path = None
+                current_branch = None
+                is_detached = False
+
+        # Handle last entry if no trailing newline
+        if current_worktree_path and current_branch is not None and not is_detached:
+            worktrees[current_branch] = current_worktree_path
+
+        return worktrees
+
+    def get_main_worktree_root_dir(self) -> str:
+        """
+        Returns the path to the main worktree (not a linked worktree).
+        """
+        if not self.__main_worktree_root_dir:
+            if self.get_git_version() < (2, 5):
+                # git worktree command was introduced in git 2.5
+                # If worktrees aren't supported, just return the current root dir
+                self.__main_worktree_root_dir = self.get_current_worktree_root_dir()
+            else:
+                # We can't rely on `git rev-parse --git-common-dir`
+                # since in some earlier supported versions of git
+                # this path is apparently printed in a faulty way when dealing with worktrees.
+                # Let's parse the output of of `git worktree list` instead.
+                result = self._popen_git("worktree", "list", "--porcelain")
+
+                # The first worktree in the list is always the main worktree
+                first_entry = result.stdout.splitlines()[0]
+                if first_entry.startswith('worktree '):
+                    self.__main_worktree_root_dir = first_entry[len('worktree '):]
+                else:
+                    raise UnexpectedMacheteException("Could not obtain the main worktree path from "
+                                                     f"`git worktree list --porcelain` output (first line: `{first_entry}`)")
+        return self.__main_worktree_root_dir
 
     def checkout(self, branch: LocalBranchShortName) -> None:
         self._run_git("checkout", "--quiet", branch, "--", flush_caches=True)


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1528

## Chain of upstream PRs as of 2025-11-14

* PR #1528:
  `develop` ← `refactor/rename-worktree-git-ops`

  * **PR #1524 (THIS ONE)**:
    `refactor/rename-worktree-git-ops` ← `improve/1522-worktree-switch-traverse`

<!-- end git-machete generated -->

- Add get_worktrees() and get_worktree_path() methods to GitOperations
- Modify traverse to cd into worktrees where branches are checked out
- Cache worktree information to avoid repeated git worktree list calls
- Add informative messages when changing directories to worktrees
- Add comprehensive tests for worktree handling including detached HEAD cases
- Add integration test for traverse with multiple worktrees

Fixes #1522


**TBD**: how about checkout from other commands like `git machete go`? ➡️ leave as is, there's no easy way to switch shell's wd from inside Python process; just fail

**TODO**: mention in docs ➡️ done