### PR TITLE
Fix raw HTTP 422 in case head branch is missing on remote

### DIFF
--- a/git_machete/client/with_code_hosting.py
+++ b/git_machete/client/with_code_hosting.py
@@ -16,7 +16,7 @@ from git_machete.git_operations import (GitContext, GitFormatPatterns,
                                         GitLogEntry, LocalBranchShortName,
                                         RemoteBranchShortName,
                                         SyncToRemoteStatus)
-from git_machete.utils import (bold, debug, find_or_none, fmt,
+from git_machete.utils import (bold, colored_yes_no, debug, find_or_none, fmt,
                                get_pretty_choices, get_right_arrow, slurp_file,
                                warn)
 
@@ -265,15 +265,55 @@ class MacheteClientWithCodeHosting(MacheteClient):
                  f"Generally, {spec.pr_short_name}s need to be created "
                  f"in whatever {spec.repository_name} the {spec.base_branch_name} branch lives.\n")
 
+        head_remote_branch = RemoteBranchShortName(f"{head_org_repo_remote.remote}/{head}")
+        remote_head_branch_exists_locally = head_remote_branch in self._git.get_remote_branches()
         base_remote_branch = RemoteBranchShortName(f"{base_org_repo_remote.remote}/{base}")
         remote_base_branch_exists_locally = base_remote_branch in self._git.get_remote_branches()
-        print(f"Checking if {spec.base_branch_name} branch {bold(base)} "
-              f"exists in {bold(base_org_repo_remote.remote)} remote... ", end='', flush=True)
-        base_branch_found_on_remote = self._git.does_remote_branch_exist(base_org_repo_remote.remote, base)
-        print(fmt('<green><b>YES</b></green>' if base_branch_found_on_remote else '<red><b>NO</b></red>'))
-        if not base_branch_found_on_remote and remote_base_branch_exists_locally:
-            self._git.delete_remote_branch(base_remote_branch)
 
