### PR TITLE
In `advance`, only push when the branch is ahead of remote

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## New in git-machete 3.38.2
 
+- improved: `advance` now only suggests push when the branch is ahead of remote; for other sync-to-remote statuses (behind, diverged, in sync, untracked), a warning is displayed instead
 - improved: every time a branch is checked out, a `Checking out <branch>... OK` message is printed out for consistency
 
 ## New in git-machete 3.38.1

--- a/ci/checks/prohibit-trailing-whitespace.sh
+++ b/ci/checks/prohibit-trailing-whitespace.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 if git grep -EIn ' +$' -- :!git_machete/generated_docs.py; then
-  echo 'The above lines contain trailing whitespace, please tidy up'
+  echo 'The above lines contain trailing whitespace, please tidy up (just run `tox`)'
   exit 1
 fi

--- a/git_machete/client/advance.py
+++ b/git_machete/client/advance.py
@@ -1,7 +1,8 @@
 from git_machete.client.base import MacheteClient, SquashMergeDetection
 from git_machete.exceptions import MacheteException
-from git_machete.git_operations import GitContext, LocalBranchShortName
-from git_machete.utils import bold, flat_map, get_pretty_choices
+from git_machete.git_operations import (GitContext, LocalBranchShortName,
+                                        SyncToRemoteStatus)
+from git_machete.utils import bold, flat_map, get_pretty_choices, warn
 
 
 class AdvanceMacheteClient(MacheteClient):
@@ -51,9 +52,10 @@ class AdvanceMacheteClient(MacheteClient):
             else:
                 return
 
-        remote = self._git.get_combined_remote_for_fetching_of_branch(branch)
+        s, remote = self._git.get_combined_remote_sync_status(branch)
         anno = self.annotations.get(branch)
-        if remote and (not anno or anno.qualifiers.push):
+
+        if remote and (not anno or anno.qualifiers.push) and s == SyncToRemoteStatus.AHEAD_OF_REMOTE:
             push_msg = f"\nBranch {bold(branch)} is now fast-forwarded to match {bold(down_branch)}. " \
                 f"Push {bold(branch)} to {bold(remote)}?" + get_pretty_choices('y', 'N')
             opt_yes_push_msg = f"\nBranch {bold(branch)} is now fast-forwarded to match {bold(down_branch)}. " \
@@ -65,6 +67,20 @@ class AdvanceMacheteClient(MacheteClient):
             else:
                 branch_pushed_or_fast_forwarded_msg = f"\nBranch {bold(branch)} is now fast-forwarded to match {bold(down_branch)}."
         else:
+            if remote:
+                sync_status_warnings = {
+                    SyncToRemoteStatus.BEHIND_REMOTE:
+                        f"Branch {bold(branch)} is behind {bold(remote)}. "
+                        f"Consider fetching and re-running the operation.",
+                    SyncToRemoteStatus.DIVERGED_FROM_AND_OLDER_THAN_REMOTE:
+                        f"Branch {bold(branch)} diverged from (and is older than) {bold(remote)}.",
+                    SyncToRemoteStatus.DIVERGED_FROM_AND_NEWER_THAN_REMOTE:
+                        f"Branch {bold(branch)} diverged from (and is newer than) {bold(remote)}.",
+                    SyncToRemoteStatus.UNTRACKED:
+                        f"Branch {bold(branch)} is untracked. Consider setting up a remote tracking branch."
+                }
+                if s in sync_status_warnings:
+                    warn(sync_status_warnings[s])
             branch_pushed_or_fast_forwarded_msg = f"\nBranch {bold(branch)} is now fast-forwarded to match {bold(down_branch)}."
 
         down_anno = self.annotations.get(down_branch)

