### PR TITLE
Refresh package database before dry-running AUR package build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,7 +297,7 @@ only_special_branches: &only_special_branches
   filters:
     branches:
       only:
-        - "/.*(ci|dependabot.pip|deploy|dry.run|hotfix|macos|publish|release|windows).*/"
+        - "/.*(aur|ci|dependabot.pip|deploy|dry.run|hotfix|macos|publish|release|windows).*/"
         - "develop"
         - "master"
 

--- a/ci/aur/Dockerfile
+++ b/ci/aur/Dockerfile
@@ -3,9 +3,9 @@
 
 FROM archlinux:base-devel
 # https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported
-RUN pacman -Syu --noconfirm git
+RUN pacman --sync --refresh --sysupgrade --noconfirm git sudo
 
-RUN useradd -m builder && \
+RUN useradd --create-home builder && \
     echo "builder ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/builder && \
     chmod 0440 /etc/sudoers.d/builder
 USER builder

--- a/ci/aur/build-context/entrypoint.sh
+++ b/ci/aur/build-context/entrypoint.sh
@@ -12,4 +12,7 @@ hash=$(curl -L -s $url | sha256sum | head -c 64)
 sed -i "s/sha256sums=('[^']*/sha256sums=('$hash/" PKGBUILD
 cat PKGBUILD
 
+# Refresh package database to avoid 404 errors with stale Docker images
+sudo pacman --sync --refresh --noconfirm
+
 makepkg --syncdeps --log --install --clean --noconfirm


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1540

## Chain of upstream PRs as of 2025-12-03

* PR #1540:
  `master` ← `develop`

  * **PR #1549 (THIS ONE)**:
    `develop` ← `fix/aur-404`

<!-- end git-machete generated -->