+        # Check both base and head branches in a single git ls-remote call if they use the same remote
+        if base_org_repo_remote.remote == head_org_repo_remote.remote:
+            print(f"Checking if {spec.head_branch_name} branch {bold(head)} "
+                  f"exists in {bold(head_org_repo_remote.remote)} remote... ", end='', flush=True)
+
+            branches_existence = self._git.do_remote_branches_exist(base_org_repo_remote.remote, base, head)
+            base_branch_found_on_remote = branches_existence[base]
+            head_branch_found_on_remote = branches_existence[head]
+
+            print(fmt(colored_yes_no(head_branch_found_on_remote)))
+
+            print(f"Checking if {spec.base_branch_name} branch {bold(base)} "
+                  f"exists in {bold(base_org_repo_remote.remote)} remote... ", end='', flush=True)
+            print(fmt(colored_yes_no(base_branch_found_on_remote)))
+        else:
+            # Different remotes, check separately (head first, then base)
+            print(f"Checking if {spec.head_branch_name} branch {bold(head)} "
+                  f"exists in {bold(head_org_repo_remote.remote)} remote... ", end='', flush=True)
+            head_branch_found_on_remote = self._git.does_remote_branch_exist(head_org_repo_remote.remote, head)
+            print(fmt(colored_yes_no(head_branch_found_on_remote)))
+
+            print(f"Checking if {spec.base_branch_name} branch {bold(base)} "
+                  f"exists in {bold(base_org_repo_remote.remote)} remote... ", end='', flush=True)
+            base_branch_found_on_remote = self._git.does_remote_branch_exist(base_org_repo_remote.remote, base)
+            print(fmt(colored_yes_no(base_branch_found_on_remote)))
+
+        # Check head branch first - fail fast if it was removed from remote
+        if not head_branch_found_on_remote:
+            # Branch was pushed before but has been removed from remote
+            # (sync_before_creating_pull_request ensures the branch is pushed, so if it's missing here, it must have been removed)
+            if remote_head_branch_exists_locally:
+                raise MacheteException(
+                    f"{spec.head_branch_name.capitalize()} branch {bold(head)} "
+                    f"has been removed from {bold(head_org_repo_remote.remote)} remote since the last fetch/push.\n"
+                    f"Do you really want to create {spec.pr_short_name_article} {spec.pr_short_name} for this branch?")
+
+        # Check base branch - fail fast if it was removed from remote
+        if not base_branch_found_on_remote and remote_base_branch_exists_locally:
+            raise MacheteException(
+                f"{spec.base_branch_name.capitalize()} branch {bold(base)} "
+                f"has been removed from {bold(base_org_repo_remote.remote)} remote since the last fetch/push.\n"
+                f"Do you really want to create {spec.pr_short_name_article} {spec.pr_short_name} to this branch?")
+
+        # Handle missing base branch (push it if necessary)
         if not base_branch_found_on_remote:
             self._handle_untracked_branch(
                 branch=base,

--- a/git_machete/client/with_code_hosting.py
+++ b/git_machete/client/with_code_hosting.py
@@ -297,14 +297,13 @@ class MacheteClientWithCodeHosting(MacheteClient):
             print(fmt(colored_yes_no(base_branch_found_on_remote)))
 
         # Check head branch first - fail fast if it was removed from remote
-        if not head_branch_found_on_remote:
-            # Branch was pushed before but has been removed from remote
-            # (sync_before_creating_pull_request ensures the branch is pushed, so if it's missing here, it must have been removed)
-            if remote_head_branch_exists_locally:
-                raise MacheteException(
-                    f"{spec.head_branch_name.capitalize()} branch {bold(head)} "
-                    f"has been removed from {bold(head_org_repo_remote.remote)} remote since the last fetch/push.\n"
-                    f"Do you really want to create {spec.pr_short_name_article} {spec.pr_short_name} for this branch?")
+        # Branch was pushed before but has been removed from remote
+        # (sync_before_creating_pull_request ensures the branch is pushed, so if it's missing here, it must have been removed)
+        if not head_branch_found_on_remote and remote_head_branch_exists_locally:
+            raise MacheteException(
+                f"{spec.head_branch_name.capitalize()} branch {bold(head)} "
+                f"has been removed from {bold(head_org_repo_remote.remote)} remote since the last fetch/push.\n"
+                f"Do you really want to create {spec.pr_short_name_article} {spec.pr_short_name} for this branch?")
 
         # Check base branch - fail fast if it was removed from remote
         if not base_branch_found_on_remote and remote_base_branch_exists_locally:

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -498,10 +498,12 @@ class GitContext:
         # Output format: <hash>\trefs/heads/<branch-name>
         existing_branches: Set[str] = set()
         for line in result.stdout.splitlines():
-            if '\t' in line:
-                ref = line.split('\t')[1]
-                if ref.startswith('refs/heads/'):
-                    existing_branches.add(ref[len('refs/heads/'):])
+            if '\t' not in line:
+                raise UnexpectedMacheteException(f"Malformed line in git ls-remote output: {repr(line)}")
+            ref = line.split('\t')[1]
+            if not ref.startswith('refs/heads/'):
+                raise UnexpectedMacheteException(f"Unexpected ref format in git ls-remote output: {repr(line)}")
+            existing_branches.add(ref[len('refs/heads/'):])
 
         return {branch: branch in existing_branches for branch in branches}
 

--- a/git_machete/utils.py
+++ b/git_machete/utils.py
@@ -457,6 +457,10 @@ def get_pretty_choices(*choices: str) -> str:
     return " (" + (", ".join(map_truthy_only(format_choice, choices))) + ") "
 
 
+def colored_yes_no(value: bool) -> str:  # noqa: KW
+    return '<green><b>YES</b></green>' if value else '<red><b>NO</b></red>'
+
+
 def get_current_date() -> str:
     return datetime.datetime.now().strftime("%Y-%m-%d")
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,4 +1,5 @@
 import itertools
+import os
 from contextlib import contextmanager
 from textwrap import dedent
 from typing import Iterator
@@ -380,3 +381,31 @@ class TestGitHub(BaseTest):
             "Possible values for subcommand are: anno-prs, checkout-prs, create-pr, restack-pr, retarget-pr, update-pr-descriptions, sync\n"
         assert type(e) is SystemExit
         assert e.code == ExitCode.ARGUMENT_ERROR
+
+    def test_github_create_pr_with_missing_head_branch_on_remote(self, mocker: MockerFixture) -> None:
+        """Test that creating a PR fails gracefully when head branch doesn't exist in remote"""
+        # No need to mock GitHub API or input since we catch the error before making API calls
+        self.patch_symbol(mocker, 'git_machete.code_hosting.OrganizationAndRepository.from_url', mock_from_url)
+
+        (local_path, remote_path) = create_repo_with_remote()
+        new_branch("develop")
+        commit("develop commit")
+        push()
+
+        new_branch("feature")
+        commit("feature commit")
+        push()
+
+        # Delete the branch from the actual remote repository to simulate the scenario
+        os.chdir(remote_path)
+        delete_branch("feature")
+        os.chdir(local_path)
+
+        rewrite_branch_layout_file("develop\n\tfeature")
+
+        # This should now fail with a clear error message before attempting to call the GitHub API
+        expected_error_message = (
+            "Head branch feature has been removed from origin remote since the last fetch/push.\n"
+            "Do you really want to create a PR for this branch?"
+        )
+        assert_failure(['github', 'create-pr'], expected_error_message)

--- a/tests/test_github_create_pr.py
+++ b/tests/test_github_create_pr.py
@@ -1102,3 +1102,31 @@ class TestGitHubCreatePR(BaseTest):
             o-feature *  PR #1 (some_other_user)
             """,
         )
+
+    def test_github_create_pr_with_missing_head_branch_on_remote(self, mocker: MockerFixture) -> None:
+        """Test that creating a PR fails gracefully when head branch doesn't exist in remote"""
+        # No need to mock GitHub API or input since we catch the error before making API calls
+        self.patch_symbol(mocker, 'git_machete.code_hosting.OrganizationAndRepository.from_url', mock_from_url)
+
+        (local_path, remote_path) = create_repo_with_remote()
+        new_branch("develop")
+        commit("develop commit")
+        push()
+
+        new_branch("feature")
+        commit("feature commit")
+        push()
+
+        # Delete the branch from the actual remote repository to simulate the scenario
+        os.chdir(remote_path)
+        delete_branch("feature")
+        os.chdir(local_path)
+
+        rewrite_branch_layout_file("develop\n\tfeature")
+
+        # This should now fail with a clear error message before attempting to call the GitHub API
+        expected_error_message = (
+            "Head branch feature has been removed from origin remote since the last fetch/push.\n"
+            "Do you really want to create a PR for this branch?"
+        )
+        assert_failure(['github', 'create-pr'], expected_error_message)

--- a/tests/test_traverse_github.py
+++ b/tests/test_traverse_github.py
@@ -305,6 +305,7 @@ class TestTraverseGitHub(BaseTest):
 
             Branch allow-ownership-link does not have a PR in GitHub.
             Create a PR from allow-ownership-link to develop? (y, d[raft], N, q, yq)
+            Checking if head branch allow-ownership-link exists in origin remote... YES
             Checking if base branch develop exists in origin remote... YES
             Creating a PR from allow-ownership-link to develop... OK, see www.github.com
             Adding github_user as assignee to PR #2... OK
@@ -350,6 +351,7 @@ class TestTraverseGitHub(BaseTest):
 
             Branch drop-constraint does not have a PR in GitHub.
             Create a PR from drop-constraint to call-ws? (y, d[raft], N, q, yq)
+            Checking if head branch drop-constraint exists in origin remote... YES
             Checking if base branch call-ws exists in origin remote... YES
             Creating a draft PR from drop-constraint to call-ws... OK, see www.github.com
             Updating description of PR #3 to include the chain of PRs... OK


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1540

## Chain of upstream PRs as of 2025-11-26

* PR #1540:
  `master` ← `develop`

  * **PR #1542 (THIS ONE)**:
    `develop` ← `fix/422-github-missing-head`

<!-- end git-machete generated -->
