### PR TITLE
In `--related` mode, always update both down- and upstream PR descriptions, even in `up-only` mode

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## New in git-machete 3.38.2
 
+- changed: `github update-pr-descriptions --related`, `gitlab update-mr-descriptions --related`, and all subcommands with `-U/--update-related-descriptions` flag now always update the entire stack (both upstream and downstream PRs/MRs); the description style still respects the `machete.github.prDescriptionIntroStyle` or `machete.gitlab.mrDescriptionIntroStyle` config setting
 - improved: `advance` now only suggests push when the branch is ahead of remote; for other sync-to-remote statuses (behind, diverged, in sync, untracked), a warning is displayed instead
 - improved: every time a branch is checked out, a `Checking out <branch>... OK` message is printed out for consistency
 

--- a/docs/man/git-machete.1
+++ b/docs/man/git-machete.1
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GIT-MACHETE" "1" "Jan 12, 2026" "" "git-machete"
+.TH "GIT-MACHETE" "1" "Jan 19, 2026" "" "git-machete"
 .SH NAME
 git-machete \- git-machete 3.38.2
 .sp
@@ -1111,9 +1111,7 @@ Update PR descriptions for all PRs authored by the given GitHub user, where \fB<
 Update PR descriptions for all PRs opened by the current user associated with the GitHub token.
 .TP
 .B  \-\-related
-Update PR descriptions for all PRs that are upstream and/or downstream of the PR for the current branch.
-If \fBmachete.github.prDescriptionIntroStyle\fP is \fBup\-only\fP (default) or \fBup\-only\-no\-branches\fP, then only downstream PR descriptions are updated.
-If \fBmachete.github.prDescriptionIntroStyle\fP is \fBfull\fP or \fBfull\-no\-branches\fP, then both downstream and upstream PR descriptions are updated.
+Update PR descriptions for all PRs both upstream and downstream of the PR for the current branch (the entire stack).
 .UNINDENT
 .UNINDENT
 .sp
@@ -1379,9 +1377,7 @@ Update MR descriptions for all MRs authored by the given GitLab user, where \fB<
 Update MR descriptions for all MRs opened by the current user associated with the GitLab token.
 .TP
 .B  \-\-related
-Update MR descriptions for all MRs that are upstream and/or downstream of the MR for the current branch.
-If \fBmachete.gitlab.mrDescriptionIntroStyle\fP is \fBup\-only\fP (default) or \fBup\-only\-no\-branches\fP, then only downstream MR descriptions are updated.
-If \fBmachete.gitlab.mrDescriptionIntroStyle\fP is \fBfull\fP or \fBfull\-no\-branches\fP, then both downstream and upstream MR descriptions are updated.
+Update MR descriptions for all MRs both upstream and downstream of the MR for the current branch (the entire stack).
 .UNINDENT
 .UNINDENT
 .sp

--- a/docs/source/cli/github.rst
+++ b/docs/source/cli/github.rst
@@ -159,9 +159,7 @@ Create, check out and manage GitHub PRs while keeping them reflected in branch l
 
     --mine               Update PR descriptions for all PRs opened by the current user associated with the GitHub token.
 
-    --related            Update PR descriptions for all PRs that are upstream and/or downstream of the PR for the current branch.
-                         If ``machete.github.prDescriptionIntroStyle`` is ``up-only`` (default) or ``up-only-no-branches``, then only downstream PR descriptions are updated.
-                         If ``machete.github.prDescriptionIntroStyle`` is ``full`` or ``full-no-branches``, then both downstream and upstream PR descriptions are updated.
+    --related            Update PR descriptions for all PRs both upstream and downstream of the PR for the current branch (the entire stack).
 
 **Git config keys:**
 

--- a/docs/source/cli/gitlab.rst
+++ b/docs/source/cli/gitlab.rst
@@ -150,9 +150,7 @@ Create, check out and manage GitLab MRs while keeping them reflected in branch l
 
     --mine               Update MR descriptions for all MRs opened by the current user associated with the GitLab token.
 
-    --related            Update MR descriptions for all MRs that are upstream and/or downstream of the MR for the current branch.
-                         If ``machete.gitlab.mrDescriptionIntroStyle`` is ``up-only`` (default) or ``up-only-no-branches``, then only downstream MR descriptions are updated.
-                         If ``machete.gitlab.mrDescriptionIntroStyle`` is ``full`` or ``full-no-branches``, then both downstream and upstream MR descriptions are updated.
+    --related            Update MR descriptions for all MRs both upstream and downstream of the MR for the current branch (the entire stack).
 
 **Git config keys:**
 

--- a/git_machete/client/with_code_hosting.py
+++ b/git_machete/client/with_code_hosting.py
@@ -979,11 +979,9 @@ class MacheteClientWithCodeHosting(MacheteClient):
                 return []
             return result
         elif related_to:
