### PR TITLE
Fix branch coverage missing after PR #1536

### DIFF
--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -1216,9 +1216,6 @@ class GitContext:
         delete_option = '-D' if force else '-d'
         return self._run_git('branch', delete_option, branch_name, flush_caches=True)
 
-    def delete_remote_branch(self, branch_name: RemoteBranchShortName) -> int:
-        return self._run_git('branch', '-d', '-r', branch_name, flush_caches=True)
-
     def display_diff(self, branch: Optional[LocalBranchShortName], against: AnyRevision,
                      *, opt_stat: bool, extra_git_diff_args: List[str]) -> int:
         params = []

--- a/tests/test_github_create_pr.py
+++ b/tests/test_github_create_pr.py
@@ -839,6 +839,10 @@ class TestGitHubCreatePR(BaseTest):
         commit()
         push()  # Push the branch so it exists in the remote
 
+        # Add another commit to make the branch AHEAD_OF_REMOTE,
+        # which tests the case where push=no prevents automatic push during create-pr
+        commit()
+
         rewrite_branch_layout_file("master\n\tdevelop push=no")
 
         assert_success(

--- a/tests/test_gitlab_create_mr.py
+++ b/tests/test_gitlab_create_mr.py
@@ -820,6 +820,10 @@ class TestGitLabCreateMR(BaseTest):
         commit()
         push()
 
+        # Add another commit to make the branch AHEAD_OF_REMOTE,
+        # which tests the case where push=no prevents automatic push during create-mr
+        commit()
+
         rewrite_branch_layout_file("master\n\tdevelop push=no")
 
         assert_success(

--- a/tox.ini
+++ b/tox.ini
@@ -24,9 +24,7 @@ install_command =
 deps =
   -r{[requirements]dir}/testenv.txt
   -r{[requirements]dir}/testenv-runtime.txt
-allowlist_externals = mkdir
 commands =
-  mkdir -p test-results/
   # `python -m pytest` so that the local plugin for `--full-operands` can be loaded, see https://stackoverflow.com/a/48306599
   python -m pytest -p tests.pytest_full_operands \
     --numprocesses=auto --junitxml=test-results/testenv-{envname}.xml -m "not completion_e2e" {posargs}
@@ -98,7 +96,6 @@ deps =
   -r{[requirements]dir}/testenv-runtime.txt
 commands =
   pip install .  # for some reason, `usedevelop = True` seems to be ignored
-  mkdir -p test-results/
   pytest --numprocesses=auto --junitxml=test-results/testenv-{envname}.xml -m completion_e2e {posargs}
 
 [pytest]


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1540

## Chain of upstream PRs as of 2025-11-28

* PR #1540:
  `master` ← `develop`

  * **PR #1545 (THIS ONE)**:
    `develop` ← `fix/missing-coverage-pr-1536`

<!-- end git-machete generated -->
