### PR TITLE
Fix worktree path format on Windows

### DIFF
--- a/git_machete/client/traverse.py
+++ b/git_machete/client/traverse.py
@@ -1,5 +1,4 @@
 import itertools
-import os
 from enum import auto
 from typing import Dict, List, Optional, Type, Union
 
@@ -12,7 +11,8 @@ from git_machete.exceptions import MacheteException, UnexpectedMacheteException
 from git_machete.git_operations import (GitContext, LocalBranchShortName,
                                         SyncToRemoteStatus)
 from git_machete.utils import (bold, flat_map, fmt, get_pretty_choices,
-                               get_right_arrow, warn)
+                               get_right_arrow, normalize_path_for_display,
+                               warn)
 
 
 class TraverseReturnTo(ParsableEnum):
@@ -499,10 +499,7 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
             final_worktree_path = self.__worktree_root_dir_for_branch.get(final_branch)
             if final_worktree_path and initial_worktree_root != final_worktree_path:
                 # Final branch is checked out in a worktree different from where we started
-                # Normalize path to forward slashes for cross-platform compatibility
-                # (forward slashes work in Git Bash, PowerShell, and CMD on Windows)
-                # Use realpath to handle symlinks and macOS /private prefix
-                normalized_path = os.path.realpath(final_worktree_path).replace('\\', '/')
+                normalized_path = normalize_path_for_display(final_worktree_path)
                 warn(
                     f"branch {bold(final_branch)} is checked out in worktree at {bold(normalized_path)}\n"
                     f"You may want to change directory with:\n"

--- a/git_machete/client/traverse.py
+++ b/git_machete/client/traverse.py
@@ -498,6 +498,7 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
             final_worktree_path = self.__worktree_root_dir_for_branch.get(final_branch)
             if final_worktree_path and initial_worktree_root != final_worktree_path:
                 # Final branch is checked out in a worktree different from where we started
+                # TODO (#1531): on Windows, format the paths accordingly in each shell
                 warn(
                     f"branch {bold(final_branch)} is checked out in worktree at {bold(final_worktree_path)}\n"
                     f"You may want to change directory with:\n"

--- a/git_machete/client/traverse.py
+++ b/git_machete/client/traverse.py
@@ -1,4 +1,5 @@
 import itertools
+import os
 from enum import auto
 from typing import Dict, List, Optional, Type, Union
 
@@ -498,8 +499,11 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
             final_worktree_path = self.__worktree_root_dir_for_branch.get(final_branch)
             if final_worktree_path and initial_worktree_root != final_worktree_path:
                 # Final branch is checked out in a worktree different from where we started
-                # TODO (#1531): on Windows, format the paths accordingly in each shell
+                # Normalize path to forward slashes for cross-platform compatibility
+                # (forward slashes work in Git Bash, PowerShell, and CMD on Windows)
+                # Use realpath to handle symlinks and macOS /private prefix
+                normalized_path = os.path.realpath(final_worktree_path).replace('\\', '/')
                 warn(
-                    f"branch {bold(final_branch)} is checked out in worktree at {bold(final_worktree_path)}\n"
+                    f"branch {bold(final_branch)} is checked out in worktree at {bold(normalized_path)}\n"
                     f"You may want to change directory with:\n"
-                    f"  `cd {final_worktree_path}`")
+                    f"  `cd {normalized_path}`")

--- a/tests/test_traverse.py
+++ b/tests/test_traverse.py
@@ -2132,7 +2132,7 @@ class TestTraverse(BaseTest):
 
         # Verify the warning is emitted
         assert "branch branch-2 is checked out in worktree at" in output
-        assert f"You may want to change directory with:\n  cd {os.path.realpath(branch_2_worktree)}" in output
+        assert f"You may want to change directory with:\n  cd {branch_2_worktree}" in output
 
     def test_traverse_no_warn_when_final_branch_in_same_worktree(self) -> None:
         if get_git_version() < (2, 5):

--- a/tests/test_traverse.py
+++ b/tests/test_traverse.py
@@ -2132,7 +2132,10 @@ class TestTraverse(BaseTest):
 
         # Verify the warning is emitted
         assert "branch branch-2 is checked out in worktree at" in output
-        assert f"You may want to change directory with:\n  cd {branch_2_worktree}" in output
+        # Normalize to forward slashes for cross-platform compatibility
+        # Use realpath to handle macOS /private prefix
+        normalized_branch_2_worktree = os.path.realpath(branch_2_worktree).replace('\\', '/')
+        assert f"You may want to change directory with:\n  cd {normalized_branch_2_worktree}" in output
 
     def test_traverse_no_warn_when_final_branch_in_same_worktree(self) -> None:
         if get_git_version() < (2, 5):
@@ -2201,4 +2204,7 @@ class TestTraverse(BaseTest):
         # Verify traverse stops early and the warning is still emitted
         assert "Rebase branch-1 onto root?" in output
         assert "branch branch-1 is checked out in worktree at" in output
-        assert f"You may want to change directory with:\n  cd {os.path.realpath(branch_1_worktree)}" in output
+        # Normalize to forward slashes for cross-platform compatibility
+        # Use realpath to handle macOS /private prefix
+        normalized_branch_1_worktree = os.path.realpath(branch_1_worktree).replace('\\', '/')
+        assert f"You may want to change directory with:\n  cd {normalized_branch_1_worktree}" in output

--- a/tests/test_traverse.py
+++ b/tests/test_traverse.py
@@ -4,6 +4,7 @@ import subprocess
 from pytest_mock import MockerFixture
 
 from git_machete.exceptions import UnderlyingGitException
+from git_machete.utils import normalize_path_for_display
 
 from .base_test import BaseTest
 from .mockers import (assert_failure, assert_success,
@@ -1960,7 +1961,7 @@ class TestTraverse(BaseTest):
         # In worktrees, .git is a file not a directory, so use git command directly
         execute("touch feature-1-file.txt")
         execute("git add feature-1-file.txt")
-        execute("git commit -m 'feature-1 additional commit'")
+        execute('git commit -m "feature-1 additional commit"')
         os.chdir(initial_dir)
 
         # Modify develop so feature-2 needs to be rebased
@@ -1974,10 +1975,10 @@ class TestTraverse(BaseTest):
 
         # Verify key behaviors happened:
         # 1. It switched to feature-1 worktree
-        normalized_feature_1_worktree = os.path.realpath(feature_1_worktree).replace('\\', '/')
+        normalized_feature_1_worktree = normalize_path_for_display(feature_1_worktree)
         assert f"Changing directory to {normalized_feature_1_worktree} worktree where feature-1 is checked out" in output
         # 2. It switched to feature-2 worktree
-        normalized_feature_2_worktree = os.path.realpath(feature_2_worktree).replace('\\', '/')
+        normalized_feature_2_worktree = normalize_path_for_display(feature_2_worktree)
         assert f"Changing directory to {normalized_feature_2_worktree} worktree where feature-2 is checked out" in output
         # 3. Operations were performed
         assert "Rebasing feature-1 onto develop" in output
@@ -2044,7 +2045,7 @@ class TestTraverse(BaseTest):
         output = launch_command("traverse", "-y", "--start-from=first-root")
 
         # Verify lines 88-89 were executed (cd to main worktree for root)
-        normalized_local_path = os.path.realpath(local_path).replace('\\', '/')
+        normalized_local_path = normalize_path_for_display(local_path)
         assert f"Changing directory to main worktree at {normalized_local_path}" in output, \
             f"Expected 'Changing directory to main worktree at {normalized_local_path}' in output, but got:\n{output}"
 
@@ -2135,9 +2136,7 @@ class TestTraverse(BaseTest):
 
         # Verify the warning is emitted
         assert "branch branch-2 is checked out in worktree at" in output
-        # Normalize to forward slashes for cross-platform compatibility
-        # Use realpath to handle macOS /private prefix
-        normalized_branch_2_worktree = os.path.realpath(branch_2_worktree).replace('\\', '/')
+        normalized_branch_2_worktree = normalize_path_for_display(branch_2_worktree)
         assert f"You may want to change directory with:\n  cd {normalized_branch_2_worktree}" in output
 
     def test_traverse_no_warn_when_final_branch_in_same_worktree(self) -> None:
@@ -2204,9 +2203,7 @@ class TestTraverse(BaseTest):
         self.patch_symbol(mocker, 'builtins.input', mock_input_returning("q"))
         output = launch_command("traverse")
 
-        # Normalize to forward slashes for cross-platform compatibility
-        # Use realpath to handle macOS /private prefix
-        normalized_branch_1_worktree = os.path.realpath(branch_1_worktree).replace('\\', '/')
+        normalized_branch_1_worktree = normalize_path_for_display(branch_1_worktree)
 
         # Verify traverse changed directory to the worktree during traversal
         assert f"Changing directory to {normalized_branch_1_worktree} worktree where branch-1 is checked out" in output

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,9 @@
+import os
 import re
+import sys
+import tempfile
+
+import pytest
 
 from git_machete import utils
 
@@ -33,3 +38,60 @@ class TestUtils:
 
     def test_hex_repr(self) -> None:
         assert utils.hex_repr("Hello, world!") == "48:65:6c:6c:6f:2c:20:77:6f:72:6c:64:21"
+
+    def test_normalize_path_for_display_general(self) -> None:
+        """Test that normalize_path_for_display returns an absolute path with forward slashes."""
+        # Create a temporary directory to ensure we're working with real paths
+        with tempfile.TemporaryDirectory() as tmpdir:
+            normalized = utils.normalize_path_for_display(tmpdir)
+            # Should be absolute
+            assert os.path.isabs(normalized)
+            # Should use forward slashes (no backslashes)
+            assert '\\' not in normalized
+            # Should be a valid path that exists
+            assert os.path.exists(normalized)
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific test for backslash conversion")
+    def test_normalize_path_for_display_windows_backslashes(self) -> None:
+        """Test that backslashes are converted to forward slashes on Windows."""
+        # On Windows, os.path.realpath() returns paths with backslashes
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # tmpdir will have backslashes on Windows (e.g., C:\Users\...)
+            # Verify it contains backslashes before normalization
+            assert '\\' in tmpdir or '/' in tmpdir  # Windows paths have one or the other
+
+            normalized = utils.normalize_path_for_display(tmpdir)
+
+            # After normalization, should have forward slashes only
+            assert '\\' not in normalized
+            assert '/' in normalized
+            # Should still start with drive letter (e.g., C:/)
+            assert normalized[1:3] == ':/'
+
+    @pytest.mark.skipif(sys.platform != "darwin", reason="macOS-specific test for /private prefix")
+    def test_normalize_path_for_display_macos_private_prefix(self) -> None:
+        """Test that /private prefix is consistently added on macOS for /tmp and /var paths."""
+        # On macOS, /tmp and /var are symlinks to /private/tmp and /private/var
+        # tempfile.mkdtemp() may return paths with or without /private prefix
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # tmpdir is in /tmp or /var on macOS
+            # It might be returned as /var/folders/... or /private/var/folders/...
+
+            normalized = utils.normalize_path_for_display(tmpdir)
+
+            # After normalization with realpath(), should have /private prefix if in /var or /tmp
+            # (realpath resolves the symlink)
+            if '/tmp' in tmpdir or '/var' in tmpdir:
+                # Should start with /private after normalization
+                assert normalized.startswith('/private/'), \
+                    f"Expected path to start with /private/, got: {normalized}"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Unix-specific test for absolute paths")
+    def test_normalize_path_for_display_unix_absolute_paths(self) -> None:
+        """Test that paths start with / on Unix systems."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            normalized = utils.normalize_path_for_display(tmpdir)
+            # Should start with / on Unix
+            assert normalized.startswith('/')
+            # Should not contain backslashes
+            assert '\\' not in normalized


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1529

## Chain of upstream PRs as of 2025-11-17

* PR #1529:
  `master` ← `develop`

  * **PR #1532 (THIS ONE)**:
    `develop` ← `fix/windows-worktree-paths`

<!-- end git-machete generated -->
