### PR TITLE
Cache `git merge-base` results

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,9 +2,10 @@
 
 ## New in git-machete 3.39.1
 
+- changed: whenever git-machete prints a path on Windows, the path is now POSIX-compatible (with `/`)
 - fixed: suggested `update` command in deprecation message for `fork-point --override-to=...` and `--override-to-inferred`
 - fixed: subtle bugs related to relative main/git directory paths when switching worktrees in `traverse`
-- changed: whenever git-machete prints a path on Windows, the path is now POSIX-compatible (with `/`)
+- improved: `git merge-base` results are written into `.git/machete-merge-base-cache` for faster retrieval in large repositories
 
 ## New in git-machete 3.39.0
 

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -233,7 +233,7 @@ class GitContext:
         self.__is_equivalent_patch_reachable_cached: Dict[Tuple[FullCommitHash, FullCommitHash], bool] = {}
         self.__is_equivalent_tree_reachable_cached: Dict[Tuple[FullCommitHash, FullCommitHash], bool] = {}
         self.__local_branches_cached: Optional[List[LocalBranchShortName]] = None
-        self.__merge_base_cached: Dict[Tuple[FullCommitHash, FullCommitHash], Optional[FullCommitHash]] = {}
+        self._merge_base_cached: Optional[Dict[Tuple[FullCommitHash, FullCommitHash], Optional[FullCommitHash]]] = None
         self.__reflogs_cached: Optional[Dict[AnyBranchName, List[GitReflogEntry]]] = None
         self.__remaining_log_hashes_cached: Dict[FullCommitHash, List[FullCommitHash]] = {}
         self.__remote_branches_cached: Optional[List[RemoteBranchShortName]] = None
@@ -899,28 +899,97 @@ class GitContext:
             raise UnderlyingGitException("Not currently on any branch")
         return result
 
+    def __get_merge_base_cache_path(self) -> str:
+        return os.path.join(self.get_main_worktree_git_dir(), "machete-merge-base-cache")
+
+    def __load_merge_base_cache(self) -> None:
+        """Load merge-base cache from file. Called lazily on first use."""
+        if self._merge_base_cached is not None:
+            return
+
+        self._merge_base_cached = {}
+        cache_path = self.__get_merge_base_cache_path()
+        if not os.path.exists(cache_path):
+            return
+
+        debug(f"reading merge-base cache from {cache_path}")
+        with open(cache_path, 'r') as f:
+            for line_num, line in enumerate(f, start=1):
+                line = line.strip()
+                if not line:
+                    continue
+
+                parts = line.split()
+                if len(parts) < 2 or len(parts) > 3:
+                    debug(f"{cache_path}:{line_num}: invalid number of fields (expected 2 or 3, got {len(parts)}), ignoring")
+                    continue
+
+                hash1_str, hash2_str = parts[0], parts[1]
+                merge_base_str = parts[2] if len(parts) == 3 else None
+
+                # Validate that all hashes are full commit hashes (40 hex chars)
+                if not FullCommitHash.is_valid(hash1_str) or not FullCommitHash.is_valid(hash2_str):
+                    debug(f"{cache_path}:{line_num}: invalid input commit hash format, ignoring")
+                    continue
+
+                if merge_base_str is not None and not FullCommitHash.is_valid(merge_base_str):
+                    debug(f"{cache_path}:{line_num}: invalid merge-base commit hash format, ignoring")
+                    continue
+
+                hash1 = FullCommitHash.of(hash1_str)
+                hash2 = FullCommitHash.of(hash2_str)
+                # Normalize: ensure hash1 <= hash2
+                if hash1 > hash2:
+                    hash1, hash2 = hash2, hash1
+
+                merge_base = FullCommitHash.of(merge_base_str) if merge_base_str else None
+                self._merge_base_cached[(hash1, hash2)] = merge_base
+
+    def __save_merge_base_cache_entry(self, *, hash1: FullCommitHash, hash2: FullCommitHash, merge_base: Optional[FullCommitHash]) -> None:
+        """Append a merge-base cache entry to the cache file."""
+        cache_path = self.__get_merge_base_cache_path()
+        with open(cache_path, 'a') as f:
+            debug(f"writing merge-base cache entry to {cache_path}: {hash1} {hash2} {merge_base or '(no merge-base)'}")
+            if merge_base is not None:
+                f.write(f"{hash1} {hash2}  {merge_base}\n")
+            else:
+                f.write(f"{hash1} {hash2}\n")
+
     def __get_merge_base_for_commit_hashes(self, hash1: FullCommitHash, hash2: FullCommitHash) -> Optional[FullCommitHash]:  # noqa: KW
         # This if statement is not changing the outcome of the later return, but
         # it enhances the efficiency of the script. If both hashes are the same,
         # there is no point running git merge-base.
         if hash1 == hash2:
             return hash1
