### PR TITLE
Split `status()` into computing and rendering

### DIFF
--- a/docs/man/git-machete.1
+++ b/docs/man/git-machete.1
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GIT-MACHETE" "1" "Mar 07, 2026" "" "git-machete"
+.TH "GIT-MACHETE" "1" "Mar 09, 2026" "" "git-machete"
 .SH NAME
 git-machete \- git-machete 3.39.2
 .sp

--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -6,10 +6,9 @@ import shlex
 import shutil
 import sys
 import textwrap
-from collections import OrderedDict
 from enum import Enum, auto
-from typing import (Callable, Dict, Iterator, List, NoReturn, Optional, Tuple,
-                    Type, TypeVar)
+from typing import (Callable, Dict, Iterator, List, NamedTuple, NoReturn,
+                    Optional, Tuple, Type, TypeVar)
 
 from git_machete import git_config_keys, utils
 from git_machete.annotation import Annotation
@@ -50,6 +49,49 @@ sync_to_parent_status_to_junction_ascii_only_map: Dict[SyncToParentStatus, str] 
     SyncToParentStatus.OUT_OF_SYNC: "x-",
     SyncToParentStatus.MERGED_TO_PARENT: "m-"
 }
+
+
+class StatusFlags(NamedTuple):
+    """Options and display flags for status output."""
+
+    maybe_space_before_branch_name: str
+    opt_list_commits: bool
+    opt_list_commits_with_hashes: bool
+    opt_squash_merge_detection: 'SquashMergeDetection'
+
+
+class StatusOngoingOperation(NamedTuple):
+    """Which branch (if any) is checked out / rebased / bisected and which Git operations are in progress."""
+
+    currently_bisected_branch: Optional[LocalBranchShortName]
+    currently_rebased_branch: Optional[LocalBranchShortName]
+    currently_checked_out_branch: Optional[LocalBranchShortName]
+    is_am_in_progress: bool
+    is_cherry_pick_in_progress: bool
+    is_merge_in_progress: bool
+    is_revert_in_progress: bool
+
+
+class StatusBranch(NamedTuple):
+    """Per-branch data for status output (tree structure, sync state, commits, annotations)."""
+
+    up_branch: Optional[LocalBranchShortName]
+    down_branches: List[LocalBranchShortName]
+    sync_to_parent_status: SyncToParentStatus
+    commits: List[Tuple[GitLogEntry, str]]
+    sync_status: str
+    hook_output: str
+    annotation: Optional[Annotation]
+
+
+class StatusData(NamedTuple):
+    """All precomputed data needed to render status output (tree and optional warning)."""
+
+    flags: StatusFlags
+    branches: Dict[LocalBranchShortName, StatusBranch]
+    roots: List[LocalBranchShortName]
+    ongoing_operation: StatusOngoingOperation
+
 
 E = TypeVar('E', bound='Enum')
 
@@ -445,53 +487,177 @@ class MacheteClient:
             print("")
         self.__empty_line_status = new_status
 
-    def status(
-            self,
-            *,
-            warn_when_branch_in_sync_but_fork_point_off: bool,
-            opt_list_commits: bool,
-            opt_list_commits_with_hashes: bool,
-            opt_squash_merge_detection: SquashMergeDetection
-    ) -> None:
-        next_sibling_of_ancestor_by_branch: OrderedDict[LocalBranchShortName, List[Optional[LocalBranchShortName]]] = OrderedDict()
+    @staticmethod
+    def _format_status_output(data: StatusData) -> str:
+        """Pure function: given StatusData, returns the formatted status tree string."""
+        out = io.StringIO()
+        space = data.flags.maybe_space_before_branch_name
+
+        next_sibling_of_ancestor_by_branch: Dict[LocalBranchShortName, List[Optional[LocalBranchShortName]]] = {}
+        branches_in_display_order: List[LocalBranchShortName] = []
 
         def prefix_dfs(parent: LocalBranchShortName, accumulated_path: List[Optional[LocalBranchShortName]]) -> None:
             next_sibling_of_ancestor_by_branch[parent] = accumulated_path
