### PR TITLE
Print forward slashes only in paths on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,7 @@ jobs:
             pip3 install tox
 
             # For enforce-shell-scripts-pass-shellcheck.sh
+            sudo apt-get update
             sudo apt-get install shellcheck
 
             # For enforce-links-correct.sh

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 - fixed: suggested `update` command in deprecation message for `fork-point --override-to=...` and `--override-to-inferred`
 - fixed: subtle bugs related to relative main/git directory paths when switching worktrees in `traverse`
+- changed: whenever git-machete prints a path on Windows, the path is now POSIX-compatible (with `/`)
 
 ## New in git-machete 3.39.0
 

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -640,7 +640,7 @@ def launch_internal(orig_args: List[str]) -> None:
         elif cmd == "file":
             # No need to read branch layout file.
             file_client = MacheteClient(git)
-            print(os.path.abspath(file_client.branch_layout_file_path))
+            print(utils.abspath_posix(file_client.branch_layout_file_path))
         elif cmd == "fork-point":
             fork_point_client = ForkPointMacheteClient(git)
             fork_point_client.read_branch_layout_file()
@@ -973,10 +973,10 @@ def launch_internal(orig_args: List[str]) -> None:
         if initial_current_directory and not utils.does_directory_exist(initial_current_directory):
             nearest_existing_parent_directory = initial_current_directory
             while not utils.does_directory_exist(nearest_existing_parent_directory):
-                nearest_existing_parent_directory = os.path.join(
+                nearest_existing_parent_directory = utils.join_paths_posix(
                     nearest_existing_parent_directory, os.path.pardir)
             warn(f"current directory {initial_current_directory} no longer exists, "
-                 f"the nearest existing parent directory is {os.path.abspath(nearest_existing_parent_directory)}")
+                 f"the nearest existing parent directory is {utils.abspath_posix(nearest_existing_parent_directory)}")
 
 
 def main() -> None:

--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -25,7 +25,8 @@ from git_machete.git_operations import (HEAD, AnyBranchName, AnyRevision,
                                         SyncToRemoteStatus)
 from git_machete.utils import (AnsiEscapeCodes, PopenResult, bold, colored,
                                debug, dim, excluding, flat_map, fmt,
-                               get_pretty_choices, get_second, tupled,
+                               get_pretty_choices, get_second,
+                               join_paths_posix, relpath_posix, tupled,
                                underline, warn)
 
 
@@ -118,12 +119,12 @@ class MacheteClient:
             machete_file_directory = self._git.get_main_worktree_git_dir()
         else:
             machete_file_directory = self._git.get_current_worktree_git_dir()
-        abs_path = os.path.join(machete_file_directory, 'machete')
+        abs_path = join_paths_posix(machete_file_directory, 'machete')
         # Make the path relative to the current working directory, if possible.
         # This is more convenient for display purposes, and shouldn't introduce any problems in traverse
         # (since machete file path is only retrieved at the start, before any potential CWD changes)
         try:
-            return os.path.relpath(abs_path, start=os.getcwd())
+            return relpath_posix(abs_path)
         except Exception:  # pragma: no cover
             # If for some reason relpath fails, fall back to absolute path.
             return abs_path

--- a/git_machete/client/traverse.py
+++ b/git_machete/client/traverse.py
@@ -12,10 +12,9 @@ from git_machete.git_config_keys import \
     TRAVERSE_WHEN_BRANCH_NOT_CHECKED_OUT_IN_ANY_WORKTREE
 from git_machete.git_operations import (GitContext, LocalBranchShortName,
                                         SyncToRemoteStatus)
-from git_machete.utils import (bold, flat_map, fmt, get_pretty_choices,
-                               get_right_arrow, green_ok,
-                               normalize_path_for_display, print_no_newline,
-                               warn)
+from git_machete.utils import (abspath_posix, bold, flat_map, fmt,
+                               get_pretty_choices, get_right_arrow, green_ok,
+                               print_no_newline, warn)
 
 
 class TraverseReturnTo(ParsableEnum):
@@ -528,7 +527,7 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
             final_worktree_path = self.__worktree_root_dir_for_branch.get(final_branch)
             if final_worktree_path and initial_worktree_root != final_worktree_path:
                 # Final branch is checked out in a worktree different from where we started
