### PR TITLE
Explicitly disable interactive `go` on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,7 +297,7 @@ only_special_branches: &only_special_branches
   filters:
     branches:
       only:
-        - "/.*(ci|dependabot.pip|deploy|dry.run|hotfix|publish|release|windows).*/"
+        - "/.*(ci|dependabot.pip|deploy|dry.run|hotfix|macos|publish|release|windows).*/"
         - "develop"
         - "master"
 

--- a/docs/man/git-machete.1
+++ b/docs/man/git-machete.1
@@ -1480,6 +1480,8 @@ If \fB<direction>\fP is not provided, an interactive mode is launched where you 
 \fBq or Ctrl+C\fP: Quit without checking out
 .UNINDENT
 .sp
+\fBNote:\fP Interactive mode is not supported on Windows yet.
+.sp
 If \fB<direction>\fP is provided, checks out the branch specified by the given direction relative to the current branch:
 .INDENT 0.0
 .IP \(bu 2

--- a/docs/source/cli/go.rst
+++ b/docs/source/cli/go.rst
@@ -22,6 +22,8 @@ If ``<direction>`` is not provided, an interactive mode is launched where you ca
 * **Enter or Space**: Check out the selected branch
 * **q or Ctrl+C**: Quit without checking out
 
+**Note:** Interactive mode is not supported on Windows yet.
+
 If ``<direction>`` is provided, checks out the branch specified by the given direction relative to the current branch:
 
 * ``down``:    the direct children/downstream branch of the current branch.

--- a/git_machete/client/go_interactive.py
+++ b/git_machete/client/go_interactive.py
@@ -1,10 +1,17 @@
 import sys
-import termios
-import tty
 from typing import List, Optional, Tuple
+
+try:
+    import termios
+    import tty
+except ImportError:
+    # termios and tty are not available on Windows
+    termios = None  # type: ignore[assignment]
+    tty = None  # type: ignore[assignment]
 
 from git_machete import utils
 from git_machete.client.base import MacheteClient
+from git_machete.exceptions import UnexpectedMacheteException
 from git_machete.git_operations import LocalBranchShortName
 from git_machete.utils import AnsiEscapeCodes, bold, index_or_none, warn
 
@@ -124,6 +131,9 @@ class GoInteractiveMacheteClient(MacheteClient):
         Launch interactive branch selection interface.
         Returns the selected branch or None if cancelled.
         """
+        if termios is None or tty is None:
+            raise UnexpectedMacheteException("Interactive mode is not supported on Windows yet")
+
         # Get flat list of branches with depths from already-parsed state
         self._managed_branches_with_depths = self._get_branch_list_with_depths()
 

--- a/git_machete/generated_docs.py
+++ b/git_machete/generated_docs.py
@@ -994,6 +994,8 @@ long_docs: Dict[str, str] = {
            * <b>Enter or Space</b>: Check out the selected branch
            * <b>q or Ctrl+C</b>: Quit without checking out
 
+        <b>Note:</b> Interactive mode is not supported on Windows yet.
+
         If `<direction>` is provided, checks out the branch specified by the given direction relative to the current branch:
 
            * `down`:    the direct children/downstream branch of the current branch.

--- a/tests/test_go_interactive.py
+++ b/tests/test_go_interactive.py
@@ -1,9 +1,14 @@
-import fcntl
 import os
 import sys
 import threading
 import time
 from typing import Any, Callable, Dict
+
+try:
+    import fcntl
+except ImportError:
+    # fcntl is not available on Windows
+    fcntl = None  # type: ignore[assignment]
 
 import pytest
 from pytest_mock import MockerFixture
@@ -88,6 +93,7 @@ def read_line_from_fd(fd: int, timeout: float = 2.0) -> str:
     return ''
 
 
+@pytest.mark.skipif(sys.platform == 'win32', reason="Interactive mode is not supported on Windows")
 class TestGoInteractive(BaseTest):
     def setup_method(self) -> None:
         """Set up a standard 4-branch repository for each test."""


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1540

## Chain of upstream PRs as of 2025-11-26

* PR #1540:
  `master` ← `develop`

  * **PR #1541 (THIS ONE)**:
    `develop` ← `fix/windows-go-interactive`

<!-- end git-machete generated -->