--- a/tests/test_advance.py
+++ b/tests/test_advance.py
@@ -273,3 +273,133 @@ class TestAdvance(BaseTest):
             m-level-1-branch  slide-out=no (untracked)
             """
         )
+
+    def test_advance_when_branch_in_sync_with_remote_after_ff(self, mocker: MockerFixture) -> None:
+        """
+        Verify that when the branch is in sync with remote after fast-forward,
+        push is not suggested.
+        """
+        create_repo_with_remote()
+        new_branch("root")
+        commit("root-initial")
+        push()
+
+        # Create level-1-branch and push it to origin/root
+        # This simulates the scenario where origin/root is already at the target commit
+        new_branch("level-1-branch")
+        commit("level-1-commit")
+        push(tracking_branch="root", set_upstream=False)
+
+        # Go back to root (which is behind origin/root now)
+        check_out("root")
+
+        body: str = \
+            """
+            root
+                level-1-branch
+            """
+        rewrite_branch_layout_file(body)
+
+        self.patch_symbol(mocker, "builtins.input", mock_input_returning_y)
+        output = launch_command("advance")
+
+        # After advance, root is at level-1-branch commit, which is same as origin/root
+        # So they are in sync, and push should not be suggested
+        assert "Push root to origin?" not in output
+
+    def test_advance_when_branch_diverged_from_and_older_than_remote(self, mocker: MockerFixture) -> None:
+        """
+        Verify that when the branch diverged from and is older than remote after fast-forward,
+        a warning is shown and push is not suggested.
+        """
+        import time
+
+        from .mockers_git_repository import fetch, reset_to
+
+        create_repo_with_remote()
+        new_branch("root")
+        commit("root-initial")
+        push()
+
+        # Get the commit hash before we diverge
+        initial_hash = get_commit_hash("root")
+
+        # Create level-1-branch (this will be the target of advance)
+        new_branch("level-1-branch")
+        commit("level-1-commit")
+
+        # Go back to root
+        check_out("root")
+
+        # Create divergence on remote: push a different commit as origin/root (newer timestamp)
+        new_branch("temp-diverge")
+        reset_to(initial_hash)
+        # Wait a bit to ensure newer timestamp
+        time.sleep(1)
+        commit("diverged-remote-newer")
+        push(tracking_branch="root", set_upstream=False)
+
+        # Now level-1-branch (where root will advance to) has diverged from origin/root
+        # and is older (was created before the remote commit)
+        check_out("root")
+        reset_to(initial_hash)
+        fetch()
+
+        body: str = \
+            """
+            root
+                level-1-branch
+            """
+        rewrite_branch_layout_file(body)
+
+        self.patch_symbol(mocker, "builtins.input", mock_input_returning_y)
+        output = launch_command("advance")
+
+        assert "Branch root diverged from (and is older than) origin." in output
+        assert "Push root to origin?" not in output
+
+    def test_advance_when_branch_diverged_from_and_newer_than_remote(self, mocker: MockerFixture) -> None:
+        """
+        Verify that when the branch diverged from and is newer than remote after fast-forward,
+        a warning is shown and push is not suggested.
+        """
+        import time
+
+        from .mockers_git_repository import fetch, reset_to
+
+        create_repo_with_remote()
+        new_branch("root")
+        commit("root-initial")
+        push()
+        root_hash = get_commit_hash("root")
+
+        # Make remote commit (older timestamp)
+        new_branch("temp-old-remote")
+        reset_to(root_hash)
+        commit("diverged-remote-older")
+        push(tracking_branch="root", set_upstream=False)
+
+        # Now make local diverge (newer timestamp) - this will be level-1-branch
+        check_out("root")
+        reset_to(root_hash)
+        # Wait a bit to ensure newer timestamp
+        time.sleep(1)
+        new_branch("level-1-branch")
+        commit("diverged-local-newer")
+
+        # level-1-branch is now diverged from origin/root and newer
+        check_out("root")
+        fetch()
+
+        body: str = \
+            """
+            root
+                level-1-branch
+            """
+        rewrite_branch_layout_file(body)
+
+        self.patch_symbol(mocker, "builtins.input", mock_input_returning_y)
+        output = launch_command("advance")
+
+        assert "Branch root diverged from (and is newer than) origin." in output
+        assert "Push root to origin?" not in output


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1570

## Chain of upstream PRs as of 2026-01-19

* PR #1570:
  `develop` ← `fix/fork-point-message`

  * **PR #1571 (THIS ONE)**:
    `fix/fork-point-message` ← `improve/advance-push-ahead-only`

<!-- end git-machete generated -->
