### PR TITLE
Prohibit all-caps `NO(T)` in RST files in favor of bolded `**no(t)**`

### DIFF
--- a/ci/checks/prohibit-all-caps-not-in-rst.sh
+++ b/ci/checks/prohibit-all-caps-not-in-rst.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail -u
+
+if git grep -n 'NO' -- '*.rst'; then
+  echo
+  echo "Don't use all caps 'NO(T)' in RST files. Use bolded '**no(t)**' instead."
+  exit 1
+fi

--- a/ci/checks/run-all-checks.sh
+++ b/ci/checks/run-all-checks.sh
@@ -1,52 +1,63 @@
 #!/usr/bin/env bash
 
+set -e
+
 # We don't want `less` to open for `git grep` results.
 export GIT_PAGER=cat
 
-PATH=./ci/checks:$PATH
+function _() {
+  script=$1
+  echo "> $script" >&2
+  if ! "./ci/checks/$script.sh"; then
+    failed="$failed, $script"
+  fi
+}
 
-# `-x`, so that we have more clarity which check actually failed
-# (rather than searching the right script by error message).
-set -e -x
-
-enforce-bumped-version.sh
-enforce-consistent-style-for-fork-point.sh
-enforce-consistent-style-for-github.sh
-enforce-consistent-style-for-gitlab.sh
-enforce-correct-shebangs.sh
-enforce-indent-two-spaces-outside-python.sh
-enforce-issue-number-for-todos.sh
+_ enforce-bumped-version
+_ enforce-consistent-style-for-fork-point
+_ enforce-consistent-style-for-github
+_ enforce-consistent-style-for-gitlab
+_ enforce-correct-shebangs
+_ enforce-indent-two-spaces-outside-python
+_ enforce-issue-number-for-todos
 if [[ $CI ]] || command -v remark; then
-  enforce-links-correct.sh
+  _ enforce-links-correct
 else
   echo 'Warning: remark CLI not installed, link check will be skipped. Use `npm install remark-cli remark-validate-links`'
 fi
-enforce-mocking-only-whitelisted-methods.sh
-enforce-newline-at-eof.sh
-enforce-release-notes-up-to-date.sh
-enforce-shell-scripts-pass-shellcheck.sh
-enforce-tox-testenvs-all-have-deps.sh
-enforce-yq-check-for-each-y-yes-yq-check.sh
-prohibit-a-mr.sh
-prohibit-bash-usages-from-python.sh
-prohibit-current-date-in-tests.sh
-prohibit-deploy-step-in-circleci.sh
-prohibit-double-backticks-in-python.sh
-prohibit-exempli-gratia-in-rst.sh
-prohibit-fish-completion-repetition-checks-for-long-options.sh
-prohibit-fork-point-in-git-context.sh
-prohibit-github-in-gitlab-files.sh
-prohibit-github-mr-or-gitlab-pr.sh
-prohibit-gitlab-in-github-files.sh
-prohibit-grey.sh
-prohibit-id-est-in-rst.sh
-prohibit-markdown-links-in-rst.sh
-prohibit-mrs-in-github-files.sh
-prohibit-prs-in-gitlab-files.sh
-prohibit-single-backtick-in-rst.sh
-prohibit-split-backslash-n.sh
-prohibit-strings-split-without-delimiter.sh
-prohibit-strings-with-backslash-continuation.sh
-prohibit-strings-with-useless-interpolations.sh
-prohibit-tab-character.sh
-prohibit-trailing-whitespace.sh
+_ enforce-mocking-only-whitelisted-methods
+_ enforce-newline-at-eof
+_ enforce-release-notes-up-to-date
+_ enforce-shell-scripts-pass-shellcheck
+_ enforce-tox-testenvs-all-have-deps
+_ enforce-yq-check-for-each-y-yes-yq-check
+_ prohibit-a-mr
+_ prohibit-all-caps-not-in-rst
+_ prohibit-bash-usages-from-python
+_ prohibit-current-date-in-tests
+_ prohibit-deploy-step-in-circleci
+_ prohibit-double-backticks-in-python
+_ prohibit-exempli-gratia-in-rst
+_ prohibit-fish-completion-repetition-checks-for-long-options
+_ prohibit-fork-point-in-git-context
+_ prohibit-github-in-gitlab-files
+_ prohibit-github-mr-or-gitlab-pr
+_ prohibit-gitlab-in-github-files
+_ prohibit-grey
+_ prohibit-id-est-in-rst
+_ prohibit-markdown-links-in-rst
+_ prohibit-mrs-in-github-files
+_ prohibit-prs-in-gitlab-files
+_ prohibit-single-backtick-in-rst
+_ prohibit-split-backslash-n
+_ prohibit-strings-split-without-delimiter
+_ prohibit-strings-with-backslash-continuation
+_ prohibit-strings-with-useless-interpolations
+_ prohibit-tab-character
+_ prohibit-trailing-whitespace
+
+if [[ $failed ]]; then
+  echo
+  echo "ERROR: ${failed#, } failed" >&2
+  exit 1
+fi