-                normalized_path = normalize_path_for_display(final_worktree_path)
+                normalized_path = abspath_posix(final_worktree_path)
                 warn(
                     f"branch {bold(final_branch)} is checked out in worktree at {bold(normalized_path)}\n"
                     f"You may want to change directory with:\n"

--- a/git_machete/client/with_code_hosting.py
+++ b/git_machete/client/with_code_hosting.py
@@ -18,7 +18,8 @@ from git_machete.git_operations import (GitContext, GitFormatPatterns,
                                         SyncToRemoteStatus)
 from git_machete.utils import (bold, colored_yes_no, debug, find_or_none, fmt,
                                get_pretty_choices, get_right_arrow, green_ok,
-                               print_no_newline, slurp_file, warn)
+                               join_paths_posix, print_no_newline, slurp_file,
+                               warn)
 
 
 class PRDescriptionIntroStyle(ParsableEnum):
@@ -353,7 +354,7 @@ class MacheteClientWithCodeHosting(MacheteClient):
             if os.path.isfile(machete_description_path):
                 description = slurp_file(machete_description_path)
             else:
-                code_hosting_description_paths = [os.path.join(self._git.get_current_worktree_root_dir(), *path)
+                code_hosting_description_paths = [join_paths_posix(self._git.get_current_worktree_root_dir(), *path)
                                                   for path in spec.pr_description_paths]
                 existing = find_or_none(os.path.isfile, code_hosting_description_paths)
                 if existing:

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -11,8 +11,8 @@ from typing import (Any, Dict, Iterator, List, Match, NamedTuple, Optional,
 from . import utils
 from .constants import MAX_COMMITS_FOR_SQUASH_MERGE_DETECTION
 from .exceptions import UnderlyingGitException, UnexpectedMacheteException
-from .utils import (AnsiEscapeCodes, CommandResult, colored, debug, fmt,
-                    hex_repr, join_paths_posix, slurp_file)
+from .utils import (AnsiEscapeCodes, CommandResult, abspath_posix, colored,
+                    debug, fmt, hex_repr, join_paths_posix, slurp_file)
 
 
 class AnyRevision(str):
@@ -300,10 +300,7 @@ class GitContext:
     def __rev_parse_path(self, flag: str) -> str:
         # Let's use absolute paths for main/git directories.
         # Relative paths can lead to subtle bugs when CWD changes between worktrees in traverse.
-        # It needs to be pathlib and not os.path,
-        # since we need to retain forward slashes for compatibility with what git itself returns.
-        from pathlib import Path
-        return Path(self._popen_git("rev-parse", flag).stdout.strip()).resolve().as_posix()
+        return abspath_posix(self._popen_git("rev-parse", flag).stdout.strip())
 
     def get_current_worktree_root_dir(self) -> str:
         if not self.__current_worktree_root_dir:
@@ -382,33 +379,33 @@ class GitContext:
         result = self._popen_git("worktree", "list", "--porcelain")
         worktrees: Dict[LocalBranchShortName, str] = {}
 
-        current_worktree_path: Optional[str] = None
-        current_branch: Optional[LocalBranchShortName] = None
+        latest_worktree_path: Optional[str] = None
+        latest_branch: Optional[LocalBranchShortName] = None
         is_detached: bool = False
 
         for line in result.stdout.strip().splitlines():
             if line.startswith('worktree '):
-                current_worktree_path = line[len('worktree '):]
+                latest_worktree_path = line[len('worktree '):]
             elif line.startswith('branch '):
                 # Format: "branch refs/heads/<branch-name>"
                 branch_ref = line[len('branch '):]
-                current_branch = LocalBranchFullName.of(branch_ref).to_short_name()
+                latest_branch = LocalBranchFullName.of(branch_ref).to_short_name()
                 is_detached = False
             elif line.startswith('detached'):
                 is_detached = True
-                current_branch = None
+                latest_branch = None
             elif line == '':
                 # Empty line marks end of worktree entry
                 # Only add worktrees that have a branch (not in detached HEAD state)
-                if current_worktree_path and current_branch is not None and not is_detached:
-                    worktrees[current_branch] = current_worktree_path
-                current_worktree_path = None
-                current_branch = None
+                if latest_worktree_path and latest_branch is not None and not is_detached:
+                    worktrees[latest_branch] = latest_worktree_path
+                latest_worktree_path = None
+                latest_branch = None
                 is_detached = False
 
         # Handle last entry if no trailing newline
-        if current_worktree_path and current_branch is not None and not is_detached:
-            worktrees[current_branch] = current_worktree_path
+        if latest_worktree_path and latest_branch is not None and not is_detached:
+            worktrees[latest_branch] = latest_worktree_path
 
         return worktrees
 

--- a/git_machete/git_operations.py
+++ b/git_machete/git_operations.py
@@ -12,7 +12,7 @@ from . import utils
 from .constants import MAX_COMMITS_FOR_SQUASH_MERGE_DETECTION
 from .exceptions import UnderlyingGitException, UnexpectedMacheteException
 from .utils import (AnsiEscapeCodes, CommandResult, colored, debug, fmt,
-                    hex_repr, slurp_file)
+                    hex_repr, join_paths_posix, slurp_file)
 
 
 class AnyRevision(str):
@@ -322,7 +322,7 @@ class GitContext:
         return self.__current_worktree_git_dir
 
     def get_current_worktree_git_subpath(self, *fragments: str) -> str:
-        return os.path.join(self.get_current_worktree_git_dir(), *fragments)
+        return join_paths_posix(self.get_current_worktree_git_dir(), *fragments)
 
     def get_main_worktree_root_dir(self) -> str:
         """
@@ -355,7 +355,7 @@ class GitContext:
                 git_dir: str = self.__rev_parse_path("--git-dir")
                 git_dir_parts = Path(git_dir).parts
                 if len(git_dir_parts) >= 3 and git_dir_parts[-3] == '.git' and git_dir_parts[-2] == 'worktrees':
-                    self.__main_worktree_git_dir = os.path.join(*git_dir_parts[:-2])
+                    self.__main_worktree_git_dir = join_paths_posix(*git_dir_parts[:-2])
                     debug(f'git dir pointing to {git_dir} - we are in a worktree; '
                           f'using {self.__main_worktree_git_dir} as the effective git dir instead')
                 else:
@@ -365,7 +365,8 @@ class GitContext:
         return self.__main_worktree_git_dir
 
     def get_main_worktree_git_subpath(self, *fragments: str) -> str:
-        return os.path.join(self.get_main_worktree_git_dir(), *fragments)
+        # Let's use /-style paths even on Windows, for consistency with what git itself returns.
+        return join_paths_posix(self.get_main_worktree_git_dir(), *fragments)
 
     def get_worktree_root_dirs_by_branch(self) -> Dict[LocalBranchShortName, str]:
         """
@@ -1073,7 +1074,7 @@ class GitContext:
 
     def get_hook_path(self, hook_name: str) -> str:
         hook_dir: str = self.get_config_attr_or_none("core.hooksPath") or self.get_main_worktree_git_subpath("hooks")
-        return os.path.join(hook_dir, hook_name)
+        return join_paths_posix(hook_dir, hook_name)
 
     def check_hook_executable(self, hook_path: str) -> bool:
         if not os.path.isfile(hook_path):

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -18,7 +18,8 @@ from git_machete.code_hosting import (CodeHostingClient,
                                       PullRequest)
 from git_machete.exceptions import MacheteException, UnexpectedMacheteException
 from git_machete.git_operations import LocalBranchShortName
-from git_machete.utils import bold, compact_dict, debug, popen_cmd, warn
+from git_machete.utils import (bold, compact_dict, debug, join_paths_posix,
+                               popen_cmd, warn)
 
 GITHUB_TOKEN_ENV_VAR = 'GITHUB_TOKEN'
 
@@ -122,7 +123,7 @@ class GitHubToken(NamedTuple):
     def __get_token_from_hub(cls, domain: str) -> Optional["GitHubToken"]:
         debug("4. Trying to find token via `hub` GitHub CLI...")
         home_path: str = str(Path.home())
-        config_hub_path: str = os.path.join(home_path, ".config", "hub")
+        config_hub_path: str = join_paths_posix(home_path, ".config", "hub")
         if os.path.isfile(config_hub_path):
             # ~/.config/hub is a yaml file, with a structure similar to:
             #
@@ -213,7 +214,7 @@ class GitHubClient(CodeHostingClient):
                     raise MacheteException(error_reason)
                 elif 'Reviews may only be requested from collaborators.' in error_reason:
                     print()
-                    warn(f"there are some invalid reviewers (non-collaborators) in .git{os.path.sep}info{os.path.sep}reviewers file.\n"
+                    warn("there are some invalid reviewers (non-collaborators) in .git/info/reviewers file.\n"
                          "Skipped adding reviewers to the pull request.")
                 else:
                     raise UnexpectedMacheteException(

--- a/git_machete/utils.py
+++ b/git_machete/utils.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import textwrap
 import time
+from pathlib import Path, PurePosixPath
 from typing import (Any, Callable, Dict, Iterable, List, NamedTuple, Optional,
                     Sequence, Set, Tuple, TypeVar)
 
@@ -45,31 +46,36 @@ def get_terminal_height() -> Optional[int]:
         return None
 
 
-def normalize_path_for_display(path: str) -> str:
+def join_paths_posix(*paths: str) -> str:
     """
-    Normalize a filesystem path for cross-platform display in user messages.
+    Join path components using forward slashes (POSIX-style), regardless of platform.
 
-    This function performs two normalizations:
-    1. Resolves symlinks and relative paths to absolute canonical paths via os.path.realpath()
-    2. Converts backslashes to forward slashes for consistency
-
-    Why os.path.realpath() is needed:
-    - On macOS, common directories like /tmp and /var are symlinks to /private/tmp and /private/var
-    - Git operations (like `git worktree list`) resolve these symlinks and return /private/... paths
-    - Python's tempfile module may return paths with or without /private depending on how they're obtained
-    - Without realpath(), path comparisons fail: /var/folders/... != /private/var/folders/...
-    - realpath() canonicalizes both to /private/var/folders/... ensuring consistent comparisons
-
-    Why forward slashes:
-    - Forward slashes work in all Windows environments (Git Bash, PowerShell, CMD)
-    - Git itself uses forward slashes on Windows
-    - Provides consistent output across all platforms
-    - While Git Bash technically prefers /c/foo/bar, c:/foo/bar also works and is more universal
-
-    Returns:
-        Normalized path with forward slashes that works across all platforms
+    This ensures consistent path representation across all platforms, matching
+    how Git itself represents paths. Forward slashes work in all Windows
+    environments (Git Bash, PowerShell, CMD) and are the standard on Unix-like systems.
     """
-    return os.path.realpath(path).replace('\\', '/')
+    return str(PurePosixPath(*paths))
+
+
+def abspath_posix(path: str) -> str:
+    """
+    Return an absolute path using POSIX-style forward slashes.
+
+    This ensures consistent path representation across all platforms, matching
+    how Git itself represents paths.
+    """
+    return Path(path).resolve().as_posix()
+
+
+def relpath_posix(path: str) -> str:
+    """
+    Return a relative filepath to path from the CWD, using POSIX-style forward slashes.
+
+    This ensures consistent path representation across all platforms, matching
+    how Git itself represents paths.
+    """
+    rel = os.path.relpath(path)
+    return Path(rel).as_posix()
 
 
 def excluding(iterable: Iterable[T], s: Iterable[T]) -> List[T]:
@@ -113,7 +119,7 @@ def get_second(pair: Tuple[Any, T]) -> T:
 def does_directory_exist(path: str) -> bool:
     try:
         # Note that os.path.isdir itself (without os.path.abspath) isn't reliable
-        # since it returns a false positive (True) for the current directory when if it doesn't exist
+        # since it returns a false positive (True) for the current directory when it doesn't exist
         return os.path.isdir(os.path.abspath(path))
     except OSError:  # pragma: no cover
         return False

--- a/tests/mockers.py
+++ b/tests/mockers.py
@@ -46,13 +46,9 @@ def launch_command_capturing_output_and_exception(*cmd_and_args: str) -> Tuple[O
                     utils.displayed_warnings = set()
                     cli.launch(list(cmd_and_args))
                 output = out.getvalue()
-                if sys.platform == 'win32':
-                    output = output.replace('.git\\machete', '.git/machete')
                 return output, None
         except BaseException as e:
             output = out.getvalue()
-            if sys.platform == 'win32':
-                output = output.replace('.git\\machete', '.git/machete')
             return output, e
 
 
@@ -63,8 +59,6 @@ def launch_command(*cmd_and_args: str) -> str:
                 utils.displayed_warnings = set()
                 cli.launch(list(cmd_and_args))
         output = out.getvalue()
-        if sys.platform == 'win32':
-            output = output.replace('.git\\machete', '.git/machete')
         return output
 
 
@@ -87,8 +81,6 @@ def assert_failure(cmd_and_args: Iterable[str], expected_message: str, expected_
         launch_command(*cmd_and_args)
     error_message = ei.value.msg  # type: ignore[attr-defined]
     error_message = re.sub(" +$", "", error_message, flags=re.MULTILINE)
-    if sys.platform == 'win32':
-        error_message = error_message.replace('.git\\machete', '.git/machete')
     assert error_message == expected_message
 
 

--- a/tests/test_github_create_pr.py
+++ b/tests/test_github_create_pr.py
@@ -314,7 +314,7 @@ class TestGitHubCreatePR(BaseTest):
         check_out("allow-ownership-link")
         assert_success(
             ["github", "create-pr", "--title=PR title set explicitly"],
-            f"""
+            """
             Push allow-ownership-link to origin? (y, N, q)
 
               master
@@ -343,7 +343,7 @@ class TestGitHubCreatePR(BaseTest):
             Setting milestone of PR #7 to 42... OK
             Adding github_user as assignee to PR #7... OK
             Adding invalid-user as reviewer to PR #7...
-            Warn: there are some invalid reviewers (non-collaborators) in .git{os.path.sep}info{os.path.sep}reviewers file.
+            Warn: there are some invalid reviewers (non-collaborators) in .git/info/reviewers file.
             Skipped adding reviewers to the pull request.
             OK
             """

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -5,7 +5,7 @@ import textwrap
 import pytest
 from pytest_mock import MockerFixture
 
-from git_machete.utils import normalize_path_for_display
+from git_machete.utils import abspath_posix
 
 from .base_test import BaseTest
 from .mockers import (assert_failure, assert_success, execute,
@@ -178,7 +178,7 @@ class TestStatus(BaseTest):
 
     @pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't distinguish between executable and non-executable files")
     def test_status_advice_ignored_non_executable_hook(self) -> None:
-        repo_path = normalize_path_for_display(create_repo())
+        repo_path = abspath_posix(create_repo())
         new_branch('master')
         commit()
         new_branch('develop')

--- a/tests/test_traverse_worktrees.py
+++ b/tests/test_traverse_worktrees.py
@@ -4,7 +4,7 @@ import subprocess
 import pytest
 from pytest_mock import MockerFixture
 
-from git_machete.utils import normalize_path_for_display
+from git_machete.utils import abspath_posix
 
 from .base_test import BaseTest
 from .mockers import (assert_success, launch_command, mock_input_returning,
@@ -68,8 +68,8 @@ class TestTraverseWorktrees(BaseTest):
 
         # Now run traverse - it should cd into the worktrees automatically
         # Using -y flag so no need to mock input
-        normalized_feature_1_worktree = normalize_path_for_display(feature_1_worktree)
-        normalized_feature_2_worktree = normalize_path_for_display(feature_2_worktree)
+        normalized_feature_1_worktree = abspath_posix(feature_1_worktree)
+        normalized_feature_2_worktree = abspath_posix(feature_2_worktree)
 
         # Assert the full output to verify proper messaging:
         # - When branch is not checked out anywhere: "Checking out ... OK"
@@ -171,7 +171,7 @@ class TestTraverseWorktrees(BaseTest):
         # 1. Checkout root (not in any worktree) in main worktree - triggers cache update
         # 2. Visit branch-1 (already in linked worktree, but no action needed so don't cd)
         # 3. Checkout branch-2 (not in any worktree) in main worktree - triggers cache update
-        normalized_local_path = normalize_path_for_display(local_path)
+        normalized_local_path = abspath_posix(local_path)
 
         # This test verifies the worktree cache update logic and cd'ing from linked to main worktree
         assert_success(
@@ -304,7 +304,7 @@ class TestTraverseWorktrees(BaseTest):
 
         # Verify the warning is emitted
         assert "branch branch-2 is checked out in worktree at" in output
-        normalized_branch_2_worktree = normalize_path_for_display(branch_2_worktree)
+        normalized_branch_2_worktree = abspath_posix(branch_2_worktree)
         assert f"You may want to change directory with:\n  cd {normalized_branch_2_worktree}" in output
 
     def test_traverse_no_warn_when_final_branch_in_same_worktree(self) -> None:
@@ -364,7 +364,7 @@ class TestTraverseWorktrees(BaseTest):
         check_out("root")
         self.patch_symbol(mocker, 'builtins.input', mock_input_returning("q"))
 
-        normalized_branch_1_worktree = normalize_path_for_display(branch_1_worktree)
+        normalized_branch_1_worktree = abspath_posix(branch_1_worktree)
 
         # This corner case tests that when user quits mid-traverse,
         # the final warning is shown if ended in a different worktree
@@ -420,8 +420,8 @@ class TestTraverseWorktrees(BaseTest):
         # cd into root linked worktree to start traverse from there
         os.chdir(root_worktree)
 
-        normalized_local_path = normalize_path_for_display(local_path)
-        normalized_branch_2_worktree = normalize_path_for_display(branch_2_worktree)
+        normalized_local_path = abspath_posix(local_path)
+        normalized_branch_2_worktree = abspath_posix(branch_2_worktree)
 
         # First test: default behavior (without config key set)
         # We're in root linked worktree

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,11 +39,11 @@ class TestUtils:
     def test_hex_repr(self) -> None:
         assert utils.hex_repr("Hello, world!") == "48:65:6c:6c:6f:2c:20:77:6f:72:6c:64:21"
 
-    def test_normalize_path_for_display_general(self) -> None:
-        """Test that normalize_path_for_display returns an absolute path with forward slashes."""
+    def test_abspath_posix_general(self) -> None:
+        """Test that abspath_posix returns an absolute path with forward slashes."""
         # Create a temporary directory to ensure we're working with real paths
         with tempfile.TemporaryDirectory() as tmpdir:
-            normalized = utils.normalize_path_for_display(tmpdir)
+            normalized = utils.abspath_posix(tmpdir)
             # Should be absolute
             assert os.path.isabs(normalized)
             # Should use forward slashes (no backslashes)
@@ -52,15 +52,15 @@ class TestUtils:
             assert os.path.exists(normalized)
 
     @pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific test for backslash conversion")
-    def test_normalize_path_for_display_windows_backslashes(self) -> None:
+    def test_abspath_posix_windows_backslashes(self) -> None:
         """Test that backslashes are converted to forward slashes on Windows."""
-        # On Windows, os.path.realpath() returns paths with backslashes
+        # On Windows, Path.resolve() returns paths with backslashes
         with tempfile.TemporaryDirectory() as tmpdir:
             # tmpdir will have backslashes on Windows (e.g., C:\Users\...)
             # Verify it contains backslashes before normalization
             assert '\\' in tmpdir or '/' in tmpdir  # Windows paths have one or the other
 
-            normalized = utils.normalize_path_for_display(tmpdir)
+            normalized = utils.abspath_posix(tmpdir)
 
             # After normalization, should have forward slashes only
             assert '\\' not in normalized
@@ -69,7 +69,7 @@ class TestUtils:
             assert normalized[1:3] == ':/'
 
     @pytest.mark.skipif(sys.platform != "darwin", reason="macOS-specific test for /private prefix")
-    def test_normalize_path_for_display_macos_private_prefix(self) -> None:
+    def test_abspath_posix_macos_private_prefix(self) -> None:
         """Test that /private prefix is consistently added on macOS for /tmp and /var paths."""
         # On macOS, /tmp and /var are symlinks to /private/tmp and /private/var
         # tempfile.mkdtemp() may return paths with or without /private prefix
@@ -77,20 +77,20 @@ class TestUtils:
             # tmpdir is in /tmp or /var on macOS
             # It might be returned as /var/folders/... or /private/var/folders/...
 
-            normalized = utils.normalize_path_for_display(tmpdir)
+            normalized = utils.abspath_posix(tmpdir)
 
-            # After normalization with realpath(), should have /private prefix if in /var or /tmp
-            # (realpath resolves the symlink)
+            # After normalization with resolve(), should have /private prefix if in /var or /tmp
+            # (resolve resolves the symlink)
             if '/tmp' in tmpdir or '/var' in tmpdir:
                 # Should start with /private after normalization
                 assert normalized.startswith('/private/') or normalized.startswith('/nix/'), \
                     f"Expected path to start with /private/ or /nix/ (for Nix builds), got: {normalized}"
 
     @pytest.mark.skipif(sys.platform == "win32", reason="Unix-specific test for absolute paths")
-    def test_normalize_path_for_display_unix_absolute_paths(self) -> None:
+    def test_abspath_posix_unix_absolute_paths(self) -> None:
         """Test that paths start with / on Unix systems."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            normalized = utils.normalize_path_for_display(tmpdir)
+            normalized = utils.abspath_posix(tmpdir)
             # Should start with / on Unix
             assert normalized.startswith('/')
             # Should not contain backslashes


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1598

## Chain of upstream PRs as of 2026-02-17

* PR #1598:
  `develop` ← `fix/machete-file-path-relative-windows`

  * **PR #1599 (THIS ONE)**:
    `fix/machete-file-path-relative-windows` ← `fix/windows-fwd-slash`

<!-- end git-machete generated -->