-            children = self.down_branches_for(parent)
+            branches_in_display_order.append(parent)
+            children = data.branches[parent].down_branches
             if children:
                 shifted_children: List[Optional[LocalBranchShortName]] = children[1:]  # type: ignore[assignment]
                 for (v, nv) in zip(children, shifted_children + [None]):
                     prefix_dfs(v, accumulated_path + [nv])
 
-        for root in self._state.roots:
+        for root in data.roots:
             prefix_dfs(root, accumulated_path=[])
 
-        out = io.StringIO()
+        def write_line_prefix(
+            for_branch: LocalBranchShortName,
+            next_sibling_of_ancestor: List[Optional[LocalBranchShortName]],
+            suffix: str,
+        ) -> None:
+            out.write("  " + space)
+            for sibling in next_sibling_of_ancestor[:-1]:
+                if not sibling:
+                    out.write("  " + space)
+                else:
+                    out.write(colored(
+                        f"{utils.get_vertical_bar()} " + space,
+                        sync_to_parent_status_to_edge_color_map[data.branches[sibling].sync_to_parent_status]))
+            out.write(colored(suffix, sync_to_parent_status_to_edge_color_map[data.branches[for_branch].sync_to_parent_status]))
+
+        for branch in branches_in_display_order:
+            b = data.branches[branch]
+            next_sibling_of_ancestor = next_sibling_of_ancestor_by_branch[branch]
+            if b.up_branch is not None:
+                write_line_prefix(branch, next_sibling_of_ancestor, f"{utils.get_vertical_bar()}\n")
+                for commit, fp_suffix in b.commits:
+                    write_line_prefix(branch, next_sibling_of_ancestor, utils.get_vertical_bar())
+                    out.write(
+                        f' {f"{dim(commit.short_hash)}  " if data.flags.opt_list_commits_with_hashes else ""}'
+                        f'{dim(commit.subject)}{fp_suffix}\n'
+                    )
+                if utils.ascii_only:
+                    junction = sync_to_parent_status_to_junction_ascii_only_map[b.sync_to_parent_status]
+                else:
+                    next_sibling_of_branch: Optional[LocalBranchShortName] = next_sibling_of_ancestor[-1]
+                    if next_sibling_of_branch and data.branches[next_sibling_of_branch].sync_to_parent_status == b.sync_to_parent_status:
+                        junction = "├─"
+                    else:
+                        junction = "└─"
+                write_line_prefix(branch, next_sibling_of_ancestor, junction + space)
+            else:
+                if branch != data.roots[0]:
+                    out.write("\n")
+                out.write("  " + space)
+
+            op = data.ongoing_operation
+            if branch in (op.currently_checked_out_branch, op.currently_rebased_branch, op.currently_bisected_branch):
+                if branch == op.currently_rebased_branch:
+                    prefix = "REBASING "
+                elif branch == op.currently_bisected_branch:
+                    prefix = "BISECTING "
+                elif op.is_am_in_progress:
+                    prefix = "GIT AM IN PROGRESS "
+                elif op.is_cherry_pick_in_progress:
+                    prefix = "CHERRY-PICKING "
+                elif op.is_merge_in_progress:
+                    prefix = "MERGING "
+                elif op.is_revert_in_progress:
+                    prefix = "REVERTING "
+                else:
+                    prefix = ""
+                current = f"{bold(colored(prefix, AnsiEscapeCodes.RED))}{bold(underline(branch, star_if_ascii_only=True))}"
+            else:
+                current = bold(branch)
+
+            anno = ''
+            if b.annotation is not None and b.annotation.formatted_full_text:
+                anno = '  ' + b.annotation.formatted_full_text
+
+            out.write(current + anno + b.sync_status + b.hook_output + "\n")
+
+        return out.getvalue()
+
+    @staticmethod
+    def _status_warning_message(data: StatusData) -> Optional[str]:
+        """Derives the optional warning message for yellow edges (in-sync but fork point off)."""
+        branches_in_display_order: List[LocalBranchShortName] = []
+
+        def prefix_dfs(parent: LocalBranchShortName) -> None:
+            branches_in_display_order.append(parent)
+            for child in data.branches[parent].down_branches:
+                prefix_dfs(child)
+
+        for root in data.roots:
+            prefix_dfs(root)
+
+        branches_in_sync_but_fork_point_off = [
+            b for b in branches_in_display_order
+            if data.branches[b].sync_to_parent_status == SyncToParentStatus.IN_SYNC_BUT_FORK_POINT_OFF
+        ]
+        if not branches_in_sync_but_fork_point_off:
+            return None
+        yellow_edge_branch = branches_in_sync_but_fork_point_off[0]
+        if len(branches_in_sync_but_fork_point_off) == 1:
+            first_part = (
+                f"yellow edge indicates that fork point for {bold(yellow_edge_branch)} "
+                f"is probably incorrectly inferred,\nor that some extra branch should be between "
+                f"{bold(str(data.branches[yellow_edge_branch].up_branch))} and {bold(yellow_edge_branch)}"
+            )
+        else:
+            affected_branches = ", ".join(map(bold, branches_in_sync_but_fork_point_off))
+            first_part = (
+                f"yellow edges indicate that fork points for {affected_branches} are probably incorrectly inferred,\n"
+                "or that some extra branch should be added between each of these branches and its parent"
+            )
+        if not data.flags.opt_list_commits:
+            second_part = (
+                "Run `git machete status --list-commits` or "
+                "`git machete status --list-commits-with-hashes` to see more details"
+            )
+        elif len(branches_in_sync_but_fork_point_off) == 1:
+            second_part = (
+                f"Consider using `git machete fork-point {yellow_edge_branch} --override-to-parent`,\n"
+                f"rebasing {bold(yellow_edge_branch)} onto its parent with `git machete update`,\n"
+                f"or reattaching {bold(yellow_edge_branch)} under a different parent branch"
+            )
+        else:
+            second_part = (
+                "Consider using `git machete fork-point <branch> --override-to-parent` for each affected branch,\n"
+                "rebasing each branch onto its parent with `git machete update`,\n"
+                "or reattaching the affected branches under different parent branches"
+            )
+        return f"{first_part}.\n\n{second_part}."
+
+    def _compute_status_data(self, *, flags: StatusFlags) -> StatusData:
+        branch_list: List[LocalBranchShortName] = []
+
+        def collect_branches(parent: LocalBranchShortName) -> None:
+            branch_list.append(parent)
+            for child in self.down_branches_for(parent) or []:
+                collect_branches(child)
+
+        for root in self._state.roots:
+            collect_branches(root)
+
         sync_to_parent_status: Dict[LocalBranchShortName, SyncToParentStatus] = {}