--- a/docs/man/git-machete.1
+++ b/docs/man/git-machete.1
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GIT-MACHETE" "1" "Dec 22, 2025" "" "git-machete"
+.TH "GIT-MACHETE" "1" "Jan 05, 2026" "" "git-machete"
 .SH NAME
 git-machete \- git-machete 3.38.1
 .sp
@@ -273,7 +273,7 @@ then clears the annotation for the current branch (or a branch specified with \f
 .sp
 If invoked with \fB\-H\fP/\fB\-\-sync\-github\-prs\fP (for GitHub) or \fB\-L\fP/\fB\-\-sync\-gitlab\-mrs\fP (for GitLab),
 annotates the branches based on their corresponding GitHub PR/GitLab MR numbers and authors.
-When the current user is NOT the author of the PR/MR associated with that branch, adds \fBrebase=no push=no\fP branch qualifiers used by \fBgit machete traverse\fP,
+When the current user is \fBnot\fP the author of the PR/MR associated with that branch, adds \fBrebase=no push=no\fP branch qualifiers used by \fBgit machete traverse\fP,
 so that you don\(aqt rebase or push someone else\(aqs PR/MR by accident (see help for traverse).
 Any existing annotations (except branch qualifiers) are overwritten for the branches that have an opened PR/MR;
 annotations for the other branches remain untouched.
@@ -830,7 +830,7 @@ passed to \fBgit rebase\fP by \fBgit machete\fP \fBreapply\fP/\fBslide\-out\fP/\
 provided to \fBgit diff\fP/\fBlog\fP by \fBgit machete\fP \fBdiff\fP/\fBlog\fP\&.
 .UNINDENT
 .sp
-\fBgit machete\fP assumes fork point of \fB<branch>\fP is the most recent commit in the log of \fB<branch>\fP that has NOT been introduced on that very branch,
+\fBgit machete\fP assumes fork point of \fB<branch>\fP is the most recent commit in the log of \fB<branch>\fP that has \fBnot\fP been introduced on that very branch,
 but instead occurs on a reflog (see help for \fBgit reflog\fP) of some other branch.
 This yields a correct result in typical cases, but there are some situations
 (esp. when some local branches have been deleted) where the fork point might not be determined correctly.
@@ -852,8 +852,8 @@ Note: this option is \fBdeprecated\fP since it may lead to confusing user experi
 Use \fB\-\-override\-to\-parent\fP, or rebase the branch onto its parent with \fBgit machete update \-\-fork\-point=<revision>\fP\&.
 .sp
 With \fB\-\-inferred\fP, displays the commit that \fBgit machete fork\-point\fP infers to be fork point of \fB<branch>\fP\&.
-If there is NO fork point override for \fB<branch>\fP, this is identical to the output of \fBgit machete fork\-point\fP\&.
-If there is a fork point override for \fB<branch>\fP, this is identical to the what the output of \fBgit machete fork\-point\fP would be if the override was NOT present.
+If there is \fBno\fP fork point override for \fB<branch>\fP, this is identical to the output of \fBgit machete fork\-point\fP\&.
+If there is a fork point override for \fB<branch>\fP, this is identical to the what the output of \fBgit machete fork\-point\fP would be if the override was \fBnot\fP present.
 Note: this piece of information is also displayed by \fBgit machete status \-\-list\-commits\fP in case a yellow edge occurs.
 .sp
 With \fB\-\-override\-to\-inferred\fP option, overrides fork point of \fB<branch>\fP to the result of \fBgit machete fork\-point \-\-inferred\fP for \fB<branch>\fP\&.
@@ -863,7 +863,7 @@ With \fB\-\-unset\-override\fP, unsets fork point override for \fB<branch>\fP\&.
 This is simply done by removing the corresponding \fBmachete.overrideForkPoint.<branch>.to\fP git config entry.
 .sp
 Note: if branch \fBB\fP has an overridden fork point, then \fBB\fP is considered to be connected with a green edge to its upstream (parent) \fBU\fP,
-even if the overridden fork point of \fBB\fP is NOT equal to the commit pointed by \fBU\fP\&.
+even if the overridden fork point of \fBB\fP is \fBnot\fP equal to the commit pointed by \fBU\fP\&.
 .SH FORMAT
 .sp
 Note: there is no \fBgit machete format\fP command as such; \fBformat\fP is just a topic of \fBgit machete help\fP\&.
@@ -965,7 +965,7 @@ Annotate the branches based on their corresponding GitHub PR numbers and authors
 Any existing annotations are overwritten for the branches that have an opened PR; annotations for the other branches remain untouched.
 Equivalent to \fBgit machete anno \-\-sync\-github\-prs\fP\&.
 .sp
-When the current user is NOT the author of the PR associated with that branch, adds \fBrebase=no push=no\fP branch qualifiers used by \fBgit machete traverse\fP,
+When the current user is \fBnot\fP the author of the PR associated with that branch, adds \fBrebase=no push=no\fP branch qualifiers used by \fBgit machete traverse\fP,
 so that you don\(aqt rebase or push someone else\(aqs PR by accident (see help for traverse).
 .sp
 \fBOptions:\fP
@@ -981,7 +981,7 @@ also traverse chain of pull requests upwards, adding branches one by one to git\
 Once the specified pull requests are checked out locally, annotate local branches with corresponding pull request numbers.
 If only one PR has been checked out, then switch the local repository\(aqs HEAD to its head branch.
 .sp
-When the current user is NOT the author of the PR associated with that branch, adds \fBrebase=no push=no\fP branch qualifiers used by \fBgit machete traverse\fP,
+When the current user is \fBnot\fP the author of the PR associated with that branch, adds \fBrebase=no push=no\fP branch qualifiers used by \fBgit machete traverse\fP,
 so that you don\(aqt rebase or push someone else\(aqs PR by accident (see help for traverse).
 .sp
 \fBOptions:\fP
@@ -1245,7 +1245,7 @@ Annotate the branches based on their corresponding GitLab MR numbers and authors
 Any existing annotations are overwritten for the branches that have an opened MR; annotations for the other branches remain untouched.
 Equivalent to \fBgit machete anno \-\-sync\-gitlab\-mrs\fP\&.
 .sp
-When the current user is NOT the author of the MR associated with that branch, adds \fBrebase=no push=no\fP branch qualifiers used by \fBgit machete traverse\fP,
+When the current user is \fBnot\fP the author of the MR associated with that branch, adds \fBrebase=no push=no\fP branch qualifiers used by \fBgit machete traverse\fP,
 so that you don\(aqt rebase or push someone else\(aqs MR by accident (see help for traverse).
 .sp
 \fBOptions:\fP
@@ -1261,7 +1261,7 @@ also traverse chain of merge requests upwards, adding branches one by one to git
 Once the specified merge requests are checked out locally, annotate local branches with corresponding merge request numbers.
 If only one MR has been checked out, then switch the local repository\(aqs HEAD to its source branch.
 .sp
-When the current user is NOT the author of the MR associated with that branch, adds \fBrebase=no push=no\fP branch qualifiers used by \fBgit machete traverse\fP,
+When the current user is \fBnot\fP the author of the MR associated with that branch, adds \fBrebase=no push=no\fP branch qualifiers used by \fBgit machete traverse\fP,
 so that you don\(aqt rebase or push someone else\(aqs MR by accident (see help for traverse).
 .sp
 \fBOptions:\fP
@@ -1568,7 +1568,7 @@ The hook is executed only once the slide\-out is complete and can in fact rely o
 .TP
 .B \fBmachete\-pre\-rebase <new\-base> <fork\-point\-hash> <branch\-being\-rebased>\fP
 The hook that is executed before rebase is run during \fBreapply\fP, \fBslide\-out\fP, \fBtraverse\fP and \fBupdate\fP\&.
-Note that it is NOT executed by \fBsquash\fP (despite its similarity to \fBreapply\fP), since no rebase is involved in \fBsquash\fP\&.
+Note that it is \fBnot\fP executed by \fBsquash\fP (despite its similarity to \fBreapply\fP), since no rebase is involved in \fBsquash\fP\&.
 .sp
 The parameters are exactly the three revisions that are passed to \fBgit rebase \-\-onto\fP:
 .INDENT 7.0
@@ -1594,7 +1594,7 @@ The standard output of this hook is displayed at the end of the line, after bran
 are ignored, and printing the status continues as usual.
 .sp
 Note: the hook is always invoked with \fBASCII_ONLY\fP variable passed into the environment.
-If \fBstatus\fP runs in ASCII\-only mode (if \fB\-\-color=auto\fP and stdout is NOT a terminal, or if \fB\-\-color=never\fP),
+If \fBstatus\fP runs in ASCII\-only mode (if \fB\-\-color=auto\fP and stdout is \fBnot\fP a terminal, or if \fB\-\-color=never\fP),
 then \fBASCII_ONLY=true\fP, otherwise \fBASCII_ONLY=false\fP\&.
 .UNINDENT
 .sp
@@ -1894,7 +1894,7 @@ The message for the resulting commit is taken from the earliest squashed commit 
 To simply squash the most recent N commits, use \fB\-\-fork\-point=HEAD~<N>\fP,
 for example \fBgit machete squash \-\-fork\-point=HEAD~3\fP\&.
 .sp
-Note: \fBsquash\fP does NOT run \fBgit rebase\fP under the hood.
+Note: \fBsquash\fP does \fBnot\fP run \fBgit rebase\fP under the hood.
 For more complex scenarios that require rewriting the history of current branch, see \fBreapply\fP and \fBupdate\fP\&.
 .sp
 \fBOptions:\fP
@@ -1925,10 +1925,10 @@ Apart from simply ASCII\-formatting the branch layout file, this also:
 colors the edges between upstream (parent) and downstream (children) branches:
 .INDENT 2.0
 .IP \(bu 2
-red edge means \fInot in sync\fP\&. The downstream branch is NOT a direct descendant of the upstream branch.
+red edge means \fInot in sync\fP\&. The downstream branch is \fBnot\fP a direct descendant of the upstream branch.
 .IP \(bu 2
 yellow edge means \fIin sync but fork point off\fP\&. The downstream branch is a direct descendant of the upstream branch,
-but the fork point of the downstream branch is NOT equal to the upstream branch.
+but the fork point of the downstream branch is \fBnot\fP equal to the upstream branch.
 .IP \(bu 2
 green edge means \fIin sync\fP\&. The downstream branch is a direct descendant of the upstream branch
 and the fork point of the downstream branch is equal to the upstream branch.
@@ -2163,7 +2163,7 @@ master
 .sp
 Operations like \fBgit machete github anno\-prs\fP (\fBgit machete gitlab anno\-mrs\fP)
 and \fBgit machete github checkout\-prs\fP (\fBgit machete gitlab checkout\-mrs\fP) add \fBrebase=no push=no\fP branch qualifiers
-when the current user is NOT the author of the PR/MR associated with that branch.
+when the current user is \fBnot\fP the author of the PR/MR associated with that branch.
 .sp
 \fBNote on git worktrees:\fP if a branch is already checked out in another worktree, \fBtraverse\fP will change directory to that worktree rather than failing.
 .sp

--- a/docs/source/cli/anno.rst
+++ b/docs/source/cli/anno.rst
@@ -18,7 +18,7 @@ then clears the annotation for the current branch (or a branch specified with ``
 
 If invoked with ``-H``/``--sync-github-prs`` (for GitHub) or ``-L``/``--sync-gitlab-mrs`` (for GitLab),
 annotates the branches based on their corresponding GitHub PR/GitLab MR numbers and authors.
-When the current user is NOT the author of the PR/MR associated with that branch, adds ``rebase=no push=no`` branch qualifiers used by ``git machete traverse``,
+When the current user is **not** the author of the PR/MR associated with that branch, adds ``rebase=no push=no`` branch qualifiers used by ``git machete traverse``,
 so that you don't rebase or push someone else's PR/MR by accident (see help for :ref:`traverse`).
 Any existing annotations (except branch qualifiers) are overwritten for the branches that have an opened PR/MR;
 annotations for the other branches remain untouched.

--- a/docs/source/cli/fork-point.rst
+++ b/docs/source/cli/fork-point.rst
@@ -33,7 +33,7 @@ The range of commits between the fork point and the tip of the given branch is, 
 * passed to ``git rebase`` by ``git machete`` ``reapply``/``slide-out``/``traverse``/``update``
 * provided to ``git diff``/``log`` by ``git machete`` ``diff``/``log``.
 
-``git machete`` assumes fork point of ``<branch>`` is the most recent commit in the log of ``<branch>`` that has NOT been introduced on that very branch,
+``git machete`` assumes fork point of ``<branch>`` is the most recent commit in the log of ``<branch>`` that has **not** been introduced on that very branch,
 but instead occurs on a reflog (see help for ``git reflog``) of some other branch.
 This yields a correct result in typical cases, but there are some situations
 (esp. when some local branches have been deleted) where the fork point might not be determined correctly.
@@ -55,8 +55,8 @@ Note: this option is **deprecated** since it may lead to confusing user experien
 Use ``--override-to-parent``, or rebase the branch onto its parent with ``git machete update --fork-point=<revision>``.
 
 With ``--inferred``, displays the commit that ``git machete fork-point`` infers to be fork point of ``<branch>``.
-If there is NO fork point override for ``<branch>``, this is identical to the output of ``git machete fork-point``.
-If there is a fork point override for ``<branch>``, this is identical to the what the output of ``git machete fork-point`` would be if the override was NOT present.
+If there is **no** fork point override for ``<branch>``, this is identical to the output of ``git machete fork-point``.
+If there is a fork point override for ``<branch>``, this is identical to the what the output of ``git machete fork-point`` would be if the override was **not** present.
 Note: this piece of information is also displayed by ``git machete status --list-commits`` in case a :yellow:`yellow` edge occurs.
 
 With ``--override-to-inferred`` option, overrides fork point of ``<branch>`` to the result of ``git machete fork-point --inferred`` for ``<branch>``.
@@ -67,4 +67,4 @@ This is simply done by removing the corresponding ``machete.overrideForkPoint.<b
 
 
 Note: if branch ``B`` has an overridden fork point, then ``B`` is considered to be connected with a :green:`green` edge to its upstream (parent) ``U``,
-even if the overridden fork point of ``B`` is NOT equal to the commit pointed by ``U``.
+even if the overridden fork point of ``B`` is **not** equal to the commit pointed by ``U``.

--- a/docs/source/cli/github.rst
+++ b/docs/source/cli/github.rst
@@ -48,7 +48,7 @@ Create, check out and manage GitHub PRs while keeping them reflected in branch l
     Any existing annotations are overwritten for the branches that have an opened PR; annotations for the other branches remain untouched.
     Equivalent to ``git machete anno --sync-github-prs``.
 
-    When the current user is NOT the author of the PR associated with that branch, adds ``rebase=no push=no`` branch qualifiers used by ``git machete traverse``,
+    When the current user is **not** the author of the PR associated with that branch, adds ``rebase=no push=no`` branch qualifiers used by ``git machete traverse``,
     so that you don't rebase or push someone else's PR by accident (see help for :ref:`traverse`).
 
     **Options:**
@@ -62,7 +62,7 @@ Create, check out and manage GitHub PRs while keeping them reflected in branch l
     Once the specified pull requests are checked out locally, annotate local branches with corresponding pull request numbers.
     If only one PR has been checked out, then switch the local repository's HEAD to its head branch.
 
-    When the current user is NOT the author of the PR associated with that branch, adds ``rebase=no push=no`` branch qualifiers used by ``git machete traverse``,
+    When the current user is **not** the author of the PR associated with that branch, adds ``rebase=no push=no`` branch qualifiers used by ``git machete traverse``,
     so that you don't rebase or push someone else's PR by accident (see help for :ref:`traverse`).
 
     **Options:**

--- a/docs/source/cli/gitlab.rst
+++ b/docs/source/cli/gitlab.rst
@@ -47,7 +47,7 @@ Create, check out and manage GitLab MRs while keeping them reflected in branch l
     Any existing annotations are overwritten for the branches that have an opened MR; annotations for the other branches remain untouched.
     Equivalent to ``git machete anno --sync-gitlab-mrs``.
 
-    When the current user is NOT the author of the MR associated with that branch, adds ``rebase=no push=no`` branch qualifiers used by ``git machete traverse``,
+    When the current user is **not** the author of the MR associated with that branch, adds ``rebase=no push=no`` branch qualifiers used by ``git machete traverse``,
     so that you don't rebase or push someone else's MR by accident (see help for :ref:`traverse`).
 
     **Options:**
@@ -61,7 +61,7 @@ Create, check out and manage GitLab MRs while keeping them reflected in branch l
     Once the specified merge requests are checked out locally, annotate local branches with corresponding merge request numbers.
     If only one MR has been checked out, then switch the local repository's HEAD to its source branch.
 
-    When the current user is NOT the author of the MR associated with that branch, adds ``rebase=no push=no`` branch qualifiers used by ``git machete traverse``,
+    When the current user is **not** the author of the MR associated with that branch, adds ``rebase=no push=no`` branch qualifiers used by ``git machete traverse``,
     so that you don't rebase or push someone else's MR by accident (see help for :ref:`traverse`).
 
     **Options:**

--- a/docs/source/cli/hooks.rst
+++ b/docs/source/cli/hooks.rst
@@ -40,7 +40,7 @@ Note: ``hooks`` is not a command as such, just a help topic (there is no ``git m
 
 ``machete-pre-rebase <new-base> <fork-point-hash> <branch-being-rebased>``
     The hook that is executed before rebase is run during ``reapply``, ``slide-out``, ``traverse`` and ``update``.
-    Note that it is NOT executed by ``squash`` (despite its similarity to ``reapply``), since no rebase is involved in ``squash``.
+    Note that it is **not** executed by ``squash`` (despite its similarity to ``reapply``), since no rebase is involved in ``squash``.
 
     The parameters are exactly the three revisions that are passed to ``git rebase --onto``:
 
@@ -62,7 +62,7 @@ Note: ``hooks`` is not a command as such, just a help topic (there is no ``git m
     are ignored, and printing the status continues as usual.
 
     Note: the hook is always invoked with ``ASCII_ONLY`` variable passed into the environment.
-    If ``status`` runs in ASCII-only mode (if ``--color=auto`` and stdout is NOT a terminal, or if ``--color=never``),
+    If ``status`` runs in ASCII-only mode (if ``--color=auto`` and stdout is **not** a terminal, or if ``--color=never``),
     then ``ASCII_ONLY=true``, otherwise ``ASCII_ONLY=false``.
 
 Please see `hook_samples <https://github.com/VirtusLab/git-machete/tree/master/hook_samples>`_ directory in git-machete project for examples.

--- a/docs/source/cli/squash.rst
+++ b/docs/source/cli/squash.rst
@@ -17,7 +17,7 @@ The message for the resulting commit is taken from the earliest squashed commit 
 To simply squash the most recent N commits, use ``--fork-point=HEAD~<N>``,
 for example ``git machete squash --fork-point=HEAD~3``.
 
-Note: ``squash`` does NOT run ``git rebase`` under the hood.
+Note: ``squash`` does **not** run ``git rebase`` under the hood.
 For more complex scenarios that require rewriting the history of current branch, see ``reapply`` and ``update``.
 
 **Options:**

--- a/docs/source/cli/status.rst
+++ b/docs/source/cli/status.rst
@@ -28,10 +28,10 @@ Apart from simply ASCII-formatting the branch layout file, this also:
 
 * colors the edges between upstream (parent) and downstream (children) branches:
 
-  - :red:`red edge` means *not in sync*. The downstream branch is NOT a direct descendant of the upstream branch.
+  - :red:`red edge` means *not in sync*. The downstream branch is **not** a direct descendant of the upstream branch.
 
   - :yellow:`yellow edge` means *in sync but fork point off*. The downstream branch is a direct descendant of the upstream branch,
-    but the :ref:`fork point<fork-point>` of the downstream branch is NOT equal to the upstream branch.
+    but the :ref:`fork point<fork-point>` of the downstream branch is **not** equal to the upstream branch.
 
   - :green:`green edge` means *in sync*. The downstream branch is a direct descendant of the upstream branch
     and the fork point of the downstream branch is equal to the upstream branch.

--- a/docs/source/cli/traverse.rst
+++ b/docs/source/cli/traverse.rst
@@ -89,7 +89,7 @@ Example machete file with branch qualifiers:
 
 Operations like ``git machete github anno-prs`` (``git machete gitlab anno-mrs``)
 and ``git machete github checkout-prs`` (``git machete gitlab checkout-mrs``) add ``rebase=no push=no`` branch qualifiers
-when the current user is NOT the author of the PR/MR associated with that branch.
+when the current user is **not** the author of the PR/MR associated with that branch.
 
 **Note on git worktrees:** if a branch is already checked out in another worktree, ``traverse`` will change directory to that worktree rather than failing.
 

--- a/git_machete/generated_docs.py
+++ b/git_machete/generated_docs.py
@@ -137,7 +137,7 @@ long_docs: Dict[str, str] = {
 
         If invoked with `-H`/`--sync-github-prs` (for GitHub) or `-L`/`--sync-gitlab-mrs` (for GitLab),
         annotates the branches based on their corresponding GitHub PR/GitLab MR numbers and authors.
-        When the current user is NOT the author of the PR/MR associated with that branch, adds `rebase=no push=no` branch qualifiers used by `git machete traverse`,
+        When the current user is <b>not</b> the author of the PR/MR associated with that branch, adds `rebase=no push=no` branch qualifiers used by `git machete traverse`,
         so that you don't rebase or push someone else's PR/MR by accident (see help for `traverse`).
         Any existing annotations (except branch qualifiers) are overwritten for the branches that have an opened PR/MR;
         annotations for the other branches remain untouched.
@@ -525,7 +525,7 @@ long_docs: Dict[str, str] = {
            * passed to `git rebase` by `git machete` `reapply`/`slide-out`/`traverse`/`update`
            * provided to `git diff`/`log` by `git machete` `diff`/`log`.
 
-        `git machete` assumes fork point of `<branch>` is the most recent commit in the log of `<branch>` that has NOT been introduced on that very branch,
+        `git machete` assumes fork point of `<branch>` is the most recent commit in the log of `<branch>` that has <b>not</b> been introduced on that very branch,
         but instead occurs on a reflog (see help for `git reflog`) of some other branch.
         This yields a correct result in typical cases, but there are some situations
         (esp. when some local branches have been deleted) where the fork point might not be determined correctly.
@@ -547,8 +547,8 @@ long_docs: Dict[str, str] = {
         Use `--override-to-parent`, or rebase the branch onto its parent with `git machete update --fork-point=<revision>`.
 
         With `--inferred`, displays the commit that `git machete fork-point` infers to be fork point of `<branch>`.
-        If there is NO fork point override for `<branch>`, this is identical to the output of `git machete fork-point`.
-        If there is a fork point override for `<branch>`, this is identical to the what the output of `git machete fork-point` would be if the override was NOT present.
+        If there is <b>no</b> fork point override for `<branch>`, this is identical to the output of `git machete fork-point`.
+        If there is a fork point override for `<branch>`, this is identical to the what the output of `git machete fork-point` would be if the override was <b>not</b> present.
         Note: this piece of information is also displayed by `git machete status --list-commits` in case a <yellow>yellow</yellow> edge occurs.
 
         With `--override-to-inferred` option, overrides fork point of `<branch>` to the result of `git machete fork-point --inferred` for `<branch>`.
@@ -558,7 +558,7 @@ long_docs: Dict[str, str] = {
         This is simply done by removing the corresponding `machete.overrideForkPoint.<branch>.to` git config entry.
 
         Note: if branch `B` has an overridden fork point, then `B` is considered to be connected with a <green>green</green> edge to its upstream (parent) `U`,
-        even if the overridden fork point of `B` is NOT equal to the commit pointed by `U`.
+        even if the overridden fork point of `B` is <b>not</b> equal to the commit pointed by `U`.
    """,
     "format": """
         Note: there is no `git machete format` command as such; `format` is just a topic of `git machete help`.
@@ -629,7 +629,7 @@ long_docs: Dict[str, str] = {
               Any existing annotations are overwritten for the branches that have an opened PR; annotations for the other branches remain untouched.
               Equivalent to `git machete anno --sync-github-prs`.
 
-              When the current user is NOT the author of the PR associated with that branch, adds `rebase=no push=no` branch qualifiers used by `git machete traverse`,
+              When the current user is <b>not</b> the author of the PR associated with that branch, adds `rebase=no push=no` branch qualifiers used by `git machete traverse`,
               so that you don't rebase or push someone else's PR by accident (see help for `traverse`).
 
               <b>Options:</b>
@@ -642,7 +642,7 @@ long_docs: Dict[str, str] = {
               Once the specified pull requests are checked out locally, annotate local branches with corresponding pull request numbers.
               If only one PR has been checked out, then switch the local repository's HEAD to its head branch.
 
-              When the current user is NOT the author of the PR associated with that branch, adds `rebase=no push=no` branch qualifiers used by `git machete traverse`,
+              When the current user is <b>not</b> the author of the PR associated with that branch, adds `rebase=no push=no` branch qualifiers used by `git machete traverse`,
               so that you don't rebase or push someone else's PR by accident (see help for `traverse`).
 
               <b>Options:</b>
@@ -827,7 +827,7 @@ long_docs: Dict[str, str] = {
               Any existing annotations are overwritten for the branches that have an opened MR; annotations for the other branches remain untouched.
               Equivalent to `git machete anno --sync-gitlab-mrs`.
 
-              When the current user is NOT the author of the MR associated with that branch, adds `rebase=no push=no` branch qualifiers used by `git machete traverse`,
+              When the current user is <b>not</b> the author of the MR associated with that branch, adds `rebase=no push=no` branch qualifiers used by `git machete traverse`,
               so that you don't rebase or push someone else's MR by accident (see help for `traverse`).
 
               <b>Options:</b>
@@ -840,7 +840,7 @@ long_docs: Dict[str, str] = {
               Once the specified merge requests are checked out locally, annotate local branches with corresponding merge request numbers.
               If only one MR has been checked out, then switch the local repository's HEAD to its source branch.
 
-              When the current user is NOT the author of the MR associated with that branch, adds `rebase=no push=no` branch qualifiers used by `git machete traverse`,
+              When the current user is <b>not</b> the author of the MR associated with that branch, adds `rebase=no push=no` branch qualifiers used by `git machete traverse`,
               so that you don't rebase or push someone else's MR by accident (see help for `traverse`).
 
               <b>Options:</b>
@@ -1063,7 +1063,7 @@ long_docs: Dict[str, str] = {
 
            `machete-pre-rebase <new-base> <fork-point-hash> <branch-being-rebased>`
               The hook that is executed before rebase is run during `reapply`, `slide-out`, `traverse` and `update`.
-              Note that it is NOT executed by `squash` (despite its similarity to `reapply`), since no rebase is involved in `squash`.
+              Note that it is <b>not</b> executed by `squash` (despite its similarity to `reapply`), since no rebase is involved in `squash`.
 
               The parameters are exactly the three revisions that are passed to `git rebase --onto`:
 
@@ -1085,7 +1085,7 @@ long_docs: Dict[str, str] = {
               are ignored, and printing the status continues as usual.
 
               Note: the hook is always invoked with `ASCII_ONLY` variable passed into the environment.
-              If `status` runs in ASCII-only mode (if `--color=auto` and stdout is NOT a terminal, or if `--color=never`),
+              If `status` runs in ASCII-only mode (if `--color=auto` and stdout is <b>not</b> a terminal, or if `--color=never`),
               then `ASCII_ONLY=true`, otherwise `ASCII_ONLY=false`.
 
         Please see hook_samples directory in git-machete project for examples.
@@ -1303,7 +1303,7 @@ long_docs: Dict[str, str] = {
         To simply squash the most recent N commits, use `--fork-point=HEAD~<N>`,
         for example `git machete squash --fork-point=HEAD~3`.
 
-        Note: `squash` does NOT run `git rebase` under the hood.
+        Note: `squash` does <b>not</b> run `git rebase` under the hood.
         For more complex scenarios that require rewriting the history of current branch, see `reapply` and `update`.
 
         <b>Options:</b>
@@ -1323,10 +1323,10 @@ long_docs: Dict[str, str] = {
 
            * colors the edges between upstream (parent) and downstream (children) branches:
 
-             - <red>red edge</red> means not in sync. The downstream branch is NOT a direct descendant of the upstream branch.
+             - <red>red edge</red> means not in sync. The downstream branch is <b>not</b> a direct descendant of the upstream branch.
 
              - <yellow>yellow edge</yellow> means in sync but fork point off. The downstream branch is a direct descendant of the upstream branch,
-              but the `fork point` of the downstream branch is NOT equal to the upstream branch.
+              but the `fork point` of the downstream branch is <b>not</b> equal to the upstream branch.
 
              - <green>green edge</green> means in sync. The downstream branch is a direct descendant of the upstream branch
               and the fork point of the downstream branch is equal to the upstream branch.
@@ -1503,7 +1503,7 @@ long_docs: Dict[str, str] = {
         </dim>
         Operations like `git machete github anno-prs` (`git machete gitlab anno-mrs`)
         and `git machete github checkout-prs` (`git machete gitlab checkout-mrs`) add `rebase=no push=no` branch qualifiers
-        when the current user is NOT the author of the PR/MR associated with that branch.
+        when the current user is <b>not</b> the author of the PR/MR associated with that branch.
 
         <b>Note on git worktrees:</b> if a branch is already checked out in another worktree, `traverse` will change directory to that worktree rather than failing.
 


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1565

## Chain of upstream PRs as of 2026-01-05

* PR #1565:
  `master` ← `develop`

  * **PR #1568 (THIS ONE)**:
    `develop` ← `fix/all-caps-no-in-rst`

<!-- end git-machete generated -->
