### PR TITLE
Fix exception type raised in `GoShowMacheteClient`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,7 +3,7 @@
 ## New in git-machete 3.39.0
 
 - added: `machete.traverse.whenBranchNotCheckedOutInAnyWorktree` git config key to control the behavior
-  when checking out a branch that is not checked out in any worktree; values: `cd-into-main-worktree` (default) or `stay-in-the-current-worktree`
+  when checking out a branch that is not checked out in any worktree (suggested by @a-harhar)
 - changed: `github update-pr-descriptions --related`, `gitlab update-mr-descriptions --related`,
   and all subcommands with `-U/--update-related-descriptions` flag now always update the entire stack (both upstream and downstream PRs/MRs);
   the description style still respects the `machete.github.prDescriptionIntroStyle` or `machete.gitlab.mrDescriptionIntroStyle` config setting

--- a/git_machete/client/go_show.py
+++ b/git_machete/client/go_show.py
@@ -1,8 +1,7 @@
 from typing import List, Optional
 
 from git_machete.client.base import MacheteClient, PickRoot
-from git_machete.exceptions import (UnderlyingGitException,
-                                    UnexpectedMacheteException)
+from git_machete.exceptions import MacheteException, UnexpectedMacheteException
 from git_machete.git_operations import LocalBranchShortName
 
 
@@ -19,7 +18,7 @@ class GoShowMacheteClient(MacheteClient):
             return [self._git.get_current_branch()]  # throws in case of detached HEAD, as in the spec
         elif param in ("d", "down"):
             if branch is None:
-                raise UnderlyingGitException("Not currently on any branch")
+                raise MacheteException("Not currently on any branch")
             return self.get_or_pick_down_branch_for(branch, pick_if_multiple=pick_if_multiple)
         elif param in ("f", "first"):
             # If branch is None (detached HEAD), use first root then get first branch
@@ -35,11 +34,11 @@ class GoShowMacheteClient(MacheteClient):
                 return [self.last_branch_for(branch)]
         elif param in ("n", "next"):
             if branch is None:
-                raise UnderlyingGitException("Not currently on any branch")
+                raise MacheteException("Not currently on any branch")
             return [self.next_branch_for(branch)]
         elif param in ("p", "prev"):
             if branch is None:
-                raise UnderlyingGitException("Not currently on any branch")
+                raise MacheteException("Not currently on any branch")
             return [self.prev_branch_for(branch)]
         elif param in ("r", "root"):
             # If branch is None (detached HEAD), use first root
@@ -49,7 +48,7 @@ class GoShowMacheteClient(MacheteClient):
                 return [self.root_branch_for(branch, if_unmanaged=PickRoot.FIRST)]
         elif param in ("u", "up"):
             if branch is None:
-                raise UnderlyingGitException("Not currently on any branch")
+                raise MacheteException("Not currently on any branch")
             return [self.get_or_infer_up_branch_for(branch, prompt_if_inferred_msg=None, prompt_if_inferred_yes_opt_msg=None)]
         else:  # an unknown direction is handled by argparse
             raise UnexpectedMacheteException(f"Invalid direction: `{param}`.")

--- a/tests/test_go.py
+++ b/tests/test_go.py
@@ -547,8 +547,6 @@ class TestGo(BaseTest):
         # Get a commit hash to checkout in detached HEAD mode
         detached_commit = get_commit_hash("root-2")
 
-        from git_machete.exceptions import UnderlyingGitException
-
         # These should work (navigate to absolute positions):
         check_out(detached_commit)
         launch_command("go", "first")
@@ -573,7 +571,7 @@ class TestGo(BaseTest):
         check_out(detached_commit)
 
         # These should fail (require current branch context):
-        assert_failure(["go", "down"], "Not currently on any branch", expected_type=UnderlyingGitException)
-        assert_failure(["go", "next"], "Not currently on any branch", expected_type=UnderlyingGitException)
-        assert_failure(["go", "prev"], "Not currently on any branch", expected_type=UnderlyingGitException)
-        assert_failure(["go", "up"], "Not currently on any branch", expected_type=UnderlyingGitException)
+        assert_failure(["go", "down"], "Not currently on any branch")
+        assert_failure(["go", "next"], "Not currently on any branch")
+        assert_failure(["go", "prev"], "Not currently on any branch")
+        assert_failure(["go", "up"], "Not currently on any branch")


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1585

## Chain of upstream PRs as of 2026-01-29

* PR #1585:
  `master` ← `develop`

  * **PR #1586 (THIS ONE)**:
    `develop` ← `fix/go-exception-type`

<!-- end git-machete generated -->