-        fork_point_hash_cached: Dict[LocalBranchShortName, Optional[FullCommitHash]] = {}  # TODO (#110): default dict with None
+        fork_point_hash_cached: Dict[LocalBranchShortName, Optional[FullCommitHash]] = {}
         fork_point_branches_cached: Dict[LocalBranchShortName, List[BranchPair]] = {}
 
         def fork_point_hash(for_branch: LocalBranchShortName) -> Optional[FullCommitHash]:
             if for_branch not in fork_point_hash_cached:
                 try:
-                    # We're always using fork point overrides, even when status
-                    # is launched from discover().
                     fork_point_hash_cached[for_branch], fork_point_branches_cached[for_branch] = \
                         self.__fork_point_and_containing_branch_pairs(for_branch, use_overrides=True)
                 except MacheteException:
                     fork_point_hash_cached[for_branch], fork_point_branches_cached[for_branch] = None, []
             return fork_point_hash_cached[for_branch]
 
-        # Edge colors need to be precomputed
-        # in order to render the leading parts of lines properly.
-        branch: LocalBranchShortName
         for branch in self._state.up_branch_for:
             parent_branch = self._state.up_branch_for[branch]
             assert parent_branch is not None
             if self.is_merged_to(
                     branch=branch,
                     upstream=parent_branch,
-                    opt_squash_merge_detection=opt_squash_merge_detection):
+                    opt_squash_merge_detection=flags.opt_squash_merge_detection):
                 sync_to_parent_status[branch] = SyncToParentStatus.MERGED_TO_PARENT
             elif not self._git.is_ancestor_or_equal(parent_branch.full_name(), branch.full_name()):
                 sync_to_parent_status[branch] = SyncToParentStatus.OUT_OF_SYNC