-            style = self.__get_pr_description_into_style_from_config()
-            if style in (PRDescriptionIntroStyle.FULL, PRDescriptionIntroStyle.FULL_NO_BRANCHES):
-                result = list(reversed(self.__get_upwards_path_including_pr(related_to)))
-            else:
-                result = [related_to]
+            # Always update the entire stack (both upstream and downstream) when --related is used,
+            # regardless of prDescriptionIntroStyle setting.
+            result = list(reversed(self.__get_upwards_path_including_pr(related_to)))
             result += [pr_ for pr_, _ in self.__get_downwards_tree_excluding_pr(related_to)]
             return result
 

--- a/git_machete/generated_docs.py
+++ b/git_machete/generated_docs.py
@@ -739,9 +739,7 @@ long_docs: Dict[str, str] = {
 
               --mine               Update PR descriptions for all PRs opened by the current user associated with the GitHub token.
 
-              --related            Update PR descriptions for all PRs that are upstream and/or downstream of the PR for the current branch.
-                                   If `machete.github.prDescriptionIntroStyle` is `up-only` (default) or `up-only-no-branches`, then only downstream PR descriptions are updated.
-                                   If `machete.github.prDescriptionIntroStyle` is `full` or `full-no-branches`, then both downstream and upstream PR descriptions are updated.
+              --related            Update PR descriptions for all PRs both upstream and downstream of the PR for the current branch (the entire stack).
 
         <b>Git config keys:</b>
 
@@ -929,9 +927,7 @@ long_docs: Dict[str, str] = {
 
               --mine               Update MR descriptions for all MRs opened by the current user associated with the GitLab token.
 
-              --related            Update MR descriptions for all MRs that are upstream and/or downstream of the MR for the current branch.
-                                   If `machete.gitlab.mrDescriptionIntroStyle` is `up-only` (default) or `up-only-no-branches`, then only downstream MR descriptions are updated.
-                                   If `machete.gitlab.mrDescriptionIntroStyle` is `full` or `full-no-branches`, then both downstream and upstream MR descriptions are updated.
+              --related            Update MR descriptions for all MRs both upstream and downstream of the MR for the current branch (the entire stack).
 
         <b>Git config keys:</b>
 

--- a/tests/test_github_update_pr_descriptions.py
+++ b/tests/test_github_update_pr_descriptions.py
@@ -18,6 +18,78 @@ from tests.mockers_github import (MockGitHubAPIState,
 
 
 class TestGitHubUpdatePRDescriptions(BaseTest):
+    def test_github_update_pr_descriptions_related_updates_entire_stack(self, mocker: MockerFixture) -> None:
+        """
+        Test that --related flag updates the entire stack (both upstream and downstream PRs),
+        even with the default up-only prDescriptionIntroStyle.
+
+        With the OLD logic (before PR #1574), when running `--related` from branch2 with the default
+        up-only style, only PR #2 and PR #3 (current and downstream) would be checked/updated.
+        PR #1 (upstream) would be skipped entirely.
+
+        With the NEW logic, all PRs in the stack (PR #1, PR #2, PR #3) are checked and updated,
+        regardless of the prDescriptionIntroStyle setting.
+        Still, the generated intro will follow the prDescriptionIntroStyle setting.
+        """
+        self.patch_symbol(mocker, 'git_machete.code_hosting.OrganizationAndRepository.from_url', mock_from_url)
+        self.patch_symbol(mocker, 'git_machete.github.GitHubToken.for_domain', mock_github_token_for_domain_fake)
+
+        # Create a simple 3-PR chain: PR1 -> PR2 -> PR3
+        # Give them bodies that will need updating:
+        # - PR #1 has an old git-machete generated section with outdated date
+        # - PR #2 and #3 have minimal bodies that will be updated with the PR chain info
+        prs = [
+            mock_pr_json(head='branch1', base='root', number=1,
+                         body='<!-- start git-machete generated -->\n\n'
+                              '**Last updated: 2020-01-01**\n\n'
+                              '<!-- end git-machete generated -->\n\n'
+                              '# Summary\n\nOld content'),
+            mock_pr_json(head='branch2', base='branch1', number=2, body='# Summary\n'),
+            mock_pr_json(head='branch3', base='branch2', number=3, body='# Summary\n')
+        ]
+        github_api_state = MockGitHubAPIState.with_prs(*prs)
+        self.patch_symbol(mocker, 'urllib.request.urlopen', mock_urlopen(github_api_state))
+        self.patch_symbol(mocker, 'git_machete.utils.get_current_date', lambda: '2023-12-31')
+
+        create_repo_with_remote()
+        new_branch("root")
+        commit("initial commit")
+        push()
+        new_branch("branch1")
+        commit("branch1 commit")
+        push()
+        new_branch("branch2")
+        commit("branch2 commit")
+        push()
+        new_branch("branch3")
+        commit("branch3 commit")
+        push()
+
+        body = """
+            root
+              branch1
+                branch2
+                  branch3
+            """
+        rewrite_branch_layout_file(body)
+
+        # Check out the middle branch (branch2)
+        check_out('branch2')
+
+        # Run with `--related` from the middle branch
+        # With the NEW logic, ALL PRs in the stack (PR1, PR2, PR3) are checked and updated
+        # With the OLD logic (before PR #1574), only PR2 and PR3 (current and downstream) would be updated,
+        # but NOT PR1 (upstream), because the default up-only style would exclude upstream PRs
+        assert_success(
+            ['github', 'update-pr-descriptions', '--related'],
+            """
+            Checking for open GitHub PRs... OK
+            Description of PR #1 (branch1 -> root) has been updated
+            Description of PR #2 (branch2 -> branch1) has been updated
+            Description of PR #3 (branch3 -> branch2) has been updated
+            """
+        )
+
     @staticmethod
     def prs_for_test_update_pr_descriptions() -> List[Dict[str, Any]]:
         return [

--- a/tests/test_gitlab_update_mr_descriptions.py
+++ b/tests/test_gitlab_update_mr_descriptions.py
@@ -18,6 +18,78 @@ from tests.mockers_gitlab import (MockGitLabAPIState,
 
 
 class TestGitLabUpdateMRDescriptions(BaseTest):
+    def test_gitlab_update_mr_descriptions_related_updates_entire_stack(self, mocker: MockerFixture) -> None:
+        """
+        Test that --related flag updates the entire stack (both upstream and downstream MRs),
+        even with the default up-only prDescriptionIntroStyle.
+
+        With the OLD logic (before #1574), when running `--related` from branch2 with the default
+        up-only style, only MR #2 and MR #3 (current and downstream) would be checked/updated.
+        MR #1 (upstream) would be skipped entirely.
+
+        With the NEW logic, all MRs in the stack (MR #1, MR #2, MR #3) are checked and updated,
+        regardless of the prDescriptionIntroStyle setting.
+        Still, the generated intro will follow the prDescriptionIntroStyle setting.
+        """
+        self.patch_symbol(mocker, 'git_machete.code_hosting.OrganizationAndRepository.from_url', mock_from_url)
+        self.patch_symbol(mocker, 'git_machete.gitlab.GitLabToken.for_domain', mock_gitlab_token_for_domain_fake)
+
+        # Create a simple 3-MR chain: MR1 -> MR2 -> MR3
+        # Give them bodies that will need updating:
+        # - MR #1 has an old git-machete generated section with outdated date
+        # - MR #2 and #3 have minimal bodies that will be updated with the MR chain info
+        mrs = [
+            mock_mr_json(head='branch1', base='root', number=1,
+                         body='<!-- start git-machete generated -->\n\n'
+                              '**Last updated: 2020-01-01**\n\n'
+                              '<!-- end git-machete generated -->\n\n'
+                              '# Summary\n\nOld content'),
+            mock_mr_json(head='branch2', base='branch1', number=2, body='# Summary\n'),
+            mock_mr_json(head='branch3', base='branch2', number=3, body='# Summary\n')
+        ]
+        gitlab_api_state = MockGitLabAPIState.with_mrs(*mrs)
+        self.patch_symbol(mocker, 'urllib.request.urlopen', mock_urlopen(gitlab_api_state))
+        self.patch_symbol(mocker, 'git_machete.utils.get_current_date', lambda: '2023-12-31')
+
+        create_repo_with_remote()
+        new_branch("root")
+        commit("initial commit")
+        push()
+        new_branch("branch1")
+        commit("branch1 commit")
+        push()
+        new_branch("branch2")
+        commit("branch2 commit")
+        push()
+        new_branch("branch3")
+        commit("branch3 commit")
+        push()
+
+        body = """
+            root
+              branch1
+                branch2
+                  branch3
+            """
+        rewrite_branch_layout_file(body)
+
+        # Check out the middle branch (branch2)
+        check_out('branch2')
+
+        # Run with `--related` from the middle branch
+        # With the NEW logic, ALL MRs in the stack (MR1, MR2, MR3) are checked and updated
+        # With the OLD logic (before #1574), only MR2 and MR3 (current and downstream) would be updated,
+        # but NOT MR1 (upstream), because the default up-only style would exclude upstream MRs
+        assert_success(
+            ['gitlab', 'update-mr-descriptions', '--related'],
+            """
+            Checking for open GitLab MRs... OK
+            Description of MR !1 (branch1 -> root) has been updated
+            Description of MR !2 (branch2 -> branch1) has been updated
+            Description of MR !3 (branch3 -> branch2) has been updated
+            """
+        )
+
     @staticmethod
     def mrs_for_test_update_mr_descriptions() -> List[Dict[str, Any]]:
         return [


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1571

## Chain of upstream PRs as of 2026-01-19

* PR #1570:
  `develop` ← `fix/fork-point-message`

  * PR #1571:
    `fix/fork-point-message` ← `improve/advance-push-ahead-only`

    * **PR #1574 (THIS ONE)**:
      `improve/advance-push-ahead-only` ← `improve/related-whole-stack`

<!-- end git-machete generated -->