+        # Load cache lazily on first use
+        self.__load_merge_base_cache()
         if hash1 > hash2:
             hash1, hash2 = hash2, hash1
-        if not (hash1, hash2) in self.__merge_base_cached:
+        # After __load_merge_base_cache(), the cache is guaranteed to be a dict (not None)
+        assert self._merge_base_cached is not None
+        if not (hash1, hash2) in self._merge_base_cached:
             # Note that we don't pass '--all' flag to 'merge-base', so we'll get only one merge-base
             # even if there is more than one (in the rare case of criss-cross histories).
-            # This is still okay from the perspective of is-ancestor checks that are our sole use of merge-base:
+
+            # This is still okay from the perspective of is-ancestor checks:
             # * if any of hash1, hash2 is an ancestor of another,
             #   then there is exactly one merge-base - the ancestor,
             # * if neither of hash1, hash2 is an ancestor of another,
             #   then none of the (possibly more than one) merge-bases is equal to either of hash1/hash2 anyway.
+
+            # If it comes to the other uses (like is_equivalent_patch_reachable),
+            # the results aren't well defined for the case of criss-cross histories anyway,
+            # and such histories are unlikely to emerge among branches managed by git-machete.
+
             # In the rare case when hash1, hash2 have no common commits, the flag: allow_non_zero=True
             # (allows, non zero exit code to be returned by git merge-base command, without raising an exception)
             # is used and the __get_merge_base function returns None.
             merge_base = self._popen_git("merge-base", hash1, hash2, allow_non_zero=True).stdout.strip()
-            self.__merge_base_cached[hash1, hash2] = FullCommitHash.of(merge_base) if merge_base else None
-        return self.__merge_base_cached[hash1, hash2]
+            merge_base_hash = FullCommitHash.of(merge_base) if merge_base else None
+            self._merge_base_cached[hash1, hash2] = merge_base_hash
+            # Save to cache file
+            self.__save_merge_base_cache_entry(hash1=hash1, hash2=hash2, merge_base=merge_base_hash)
+        return self._merge_base_cached[hash1, hash2]
 
     def is_ancestor_or_equal(self, earlier_revision: AnyRevision, later_revision: AnyRevision) -> bool:  # noqa: KW
         earlier_hash = self.get_commit_hash_by_revision(earlier_revision)

--- a/git_machete/utils.py
+++ b/git_machete/utils.py
@@ -161,28 +161,30 @@ def compact_dict(d: Dict[str, Any]) -> Dict[str, str]:
 
 
 def debug(msg: str) -> None:
-    if debug_mode:
-        function_name = bold(inspect.stack()[1].function)
-        args, _, _, values_original = inspect.getargvalues(inspect.stack()[1].frame)
-        # Do not write over the original values!
-        # Since Python 3.13, the result of `getargvalues` keeps a map of local variables
-        # that the Python runtime actually keeps on the stack,
-        # so overwriting a key in values_original changes the local variable.
-        values: Dict[str, Any] = dict(values_original)
+    if not debug_mode:
+        return
 