@@ -508,112 +674,53 @@ class MacheteClient:
         hook_path = self._git.get_hook_path("machete-status-branch")
         hook_executable = self._git.check_hook_executable(hook_path)
 
-        maybe_space_before_branch_name = ' ' if self._git.get_boolean_config_attr(git_config_keys.STATUS_EXTRA_SPACE_BEFORE_BRANCH_NAME,
-                                                                                  default_value=False) else ''
-
-        def print_line_prefix(for_branch: LocalBranchShortName, suffix: str) -> None:
-            out.write("  " + maybe_space_before_branch_name)
-            for sibling in next_sibling_of_ancestor[:-1]:
-                if not sibling:
-                    out.write("  " + maybe_space_before_branch_name)
-                else:
-                    out.write(colored(f"{utils.get_vertical_bar()} " + maybe_space_before_branch_name,
-                                      sync_to_parent_status_to_edge_color_map[sync_to_parent_status[sibling]]))
-            out.write(colored(suffix, sync_to_parent_status_to_edge_color_map[sync_to_parent_status[for_branch]]))
-
-        next_sibling_of_ancestor: List[Optional[LocalBranchShortName]]
-        for branch, next_sibling_of_ancestor in next_sibling_of_ancestor_by_branch.items():
-            if branch in self._state.up_branch_for:
-                print_line_prefix(branch, f"{utils.get_vertical_bar()}\n")
-                if opt_list_commits:
-                    fork_point = fork_point_hash(branch)
-                    if not fork_point:
-                        # Rare case, but can happen e.g. due to reflog expiry.
-                        commits: List[GitLogEntry] = []
-                    elif sync_to_parent_status[branch] == SyncToParentStatus.MERGED_TO_PARENT:
-                        commits = []
-                    elif sync_to_parent_status[branch] == SyncToParentStatus.IN_SYNC_BUT_FORK_POINT_OFF:
-                        upstream = self._state.up_branch_for[branch]
-                        assert upstream is not None
-                        commits = self._git.get_commits_between(upstream.full_name(), branch.full_name())
-                    else:  # (SyncToParentStatus.OutOfSync, SyncToParentStatus.InSync):
-                        commits = self._git.get_commits_between(fork_point, branch.full_name())
-
-                    for commit in commits:
+        commits_by_branch: Dict[LocalBranchShortName, List[Tuple[GitLogEntry, str]]] = {}
+        if flags.opt_list_commits:
+            for branch in self._state.up_branch_for:
+                fork_point = fork_point_hash(branch)
+                if not fork_point:
+                    commits: List[Tuple[GitLogEntry, str]] = []
+                elif sync_to_parent_status[branch] == SyncToParentStatus.MERGED_TO_PARENT:
+                    commits = []
+                elif sync_to_parent_status[branch] == SyncToParentStatus.IN_SYNC_BUT_FORK_POINT_OFF:
+                    upstream = self._state.up_branch_for[branch]
+                    assert upstream is not None
+                    raw_commits = self._git.get_commits_between(upstream.full_name(), branch.full_name())
+                    commits = []
+                    for commit in raw_commits:
                         if commit.hash == fork_point:
-                            # fork_point_branches_cached will already be there thanks to
-                            # the above call to 'fork_point_hash'.
-                            fp_branches_formatted: str = " and ".join(
+                            fp_branches_formatted = " and ".join(
                                 sorted(underline(lb_or_rb) for lb, lb_or_rb in fork_point_branches_cached[branch]))
                             right_arrow = colored(utils.get_right_arrow(), AnsiEscapeCodes.RED)
                             fork_point_str = colored("fork point ???", AnsiEscapeCodes.RED)
-                            fp_suffix: str = f' {right_arrow} {fork_point_str} ' + \
-                                ("this commit" if opt_list_commits_with_hashes else f"commit {commit.short_hash}") + \
+                            fp_suffix = (
+                                f' {right_arrow} {fork_point_str} ' +
+                                ("this commit" if flags.opt_list_commits_with_hashes else f"commit {commit.short_hash}") +
                                 f' seems to be a part of the unique history of {fp_branches_formatted}'
+                            )
                         else:
                             fp_suffix = ''
-                        print_line_prefix(branch, utils.get_vertical_bar())
-                        out.write(f' {f"{dim(commit.short_hash)}  " if opt_list_commits_with_hashes else ""}'
-                                  f'{dim(commit.subject)}{fp_suffix}\n')
-
-                junction: str
-                if utils.ascii_only:
-                    junction = sync_to_parent_status_to_junction_ascii_only_map[sync_to_parent_status[branch]]
+                        commits.append((commit, fp_suffix))
                 else:
-                    next_sibling_of_branch: Optional[LocalBranchShortName] = next_sibling_of_ancestor[-1]
-                    if next_sibling_of_branch and sync_to_parent_status[next_sibling_of_branch] == sync_to_parent_status[branch]:
-                        junction = "├─"
-                    else:
-                        # The three-legged turnstile looks pretty bad when the upward and rightward leg
-                        # have a different color than the downward leg.
-                        # It's better to use a two-legged elbow
-                        # in case `sync_to_parent_status[next_sibling_of_branch] != sync_to_parent_status[branch]`,
-                        # at the expense of a little gap to the elbow/turnstile below.
-                        junction = "└─"
-                print_line_prefix(branch, junction + maybe_space_before_branch_name)
-            else:
-                if branch != self._state.roots[0]:
-                    out.write("\n")
-                out.write("  " + maybe_space_before_branch_name)
+                    # fork_point is exclusive in get_commits_between, so it never appears in raw_commits
+                    raw_commits = self._git.get_commits_between(fork_point, branch.full_name())
+                    commits = [(commit, '') for commit in raw_commits]
+                commits_by_branch[branch] = commits
 
-            if branch in (currently_checked_out_branch, currently_rebased_branch, currently_bisected_branch):
-                # i.e. if branch is the current branch (checked out or being rebased or being bisected)
-                if branch == currently_rebased_branch:
-                    prefix = "REBASING "
-                elif branch == currently_bisected_branch:
-                    prefix = "BISECTING "
-                elif self._git.is_am_in_progress():
-                    prefix = "GIT AM IN PROGRESS "
-                elif self._git.is_cherry_pick_in_progress():
-                    prefix = "CHERRY-PICKING "
-                elif self._git.is_merge_in_progress():
-                    prefix = "MERGING "
-                elif self._git.is_revert_in_progress():
-                    prefix = "REVERTING "
-                else:
-                    prefix = ""
-                current = f"{bold(colored(prefix, AnsiEscapeCodes.RED))}{bold(underline(branch, star_if_ascii_only=True))}"
-            else:
-                current = bold(branch)
-
-            anno: str = ''
-            if branch in self._state.annotations and self._state.annotations[branch].formatted_full_text:
-                anno = '  ' + self._state.annotations[branch].formatted_full_text
-
+        sync_status_by_branch: Dict[LocalBranchShortName, str] = {}
+        hook_output_by_branch: Dict[LocalBranchShortName, str] = {}
+        for branch in self._state.managed_branches:
             s, remote = self._git.get_combined_remote_sync_status(branch)
-            sync_status = {
+            sync_status_by_branch[branch] = {
                 SyncToRemoteStatus.NO_REMOTES: "",
-                SyncToRemoteStatus.UNTRACKED:
-                    colored(" (untracked)", AnsiEscapeCodes.ORANGE),
+                SyncToRemoteStatus.UNTRACKED: colored(" (untracked)", AnsiEscapeCodes.ORANGE),
                 SyncToRemoteStatus.IN_SYNC_WITH_REMOTE: "",
-                SyncToRemoteStatus.BEHIND_REMOTE:
-                    colored(f" (behind {bold(remote)})", AnsiEscapeCodes.RED),  # type: ignore [arg-type]
-                SyncToRemoteStatus.AHEAD_OF_REMOTE:
-                    colored(f" (ahead of {bold(remote)})", AnsiEscapeCodes.RED),  # type: ignore [arg-type]
-                SyncToRemoteStatus.DIVERGED_FROM_AND_OLDER_THAN_REMOTE:
-                    colored(f" (diverged from & older than {bold(remote)})", AnsiEscapeCodes.RED),  # type: ignore [arg-type]
-                SyncToRemoteStatus.DIVERGED_FROM_AND_NEWER_THAN_REMOTE:
-                    colored(f" (diverged from {bold(remote)})", AnsiEscapeCodes.RED)  # type: ignore [arg-type]
+                SyncToRemoteStatus.BEHIND_REMOTE: colored(f" (behind {bold(remote)})", AnsiEscapeCodes.RED),  # type: ignore[arg-type]
+                SyncToRemoteStatus.AHEAD_OF_REMOTE: colored(f" (ahead of {bold(remote)})", AnsiEscapeCodes.RED),  # type: ignore[arg-type]
+                SyncToRemoteStatus.DIVERGED_FROM_AND_OLDER_THAN_REMOTE: colored(
+                    f" (diverged from & older than {bold(remote)})", AnsiEscapeCodes.RED),  # type: ignore[arg-type]
+                SyncToRemoteStatus.DIVERGED_FROM_AND_NEWER_THAN_REMOTE: colored(
+                    f" (diverged from {bold(remote)})", AnsiEscapeCodes.RED),  # type: ignore[arg-type]
             }[SyncToRemoteStatus(s)]
 
             hook_output = ""
@@ -622,47 +729,66 @@ class MacheteClient:
                 hook_env = dict(os.environ, ASCII_ONLY=str(utils.ascii_only).lower())
                 status_code, stdout, stderr = self.__popen_hook(
                     hook_path, branch, cwd=self._git.get_current_worktree_root_dir(), env=hook_env)
-
-                if status_code == 0:
-                    if not stdout.isspace():
-                        # Replace all newlines with spaces, in case the hook prints out more than one line
-                        hook_output = "  " + stdout.replace('\n', ' ').rstrip()
+                if status_code == 0 and not stdout.isspace():
+                    hook_output = "  " + stdout.replace('\n', ' ').rstrip()
                 else:
                     debug(f"machete-status-branch hook ({hook_path}) for branch {branch} "
                           f"returned {status_code}; stdout: '{stdout}'; stderr: '{stderr}'")
+            hook_output_by_branch[branch] = hook_output
 
-            out.write(current + anno + sync_status + hook_output + "\n")
+        branches: Dict[LocalBranchShortName, StatusBranch] = {}
+        for branch in branch_list:
+            branches[branch] = StatusBranch(
+                up_branch=self._state.up_branch_for.get(branch),
+                down_branches=self.down_branches_for(branch) or [],
+                sync_to_parent_status=sync_to_parent_status.get(branch, SyncToParentStatus.IN_SYNC),
+                commits=commits_by_branch.get(branch, []),
+                sync_status=sync_status_by_branch[branch],
+                hook_output=hook_output_by_branch[branch],
+                annotation=self._state.annotations.get(branch),
+            )
 
-        sys.stdout.write(out.getvalue())
-        out.close()
+        return StatusData(
+            flags=flags,
+            branches=branches,
+            roots=self._state.roots,
+            ongoing_operation=StatusOngoingOperation(
+                currently_bisected_branch=currently_bisected_branch,
+                currently_rebased_branch=currently_rebased_branch,
+                currently_checked_out_branch=currently_checked_out_branch,
+                is_am_in_progress=self._git.is_am_in_progress(),
+                is_cherry_pick_in_progress=self._git.is_cherry_pick_in_progress(),
+                is_merge_in_progress=self._git.is_merge_in_progress(),
+                is_revert_in_progress=self._git.is_revert_in_progress(),
+            ),
+        )
 
-        branches_in_sync_but_fork_point_off = [k for k, v in sync_to_parent_status.items() if v ==
-                                               SyncToParentStatus.IN_SYNC_BUT_FORK_POINT_OFF]
-        if branches_in_sync_but_fork_point_off and warn_when_branch_in_sync_but_fork_point_off:
-            yellow_edge_branch: LocalBranchShortName = branches_in_sync_but_fork_point_off[0]
-            if len(branches_in_sync_but_fork_point_off) == 1:
-                first_part = (f"yellow edge indicates that fork point for {bold(yellow_edge_branch)} "
-                              f"is probably incorrectly inferred,\nor that some extra branch should be between "
-                              f"{bold(str(self._state.up_branch_for[yellow_edge_branch]))} and {bold(yellow_edge_branch)}")
-            else:
-                affected_branches = ", ".join(map(bold, branches_in_sync_but_fork_point_off))
-                first_part = f"yellow edges indicate that fork points for {affected_branches} are probably incorrectly inferred,\n" \
-                    "or that some extra branch should be added between each of these branches and its parent"
-
-            if not opt_list_commits:
-                second_part = "Run `git machete status --list-commits` or " \
-                              "`git machete status --list-commits-with-hashes` to see more details"
-            elif len(branches_in_sync_but_fork_point_off) == 1:
-                second_part = f"Consider using `git machete fork-point {yellow_edge_branch} --override-to-parent`,\n" \
-                              f"rebasing {bold(yellow_edge_branch)} onto its parent with `git machete update`,\n" \
-                              f"or reattaching {bold(yellow_edge_branch)} under a different parent branch"
-            else:
-                second_part = "Consider using `git machete fork-point <branch> --override-to-parent` for each affected branch,\n" \
-                              "rebasing each branch onto its parent with `git machete update`,\n" \
-                              "or reattaching the affected branches under different parent branches"
-
-            print("", file=sys.stderr)
-            warn(f"{first_part}.\n\n{second_part}.")
+    def status(
+            self,
+            *,
+            warn_when_branch_in_sync_but_fork_point_off: bool,
+            opt_list_commits: bool,
+            opt_list_commits_with_hashes: bool,
+            opt_squash_merge_detection: SquashMergeDetection
+    ) -> None:
+        maybe_space_before_branch_name = (
+            ' ' if self._git.get_boolean_config_attr(
+                git_config_keys.STATUS_EXTRA_SPACE_BEFORE_BRANCH_NAME, default_value=False) else ''
+        )
+        flags = StatusFlags(
+            maybe_space_before_branch_name=maybe_space_before_branch_name,
+            opt_list_commits=opt_list_commits,
+            opt_list_commits_with_hashes=opt_list_commits_with_hashes,
+            opt_squash_merge_detection=opt_squash_merge_detection,
+        )
+        data = self._compute_status_data(flags=flags)
+        status_str = self._format_status_output(data)
+        sys.stdout.write(status_str)
+        if warn_when_branch_in_sync_but_fork_point_off:
+            warning_msg = self._status_warning_message(data)
+            if warning_msg is not None:
+                print("", file=sys.stderr)
+                warn(warning_msg)
 
     @staticmethod
     def __popen_hook(*args: str, cwd: str, env: Dict[str, str]) -> PopenResult:


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1603

## Chain of upstream PRs as of 2026-03-07

* PR #1603:
  `develop` ← `fix/underscore-identifiers`

  * **PR #1604 (THIS ONE)**:
    `fix/underscore-identifiers` ← `refactor/status-extract-rendering`

<!-- end git-machete generated -->