-        args_to_be_redacted = {'access_token', 'password', 'secret', 'token'}
-        for arg, value in values.items():
-            if arg in args_to_be_redacted or any(value_ in str(value) for value_ in CODE_HOSTING_TOKEN_PREFIXES):
-                values[arg] = '***'
-            elif type(value) is dict:
-                values[arg] = compact_dict(value)
-            values[arg] = textwrap.shorten(str(values[arg]), width=50, placeholder="...")
+    function_name = bold(inspect.stack()[1].function)
+    args, _, _, values_original = inspect.getargvalues(inspect.stack()[1].frame)
+    # Do not write over the original values!
+    # Since Python 3.13, the result of `getargvalues` keeps a map of local variables
+    # that the Python runtime actually keeps on the stack,
+    # so overwriting a key in values_original changes the local variable.
+    values: Dict[str, Any] = dict(values_original)
 
-        args_and_values_list = [arg + '=' + str(values[arg]) for arg in excluding(args, {'self'})]
-        args_and_values_str = ', '.join(args_and_values_list)
-        args_and_values_bold_str = bold(f'({args_and_values_str})')
+    args_to_be_redacted = {'access_token', 'password', 'secret', 'token'}
+    for arg, value in values.items():
+        if arg in args_to_be_redacted or any(value_ in str(value) for value_ in CODE_HOSTING_TOKEN_PREFIXES):
+            values[arg] = '***'
+        elif type(value) is dict:
+            values[arg] = compact_dict(value)
+        values[arg] = textwrap.shorten(str(values[arg]), width=50, placeholder="...")
 
-        print(f"{function_name}{args_and_values_bold_str}: {dim(msg)}", file=sys.stderr)
+    args_and_values_list = [arg + '=' + str(values[arg]) for arg in excluding(args, {'self'})]
+    args_and_values_str = ', '.join(args_and_values_list)
+    args_and_values_bold_str = bold(f'({args_and_values_str})')
+
+    print(f"{function_name}{args_and_values_bold_str}: {dim(msg)}", file=sys.stderr)
 
 
 def _run_cmd(cmd: str, *args: str, cwd: Optional[str] = None, env: Optional[Dict[str, str]] = None) -> int:

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -5,7 +5,7 @@ from git_machete.git_operations import (AnyBranchName, AnyRevision,
                                         LocalBranchShortName)
 
 from .base_test import BaseTest
-from .mockers import write_to_file
+from .mockers import read_file, write_to_file
 from .mockers_git_repository import (add_worktree, check_out, commit,
                                      create_repo, get_current_commit_hash,
                                      get_git_version, is_ancestor_or_equal,
@@ -299,3 +299,158 @@ class TestGitOperations(BaseTest):
         feature2_path = worktrees.get(LocalBranchShortName.of("feature-2"))
         assert feature2_path is not None
         assert os.path.realpath(feature2_path) == os.path.realpath(feature2_worktree)
+
+    def test_merge_base_cache_loading_and_saving(self) -> None:
+        """Test merge-base cache with various edge cases."""
+        create_repo()
+        new_branch("master")
+        commit("master first commit")
+        master_hash = FullCommitHash.of(get_current_commit_hash())
+        new_branch("feature")
+        commit("feature commit")
+        feature_hash = FullCommitHash.of(get_current_commit_hash())
+        check_out("master")
+        commit("master second commit")
+        master_hash2 = FullCommitHash.of(get_current_commit_hash())
+
+        git = GitContext()
+        cache_path = os.path.join(git.get_main_worktree_git_dir(), "machete-merge-base-cache")
+
+        # Test 1: Cache file doesn't exist - should work normally
+        assert not os.path.exists(cache_path)
+        merge_base1 = git.get_merge_base(master_hash, feature_hash)
+        assert merge_base1 is not None
+        # Cache should now exist and contain the entry
+        assert os.path.exists(cache_path)
+        cache_content = read_file(cache_path)
+        assert master_hash.full_name() in cache_content or feature_hash.full_name() in cache_content
+        assert merge_base1.full_name() in cache_content
+
+        # Test 2: Cache with valid entries (using fake hashes that will be loaded into cache)
+        valid_hash1 = "a" * 40
+        valid_hash2 = "b" * 40
+        valid_merge_base = "c" * 40
+        write_to_file(cache_path, f"{valid_hash1} {valid_hash2} {valid_merge_base}\n")
+        git = GitContext()  # New instance to test cache loading
+        # Access cache by calling get_merge_base (which triggers cache load)
+        git.get_merge_base(master_hash, feature_hash)
+        # Check that valid entry was loaded (even though these are fake hashes, they should be in cache)
+        assert git._merge_base_cached is not None
+        # Normalize hash order
+        if valid_hash1 < valid_hash2:
+            hash1_norm, hash2_norm = FullCommitHash.of(valid_hash1), FullCommitHash.of(valid_hash2)
+        else:
+            hash1_norm, hash2_norm = FullCommitHash.of(valid_hash2), FullCommitHash.of(valid_hash1)
+        assert (hash1_norm, hash2_norm) in git._merge_base_cached
+        assert git._merge_base_cached[(hash1_norm, hash2_norm)] == FullCommitHash.of(valid_merge_base)
+
+        # Test 3: Cache with valid entry missing 3rd field (no merge-base - rare case)
+        orphan_hash1 = "d" * 40
+        orphan_hash2 = "e" * 40
+        write_to_file(cache_path, f"{orphan_hash1} {orphan_hash2}\n")
+        git = GitContext()
+        git.get_merge_base(master_hash, feature_hash)  # Trigger cache load
+        assert git._merge_base_cached is not None
+        # Normalize hash order
+        if orphan_hash1 < orphan_hash2:
+            orphan1_norm, orphan2_norm = FullCommitHash.of(orphan_hash1), FullCommitHash.of(orphan_hash2)
+        else:
+            orphan1_norm, orphan2_norm = FullCommitHash.of(orphan_hash2), FullCommitHash.of(orphan_hash1)
+        assert (orphan1_norm, orphan2_norm) in git._merge_base_cached
+        assert git._merge_base_cached[(orphan1_norm, orphan2_norm)] is None
+
+        # Test 4: Cache with various invalid entries - should ignore them
+        invalid_entries = [
+            "single_entry",  # Only 1 entry
+            "hash1 hash2 hash3 hash4",  # 4+ entries
+            "short1 short2 merge",  # Short hashes (not 40 chars)
+            "x" * 39 + " " + "y" * 39 + " " + "z" * 39,  # 39-char hashes
+            "complete gibberish with spaces and stuff",  # Gibberish
+            "a" * 40 + " " + "b" * 40 + " " + "short",  # Valid hashes but short merge-base
+            "a" * 40 + " " + "short" + " " + "c" * 40,  # Short hash2
+            "short" + " " + "b" * 40 + " " + "c" * 40,  # Short hash1
+            "nothex" + "x" * 34 + " " + "b" * 40 + " " + "c" * 40,  # Invalid hex in hash1
+            "a" * 40 + " " + "nothex" + "x" * 34 + " " + "c" * 40,  # Invalid hex in hash2
+            "a" * 40 + " " + "b" * 40 + " " + "nothex" + "x" * 34,  # Invalid hex in merge-base
+        ]
+        valid_entry = f"{valid_hash1} {valid_hash2} {valid_merge_base}"
+        cache_content_with_invalid = "\n".join(invalid_entries) + "\n" + valid_entry + "\n"
+        write_to_file(cache_path, cache_content_with_invalid)
+        git = GitContext()
+        git.get_merge_base(master_hash, feature_hash)  # Trigger cache load
+        # Should still have the valid entry loaded
+        assert git._merge_base_cached is not None
+        # Normalize hash order
+        if valid_hash1 < valid_hash2:
+            valid1_norm, valid2_norm = FullCommitHash.of(valid_hash1), FullCommitHash.of(valid_hash2)
+        else:
+            valid1_norm, valid2_norm = FullCommitHash.of(valid_hash2), FullCommitHash.of(valid_hash1)
+        assert (valid1_norm, valid2_norm) in git._merge_base_cached
+        # Invalid entries should be ignored (not cause errors)
+
+        # Test 5: Cache with empty lines and whitespace
+        write_to_file(cache_path, f"\n  \n\t\n{valid_hash1} {valid_hash2} {valid_merge_base}\n\n")
+        git = GitContext()
+        git.get_merge_base(master_hash, feature_hash)  # Trigger cache load
+        assert git._merge_base_cached is not None
+        # Normalize hash order
+        if valid_hash1 < valid_hash2:
+            valid1_norm, valid2_norm = FullCommitHash.of(valid_hash1), FullCommitHash.of(valid_hash2)
+        else:
+            valid1_norm, valid2_norm = FullCommitHash.of(valid_hash2), FullCommitHash.of(valid_hash1)
+        assert (valid1_norm, valid2_norm) in git._merge_base_cached
+
+        # Test 6: Cache with hash order normalization (hash1 > hash2)
+        hash_larger = "f" * 40
+        hash_smaller = "a" * 40
+        merge_base_normalized = "0" * 40
+        write_to_file(cache_path, f"{hash_larger} {hash_smaller} {merge_base_normalized}\n")
+        git = GitContext()
+        git.get_merge_base(master_hash, feature_hash)  # Trigger cache load
+        assert git._merge_base_cached is not None
+        # Should be normalized to (smaller, larger)
+        hash_smaller_norm = FullCommitHash.of(hash_smaller)
+        hash_larger_norm = FullCommitHash.of(hash_larger)
+        assert (hash_smaller_norm, hash_larger_norm) in git._merge_base_cached
+        assert git._merge_base_cached[(hash_smaller_norm, hash_larger_norm)] == FullCommitHash.of(merge_base_normalized)
+
+        # Test 7: Cache saving appends new entries and normalizes hash order
+        initial_size = os.path.getsize(cache_path) if os.path.exists(cache_path) else 0
+        # Compute a new merge-base that's not in cache
+        new_branch("other")
+        commit("other commit")
+        other_hash = FullCommitHash.of(get_current_commit_hash())
+        # Ensure we test with hash1 > hash2 to verify normalization on write
+        if master_hash2 > other_hash:
+            larger_hash, smaller_hash = master_hash2, other_hash
+        else:
+            larger_hash, smaller_hash = other_hash, master_hash2
+        git.get_merge_base(larger_hash, smaller_hash)  # Compute merge-base to trigger cache write
+        # Check that cache file grew
+        assert os.path.exists(cache_path)
+        new_size = os.path.getsize(cache_path)
+        assert new_size > initial_size
+        # Verify the new entry is in the file with normalized order (smaller <= larger)
+        cache_content_after = read_file(cache_path)
+        # The entry should be written as "smaller_hash larger_hash merge_base"
+        # (not "larger_hash smaller_hash merge_base")
+        assert f"{smaller_hash.full_name()} {larger_hash.full_name()}" in cache_content_after
+        # Verify it's NOT written in reverse order
+        assert f"{larger_hash.full_name()} {smaller_hash.full_name()}" not in cache_content_after
+
+        # Test 8: Cache is used when entry exists (no git merge-base call needed)
+        # We'll test this by ensuring the cached value is returned
+        # First, write a cache entry for real commits
+        write_to_file(cache_path, f"{master_hash.full_name()} {feature_hash.full_name()} {merge_base1.full_name()}\n")
+        git2 = GitContext()
+        # Load cache and get merge-base - should use cached value
+        cached_merge_base = git2.get_merge_base(master_hash, feature_hash)
+        # The result should match what we put in cache
+        assert cached_merge_base == merge_base1
+        # Verify it's in the cache dict
+        assert git2._merge_base_cached is not None
+        # Normalize hash order for lookup
+        hash1_norm, hash2_norm = (master_hash, feature_hash) if master_hash < feature_hash else (feature_hash, master_hash)
+        assert git2._merge_base_cached is not None  # Help mypy understand it's not None
+        cached_result = git2._merge_base_cached.get((hash1_norm, hash2_norm))
+        assert cached_result == merge_base1


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1599

## Chain of upstream PRs as of 2026-02-17

* PR #1598:
  `develop` ← `fix/machete-file-path-relative-windows`

  * PR #1599:
    `fix/machete-file-path-relative-windows` ← `fix/windows-fwd-slash`

    * **PR #1596 (THIS ONE)**:
      `fix/windows-fwd-slash` ← `perf/merge-base-cache`

<!-- end git-machete generated -->
