### PR TITLE
Improve the branch selection in interactive `go` (now same as `status`)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## New in git-machete 3.39.2
 
+- improved: interactive `git machete go` displays a branch layout as in `status`
 - fixed: interactive `git machete go` now fails immediately when stdout is not a TTY (e.g. when piped) instead of behaving chaotically
 - improved: user-facing messages in `go`, `show`, `traverse` for the case of single root (contributed by @mvanhorn)
 

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -489,7 +489,7 @@ def update_cli_options_using_config_keys(
 
 def set_utils_global_variables(parsed_args: argparse.Namespace) -> None:
     args = vars(parsed_args)
-    utils.ascii_only = args.get("color") == "never" or (args.get("color") in {None, "auto"} and not sys.stdout.isatty())
+    utils.ascii_only = args.get("color") == "never" or (args.get("color") in {None, "auto"} and not utils.is_stdout_a_tty())
     utils.debug_mode = "debug" in args
     utils.verbose_mode = "verbose" in args
 

--- a/git_machete/client/go_interactive.py
+++ b/git_machete/client/go_interactive.py
@@ -1,5 +1,5 @@
 import sys
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple
 
 try:
     import termios
@@ -10,20 +10,21 @@ except ImportError:  # pragma: no cover; Windows-specific
     tty = None  # type: ignore[assignment]
 
 from git_machete import utils
-from git_machete.client.base import MacheteClient
+from git_machete.client.status import (StatusData, StatusFlags,
+                                       StatusMacheteClient)
 from git_machete.exceptions import MacheteException, UnexpectedMacheteException
 from git_machete.git_operations import LocalBranchShortName
 from git_machete.utils import bold, index_or_none, warn
 
 
-class GoInteractiveMacheteClient(MacheteClient):
+class GoInteractiveMacheteClient(StatusMacheteClient):
     """Client for interactive branch selection using curses-style interface (implemented without curses, just using ANSI sequences)."""
 
     MAX_VISIBLE_BRANCHES_DEFAULT = 20
     MAX_VISIBLE_BRANCHES_LOWER = 2
     MAX_VISIBLE_BRANCHES_UPPER = 50
 
-    _managed_branches_with_depths: List[Tuple[LocalBranchShortName, int]]
+    _status_data: StatusData
     _current_branch: Optional[LocalBranchShortName]
     _max_visible_branches: int
 
@@ -37,38 +38,13 @@ class GoInteractiveMacheteClient(MacheteClient):
         max_visible_branches = terminal_height - 2
         return max(self.MAX_VISIBLE_BRANCHES_LOWER, min(max_visible_branches, self.MAX_VISIBLE_BRANCHES_UPPER))
 
-    def _get_branch_list_with_depths(self) -> List[Tuple[LocalBranchShortName, int]]:
-        """Get a flat list of branches with their depths using DFS traversal."""
-        result: List[Tuple[LocalBranchShortName, int]] = []
-
-        def add_branch_and_children(branch: LocalBranchShortName, depth: int) -> None:
-            result.append((branch, depth))
-            for child_branch in self.down_branches_for(branch) or []:
-                add_branch_and_children(child_branch, depth + 1)
-
-        for root in self._state.roots:
-            add_branch_and_children(root, depth=0)
-
-        return result
-
-    def _render_branch_line(self, branch: LocalBranchShortName, depth: int) -> str:
-        """Render a single branch line with indentation."""
-        indent = "  " * depth
-        marker = " " if self._current_branch is None or branch != self._current_branch else "*"
-
-        line = f"{indent}{marker} {branch}"
-        annotation = self.annotations.get(branch)
-        if annotation and annotation.formatted_full_text:
-            line += f"  {annotation.formatted_full_text}"
-
-        return line
-
     def _draw_screen(self, *, selected_idx: int, scroll_offset: int,
-                     num_lines_drawn: int, is_first_draw: bool) -> int:
-        """Draw the branch selection screen using ANSI escape codes."""
+                     num_lines_drawn: int, is_first_draw: bool) -> Tuple[int, int]:
+        """Draw the branch selection screen using status-style output (format_status_output).
+        Returns (scroll_offset, actual_lines_drawn) so the caller can move the cursor up correctly on next redraw."""
         # Move cursor up to the start of our display area (if we've drawn before)
         if not is_first_draw and num_lines_drawn > 0:
-            sys.stdout.write(f'{utils.AE.CSI}{num_lines_drawn}A')
+            sys.stdout.write(utils.AE.cursor_up(num_lines_drawn))
 
         # Clear from cursor to end of screen (only if not first draw)
         if not is_first_draw:
@@ -79,27 +55,30 @@ class GoInteractiveMacheteClient(MacheteClient):
                        "Enter or Space: checkout, q or Ctrl+C: quit)")
         sys.stdout.write(bold(header_text) + '\n')
 
-        # Adjust scroll offset if needed
-        visible_lines = min(self._max_visible_branches, len(self._managed_branches_with_depths))
-        if selected_idx < scroll_offset:
-            scroll_offset = selected_idx
-        elif selected_idx >= scroll_offset + visible_lines:
-            scroll_offset = selected_idx - visible_lines + 1
+        branches = self._status_data.branches_in_display_order
+        selected_branch = branches[selected_idx] if 0 <= selected_idx < len(branches) else None
+        formatted = self.format_status_output(
+            self._status_data,
+            selected_branch=selected_branch,
+        )
+        lines = formatted.result.splitlines()
+        num_lines = len(lines)
+        visible_lines = min(self._max_visible_branches, num_lines)
+        # line_for_branch maps branch -> 0-based line index in result
+        selected_line_idx = formatted.line_for_branch.get(selected_branch, 0) if selected_branch else 0
+        if selected_line_idx < scroll_offset:
+            scroll_offset = selected_line_idx
+        elif selected_line_idx >= scroll_offset + visible_lines:
+            scroll_offset = selected_line_idx - visible_lines + 1
 
-        # Draw branches
-        for i in range(visible_lines):
-            branch_idx = scroll_offset + i
-            branch, depth = self._managed_branches_with_depths[branch_idx]
-            line = self._render_branch_line(branch, depth)
-
-            if branch_idx == selected_idx:
-                # Highlight selected line (inverse video)
-                sys.stdout.write(f'{utils.AE.REVERSE_VIDEO}{line}{utils.AE.ENDC}\n')
-            else:
-                sys.stdout.write(f'{line}\n')
+        lines_drawn = 1  # header
+        end = min(scroll_offset + visible_lines, num_lines)
+        for line_idx in range(scroll_offset, end):
+            sys.stdout.write(lines[line_idx] + '\n')
+            lines_drawn += 1
 
         sys.stdout.flush()
-        return scroll_offset
+        return scroll_offset, lines_drawn
 
     def _get_stdin_fd(self) -> int:  # pragma: no cover; always mocked in tests
         return sys.stdin.fileno()
@@ -136,28 +115,33 @@ class GoInteractiveMacheteClient(MacheteClient):
         """
         Launch interactive branch selection interface.
         Returns the selected branch or None if cancelled.
+        Status data is computed once at start; only rendering (format_status_output) runs on each redraw.
         """
         if termios is None or tty is None:
             raise UnexpectedMacheteException("Interactive mode is not supported on Windows yet")
         if not utils.is_stdout_a_tty():
             raise MacheteException("Interactive `git machete go` requires stdout to be a TTY.")
 
-        # Get flat list of branches with depths from already-parsed state
-        self._managed_branches_with_depths = self._get_branch_list_with_depths()
-
         self._current_branch = current_branch
-
-        # Determine maximum visible branches from terminal height
         self._max_visible_branches = self._get_max_visible_branches()
+
+        # Compute status data once (no list-commits in TUI; config same as status)
+        flags = StatusFlags(
+            maybe_space_before_branch_name=(' ' if self._config.status_extra_space_before_branch_name() else ''),
+            opt_list_commits=False,
+            opt_list_commits_with_hashes=False,
+            opt_squash_merge_detection=self._config.squash_merge_detection(),
+        )
+        self._status_data = self.compute_status_data(flags=flags)
+        branches_ordered = self._status_data.branches_in_display_order
 
         # Find initial selection (current branch or first branch if detached HEAD)
         if current_branch is not None:
-            selected_idx = index_or_none(self.managed_branches, self._current_branch)
+            selected_idx = index_or_none(branches_ordered, self._current_branch)
             if selected_idx is None:
                 selected_idx = 0
                 warn(f"current branch {self._current_branch} is unmanaged\n")
         else:
-            # Detached HEAD - start with first managed branch
             selected_idx = 0
 
         scroll_offset = 0
@@ -168,13 +152,10 @@ class GoInteractiveMacheteClient(MacheteClient):
         sys.stdout.write(utils.AE.HIDE_CURSOR)
         sys.stdout.flush()
 
+        branches = self._status_data.branches_in_display_order
         try:
             while True:
-                # Calculate how many lines we'll draw (header + visible branches)
-                visible_lines = min(self._max_visible_branches, len(self._managed_branches_with_depths))
-                num_lines_drawn = visible_lines + 1  # +1 for header
-
-                scroll_offset = self._draw_screen(
+                scroll_offset, num_lines_drawn = self._draw_screen(
                     selected_idx=selected_idx,
                     scroll_offset=scroll_offset,
                     num_lines_drawn=num_lines_drawn,
@@ -182,36 +163,28 @@ class GoInteractiveMacheteClient(MacheteClient):
                 )
                 is_first_draw = False
 
-                # Read key
                 key = self._getch()
 
                 if key == utils.AE.KEY_UP:
-                    # Wrap around from first to last
-                    selected_idx = (selected_idx - 1) % len(self._managed_branches_with_depths)
+                    selected_idx = (selected_idx - 1) % len(branches)
                 elif key == utils.AE.KEY_DOWN:
-                    # Wrap around from last to first
-                    selected_idx = (selected_idx + 1) % len(self._managed_branches_with_depths)
+                    selected_idx = (selected_idx + 1) % len(branches)
                 elif key == utils.AE.KEY_SHIFT_UP:
-                    # Jump to first branch
                     selected_idx = 0
                 elif key == utils.AE.KEY_SHIFT_DOWN:
-                    # Jump to last branch
-                    selected_idx = len(self._managed_branches_with_depths) - 1
+                    selected_idx = len(branches) - 1
                 elif key == utils.AE.KEY_LEFT:
-                    # Go to parent
-                    selected_branch, _ = self._managed_branches_with_depths[selected_idx]
+                    selected_branch = branches[selected_idx]
                     parent_branch = self.up_branch_for(selected_branch)
-                    if parent_branch:
-                        selected_idx = self.managed_branches.index(parent_branch)
+                    if parent_branch is not None:
+                        selected_idx = branches.index(parent_branch)
                 elif key == utils.AE.KEY_RIGHT:
-                    # Go to first child
-                    selected_branch, _ = self._managed_branches_with_depths[selected_idx]
+                    selected_branch = branches[selected_idx]
                     child_branches = self.down_branches_for(selected_branch)
                     if child_branches:
-                        selected_idx = self.managed_branches.index(child_branches[0])
+                        selected_idx = branches.index(child_branches[0])
                 elif key in utils.AE.KEYS_ENTER or key == utils.AE.KEY_SPACE:
-                    selected_branch, _ = self._managed_branches_with_depths[selected_idx]
-                    return selected_branch
+                    return branches[selected_idx]
                 elif key in ('q', 'Q'):
                     return None
                 elif key == utils.AE.KEY_CTRL_C:

--- a/git_machete/client/status.py
+++ b/git_machete/client/status.py
@@ -69,12 +69,26 @@ class StatusData(NamedTuple):
     ongoing_operation: StatusOngoingOperation
 
 
+class StatusFormatOutput(NamedTuple):
+    """Result of formatting status output. Returned by format_status_output."""
+
+    result: str
+    # Maps each branch to the 0-based index of the line in result (when split by newlines) where it appears.
+    line_for_branch: Dict[LocalBranchShortName, int]
+
+
 class StatusMacheteClient(MacheteClient):
     """Client for the status command. Exposes status() and can be used as a mixin for other clients."""
 
     @staticmethod
-    def _format_status_output(data: StatusData) -> str:
-        """Pure function: given StatusData, returns the formatted status tree string."""
+    def format_status_output(
+        data: StatusData,
+        *,
+        selected_branch: Optional[LocalBranchShortName] = None,
+    ) -> StatusFormatOutput:
+        """Pure function: given StatusData, returns StatusFormatOutput (result string and line_for_branch).
+        When selected_branch is set, that branch's name (not annotation/sync status) is wrapped in reverse video.
+        line_for_branch maps each branch to the 0-based line index in result where it appears."""
 
         # These maps need to be defined in a local scope to avoid for mocking the color palette more easily.
         sync_to_parent_status_to_edge_color_map: Dict[SyncToParentStatus, str] = {
@@ -89,9 +103,10 @@ class StatusMacheteClient(MacheteClient):
             SyncToParentStatus.OUT_OF_SYNC: "x-",
             SyncToParentStatus.MERGED_TO_PARENT: "m-"
         }
-
         out = io.StringIO()
         space = data.flags.maybe_space_before_branch_name
+        line_for_branch: Dict[LocalBranchShortName, int] = {}
+        line_index = 0
 
         next_sibling_of_ancestor_by_branch: Dict[LocalBranchShortName, List[Optional[LocalBranchShortName]]] = {}
 
@@ -127,12 +142,14 @@ class StatusMacheteClient(MacheteClient):
             next_sibling_of_ancestor = next_sibling_of_ancestor_by_branch[branch]
             if b.up_branch is not None:
                 write_line_prefix(branch, next_sibling_of_ancestor, f"{utils.get_vertical_bar()}\n")
+                line_index += 1
                 for commit, fp_suffix in b.commits:
                     write_line_prefix(branch, next_sibling_of_ancestor, utils.get_vertical_bar())
                     out.write(
                         f' {f"{dim(commit.short_hash)}  " if data.flags.opt_list_commits_with_hashes else ""}'
                         f'{dim(commit.subject)}{fp_suffix}\n'
                     )
+                    line_index += 1
                 if utils.ascii_only:
                     junction = sync_to_parent_status_to_junction_ascii_only_map[b.sync_to_parent_status]
                 else:
@@ -145,8 +162,10 @@ class StatusMacheteClient(MacheteClient):
             else:
                 if branch != data.roots[0]:
                     out.write("\n")
+                    line_index += 1
                 out.write("  " + space)
 
+            line_for_branch[branch] = line_index
             op = data.ongoing_operation
             if branch in (op.currently_checked_out_branch, op.currently_rebased_branch, op.currently_bisected_branch):
                 if branch == op.currently_rebased_branch:
@@ -171,9 +190,14 @@ class StatusMacheteClient(MacheteClient):
             if b.annotation is not None and b.annotation.formatted_full_text:
                 anno = '  ' + b.annotation.formatted_full_text
 
-            out.write(current + anno + b.sync_status + b.hook_output + "\n")
+            if selected_branch is not None and branch == selected_branch:
+                current_part = f"{utils.AE.REVERSE_VIDEO}{current}{utils.AE.ENDC}"
+            else:
+                current_part = current
+            out.write(f"{current_part}{anno}{b.sync_status}{b.hook_output}\n")
+            line_index += 1
 
-        return out.getvalue()
+        return StatusFormatOutput(result=out.getvalue(), line_for_branch=line_for_branch)
 
     @staticmethod
     def _status_warning_message(data: StatusData) -> Optional[str]:
@@ -216,7 +240,7 @@ class StatusMacheteClient(MacheteClient):
             )
         return f"{first_part}.\n\n{second_part}."
 
-    def _compute_status_data(self, *, flags: StatusFlags) -> StatusData:
+    def compute_status_data(self, *, flags: StatusFlags) -> StatusData:
         managed_branches: List[LocalBranchShortName] = list(self._state.managed_branches)
 
         sync_to_parent_status: Dict[LocalBranchShortName, SyncToParentStatus] = {}
@@ -359,9 +383,9 @@ class StatusMacheteClient(MacheteClient):
             opt_list_commits_with_hashes=opt_list_commits_with_hashes,
             opt_squash_merge_detection=opt_squash_merge_detection,
         )
-        data = self._compute_status_data(flags=flags)
-        status_str = self._format_status_output(data)
-        sys.stdout.write(status_str)
+        data = self.compute_status_data(flags=flags)
+        format_out = self.format_status_output(data)
+        sys.stdout.write(format_out.result)
         if warn_when_branch_in_sync_but_fork_point_off:
             warning_msg = self._status_warning_message(data)
             if warning_msg is not None:

--- a/git_machete/utils.py
+++ b/git_machete/utils.py
@@ -401,6 +401,10 @@ class SimpleAnsiEscapeCodes:
     SHOW_CURSOR = '\033[?25h'
     CLEAR_TO_END = '\033[J'  # Clear from cursor to end of screen
 
+    def cursor_up(self, num_lines: int) -> str:
+        """CSI n A — move cursor up by num_lines."""
+        return self.CSI + str(num_lines) + "A"
+
     # Arrow key codes
     KEY_UP = '\033[A'
     KEY_DOWN = '\033[B'

--- a/tests/test_go_interactive.py
+++ b/tests/test_go_interactive.py
@@ -1,17 +1,31 @@
+# flake8: noqa: E501
 import os
 import sys
+import textwrap
 from typing import Any, Tuple
 
 import pytest
 from pytest_mock import MockerFixture
 
-from git_machete.utils import AE
+from git_machete.utils import AE, SimpleAnsiEscapeCodes
 
 from .base_test import BaseTest
 from .mockers import assert_failure, launch_command, rewrite_branch_layout_file
 from .mockers_git_repository import check_out, commit, create_repo, new_branch
 
 KEY_ENTER = '\r'  # Enter key
+
+E = SimpleAnsiEscapeCodes()
+
+HEADER = (
+    "Select branch (↑/↓: prev/next, Shift+↑/↓: first/last, ←: parent, →: child, "
+    "Enter or Space: checkout, q or Ctrl+C: quit)"
+)
+
+
+def _redraw_sequence(e: SimpleAnsiEscapeCodes, num_lines: int) -> str:
+    """ANSI sequence to move cursor up num_lines and clear to end of screen (for TUI redraw)."""
+    return e.cursor_up(num_lines) + e.CLEAR_TO_END
 
 
 def mock_read_stdin_returning(*keys: str) -> Any:
@@ -66,8 +80,10 @@ class TestGoInteractive(BaseTest):
         Helper to run an interactive test by mocking stdin and terminal methods.
         Returns the captured stdout.
         """
-        # Mock is_stdout_a_tty so interactive go runs (tests redirect stdout)
+        # Force printing ANSI escape sequences even though the terminal is NOT a TTY
         self.patch_symbol(mocker, 'git_machete.utils.is_stdout_a_tty', lambda: True)
+        # Use the palette of ANSI escape code that does NOT depend on the underlying terminal properties
+        self.patch_symbol(mocker, 'git_machete.utils.AE', E)
 
         # Mock _get_stdin_fd to return a fake file descriptor
         self.patch_symbol(mocker, 'git_machete.client.go_interactive.GoInteractiveMacheteClient._get_stdin_fd',
@@ -92,12 +108,41 @@ class TestGoInteractive(BaseTest):
         # Navigate: DOWN (to feature-1), UP (back to develop), DOWN (to feature-1 again), SPACE (checkout)
         output = self.run_interactive_test(mocker, (AE.KEY_DOWN, AE.KEY_UP, AE.KEY_DOWN, AE.KEY_SPACE))
 
-        # Verify the branch list is displayed
-        assert "Select branch" in output
-        assert "master" in output
-        assert "develop" in output
-        assert "feature-1" in output
-        assert "feature-2" in output
+        # ENDC after newline matches status format (connector lines emit │\n then ENDC)
+        screen_develop_selected = textwrap.dedent(f"""\
+            {E.BOLD}{HEADER}{E.ENDC_BOLD_DIM}
+              {E.BOLD}master{E.ENDC_BOLD_DIM}
+              {E.GREEN}│
+            {E.ENDC}  {E.GREEN}└─{E.ENDC}{E.REVERSE_VIDEO}{E.BOLD}{E.UNDERLINE}develop{E.ENDC_UNDERLINE}{E.ENDC_BOLD_DIM}{E.ENDC}
+                {E.GREEN}│
+            {E.ENDC}    {E.GREEN}├─{E.ENDC}{E.BOLD}feature-1{E.ENDC_BOLD_DIM}
+                {E.GREEN}│
+            {E.ENDC}    {E.GREEN}└─{E.ENDC}{E.BOLD}feature-2{E.ENDC_BOLD_DIM}
+        """)
+        screen_feature1_selected = textwrap.dedent(f"""\
+            {E.BOLD}{HEADER}{E.ENDC_BOLD_DIM}
+              {E.BOLD}master{E.ENDC_BOLD_DIM}
+              {E.GREEN}│
+            {E.ENDC}  {E.GREEN}└─{E.ENDC}{E.BOLD}{E.UNDERLINE}develop{E.ENDC_UNDERLINE}{E.ENDC_BOLD_DIM}
+                {E.GREEN}│
+            {E.ENDC}    {E.GREEN}├─{E.ENDC}{E.REVERSE_VIDEO}{E.BOLD}feature-1{E.ENDC_BOLD_DIM}{E.ENDC}
+                {E.GREEN}│
+            {E.ENDC}    {E.GREEN}└─{E.ENDC}{E.BOLD}feature-2{E.ENDC_BOLD_DIM}
+        """)
+        redraw = _redraw_sequence(E, 8)
+        expected = (
+            E.HIDE_CURSOR +
+            screen_develop_selected +
+            redraw +
+            screen_feature1_selected +
+            redraw +
+            screen_develop_selected +
+            redraw +
+            screen_feature1_selected +
+            E.SHOW_CURSOR +
+            f"\nChecking out {E.BOLD}feature-1{E.ENDC_BOLD_DIM}... {E.GREEN}{E.BOLD}OK{E.ENDC_BOLD_DIM}{E.ENDC}\n"
+        )
+        assert output == expected
 
         # Verify we checked out feature-1
         current_branch = os.popen("git rev-parse --abbrev-ref HEAD").read().strip()
@@ -188,9 +233,21 @@ class TestGoInteractive(BaseTest):
         # Just quit
         output = self.run_interactive_test(mocker, ('q',))
 
-        # Check that annotations are shown
-        assert "PR #123" in output
-        assert "rebase=no push=no" in output or "rebase" in output
+        expected = (
+            E.HIDE_CURSOR +
+            textwrap.dedent(f"""\
+                {E.BOLD}{HEADER}{E.ENDC_BOLD_DIM}
+                  {E.REVERSE_VIDEO}{E.BOLD}{E.UNDERLINE}master{E.ENDC_UNDERLINE}{E.ENDC_BOLD_DIM}{E.ENDC}
+                  {E.GREEN}│
+                {E.ENDC}  {E.GREEN}└─{E.ENDC}{E.BOLD}develop{E.ENDC_BOLD_DIM}  {E.DIM}PR #123{E.ENDC_BOLD_DIM}
+                    {E.GREEN}│
+                {E.ENDC}    {E.GREEN}├─{E.ENDC}{E.BOLD}feature-1{E.ENDC_BOLD_DIM}  {E.DIM}{E.UNDERLINE}rebase=no push=no{E.ENDC_UNDERLINE}{E.ENDC_BOLD_DIM}
+                    {E.GREEN}│
+                {E.ENDC}    {E.GREEN}└─{E.ENDC}{E.BOLD}feature-2{E.ENDC_BOLD_DIM}
+            """) +
+            E.SHOW_CURSOR
+        )
+        assert output == expected
 
     def test_go_interactive_wrapping_navigation(self, mocker: MockerFixture) -> None:
         """Test that up/down arrow keys wrap around at the edges."""
@@ -233,6 +290,7 @@ class TestGoInteractive(BaseTest):
 
     def test_go_interactive_unmanaged_current_branch(self, mocker: MockerFixture) -> None:
         """Test that when current branch is unmanaged, a warning is shown and selection starts at first branch."""
+
         # Create an unmanaged branch (not in .git/machete)
         new_branch("unmanaged")
         check_out("unmanaged")
@@ -240,27 +298,76 @@ class TestGoInteractive(BaseTest):
         # Just quit
         output = self.run_interactive_test(mocker, ('q',))
 
-        # Check for warning in output
-        assert "current branch unmanaged is unmanaged" in output
-        assert "Select branch" in output
+        expected = (
+            E.ORANGE + "Warn: " + E.ENDC + "current branch unmanaged is unmanaged\n\n" +
+            E.HIDE_CURSOR +
+            textwrap.dedent(f"""\
+                {E.BOLD}{HEADER}{E.ENDC_BOLD_DIM}
+                  {E.REVERSE_VIDEO}{E.BOLD}master{E.ENDC_BOLD_DIM}{E.ENDC}
+                  {E.GREEN}│
+                {E.ENDC}  {E.GREEN}└─{E.ENDC}{E.BOLD}develop{E.ENDC_BOLD_DIM}
+                    {E.GREEN}│
+                {E.ENDC}    {E.GREEN}├─{E.ENDC}{E.BOLD}feature-1{E.ENDC_BOLD_DIM}
+                    {E.GREEN}│
+                {E.ENDC}    {E.GREEN}└─{E.ENDC}{E.BOLD}feature-2{E.ENDC_BOLD_DIM}
+            """) +
+            E.SHOW_CURSOR
+        )
+        assert output == expected
 
     def test_go_interactive_scrolling_down(self, mocker: MockerFixture) -> None:
         """Test that scrolling works when there are more branches than fit on screen."""
-        # Mock terminal height to 4, which results in max_visible_branches = 2 (4 - 2)
-        self.patch_symbol(mocker, 'git_machete.utils.get_terminal_height', lambda: 4)
+        # Mock terminal height to 3, which results in max_visible_branches = 1 (3 - 2)
+        # With only 1 branch visible, initial view shows just master; after 3x DOWN we show feature-2.
+        self.patch_symbol(mocker, 'git_machete.utils.get_terminal_height', lambda: 3)
 
         check_out("master")
 
         # First, check initial output without scrolling - feature-2 should be hidden
         output_no_scroll = self.run_interactive_test(mocker, ('q',))
-        assert "master" in output_no_scroll
-        assert "develop" in output_no_scroll
-        # feature-1 and feature-2 should NOT be visible initially (only 2 branches fit on screen)
-        assert "feature-2" not in output_no_scroll
+        expected_no_scroll = (
+            E.HIDE_CURSOR +
+            textwrap.dedent(f"""\
+                {E.BOLD}{HEADER}{E.ENDC_BOLD_DIM}
+                  {E.REVERSE_VIDEO}{E.BOLD}{E.UNDERLINE}master{E.ENDC_UNDERLINE}{E.ENDC_BOLD_DIM}{E.ENDC}
+                  {E.GREEN}│
+            """) +
+            E.SHOW_CURSOR
+        )
+        assert output_no_scroll == expected_no_scroll
 
         # Now navigate down to trigger scrolling and verify feature-2 becomes visible
         output_with_scroll = self.run_interactive_test(mocker, (AE.KEY_DOWN, AE.KEY_DOWN, AE.KEY_DOWN, 'q'))
-        assert "feature-2" in output_with_scroll
+        redraw = _redraw_sequence(E, 3)
+        screen_master = textwrap.dedent(f"""\
+            {E.BOLD}{HEADER}{E.ENDC_BOLD_DIM}
+              {E.REVERSE_VIDEO}{E.BOLD}{E.UNDERLINE}master{E.ENDC_UNDERLINE}{E.ENDC_BOLD_DIM}{E.ENDC}
+              {E.GREEN}│
+        """)
+        screen_develop = textwrap.dedent(f"""\
+            {E.BOLD}{HEADER}{E.ENDC_BOLD_DIM}
+              {E.GREEN}│
+            {E.ENDC}  {E.GREEN}└─{E.ENDC}{E.REVERSE_VIDEO}{E.BOLD}develop{E.ENDC_BOLD_DIM}{E.ENDC}
+        """)
+        screen_feature1 = textwrap.dedent(f"""\
+            {E.BOLD}{HEADER}{E.ENDC_BOLD_DIM}
+                {E.GREEN}│
+            {E.ENDC}    {E.GREEN}├─{E.ENDC}{E.REVERSE_VIDEO}{E.BOLD}feature-1{E.ENDC_BOLD_DIM}{E.ENDC}
+        """)
+        screen_feature2 = textwrap.dedent(f"""\
+            {E.BOLD}{HEADER}{E.ENDC_BOLD_DIM}
+                {E.GREEN}│
+            {E.ENDC}    {E.GREEN}└─{E.ENDC}{E.REVERSE_VIDEO}{E.BOLD}feature-2{E.ENDC_BOLD_DIM}{E.ENDC}
+        """)
+        expected_with_scroll = (
+            E.HIDE_CURSOR +
+            screen_master +
+            redraw + screen_develop +
+            redraw + screen_feature1 +
+            redraw + screen_feature2 +
+            E.SHOW_CURSOR
+        )
+        assert output_with_scroll == expected_with_scroll
 
         # Finally, navigate down and checkout to verify functionality
         self.run_interactive_test(mocker, (AE.KEY_DOWN, AE.KEY_DOWN, AE.KEY_DOWN, AE.KEY_SPACE))
@@ -270,21 +377,59 @@ class TestGoInteractive(BaseTest):
 
     def test_go_interactive_scrolling_up(self, mocker: MockerFixture) -> None:
         """Test that scrolling up works when starting from a branch that requires initial scroll offset."""
-        # Mock terminal height to 4, which results in max_visible_branches = 2 (4 - 2)
-        self.patch_symbol(mocker, 'git_machete.utils.get_terminal_height', lambda: 4)
+        # Mock terminal height to 3, which results in max_visible_branches = 1 (3 - 2)
+        # With only 1 branch visible, initial view shows just feature-2; after 3x UP we show master.
+        self.patch_symbol(mocker, 'git_machete.utils.get_terminal_height', lambda: 3)
 
         check_out("feature-2")
 
         # First, check initial output without scrolling - master should be hidden
         output_no_scroll = self.run_interactive_test(mocker, ('q',))
-        assert "feature-1" in output_no_scroll
-        assert "feature-2" in output_no_scroll
-        # master and develop should NOT be visible initially (only last 2 branches fit on screen)
-        assert "master" not in output_no_scroll
+        expected_no_scroll = (
+            E.HIDE_CURSOR +
+            textwrap.dedent(f"""\
+                {E.BOLD}{HEADER}{E.ENDC_BOLD_DIM}
+                    {E.GREEN}│
+                {E.ENDC}    {E.GREEN}└─{E.ENDC}{E.REVERSE_VIDEO}{E.BOLD}{E.UNDERLINE}feature-2{E.ENDC_UNDERLINE}{E.ENDC_BOLD_DIM}{E.ENDC}
+            """) +
+            E.SHOW_CURSOR
+        )
+        assert output_no_scroll == expected_no_scroll
 
         # Now navigate up to trigger scrolling and verify master becomes visible
         output_with_scroll = self.run_interactive_test(mocker, (AE.KEY_UP, AE.KEY_UP, AE.KEY_UP, 'q'))
-        assert "master" in output_with_scroll
+        redraw = _redraw_sequence(E, 3)
+        screen_feature2 = textwrap.dedent(f"""\
+            {E.BOLD}{HEADER}{E.ENDC_BOLD_DIM}
+                {E.GREEN}│
+            {E.ENDC}    {E.GREEN}└─{E.ENDC}{E.REVERSE_VIDEO}{E.BOLD}{E.UNDERLINE}feature-2{E.ENDC_UNDERLINE}{E.ENDC_BOLD_DIM}{E.ENDC}
+        """)
+        # When scrolled, each screen shows branch line then │ below it (3 lines: header + 2 content).
+        # First content line after redraw starts with ENDC (from previous line's REVERSE_VIDEO close).
+        screen_feature1 = textwrap.dedent(f"""\
+            {E.BOLD}{HEADER}{E.ENDC_BOLD_DIM}
+            {E.ENDC}    {E.GREEN}├─{E.ENDC}{E.REVERSE_VIDEO}{E.BOLD}feature-1{E.ENDC_BOLD_DIM}{E.ENDC}
+                {E.GREEN}│
+        """)
+        screen_develop = textwrap.dedent(f"""\
+            {E.BOLD}{HEADER}{E.ENDC_BOLD_DIM}
+            {E.ENDC}  {E.GREEN}└─{E.ENDC}{E.REVERSE_VIDEO}{E.BOLD}develop{E.ENDC_BOLD_DIM}{E.ENDC}
+                {E.GREEN}│
+        """)
+        screen_master = textwrap.dedent(f"""\
+            {E.BOLD}{HEADER}{E.ENDC_BOLD_DIM}
+              {E.REVERSE_VIDEO}{E.BOLD}master{E.ENDC_BOLD_DIM}{E.ENDC}
+              {E.GREEN}│
+        """)
+        expected_with_scroll = (
+            E.HIDE_CURSOR +
+            screen_feature2 +
+            redraw + screen_feature1 +
+            redraw + screen_develop +
+            redraw + screen_master +
+            E.SHOW_CURSOR
+        )
+        assert output_with_scroll == expected_with_scroll
 
         # Finally, navigate up and checkout to verify functionality
         self.run_interactive_test(mocker, (AE.KEY_UP, AE.KEY_UP, AE.KEY_UP, AE.KEY_SPACE))

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -68,6 +68,8 @@ class TestStatus(BaseTest):
 
     def test_single_invalid_branch_interactive_slide_out(self, mocker: MockerFixture) -> None:
         self.patch_symbol(mocker, "git_machete.utils.is_stdout_a_tty", lambda: True)
+        E = SimpleAnsiEscapeCodes()
+        self.patch_symbol(mocker, "git_machete.utils.AE", E)
 
         create_repo()
         new_branch('master')
@@ -79,11 +81,13 @@ class TestStatus(BaseTest):
             \t\tfoo
             """
         rewrite_branch_layout_file(body)
-        expected_output = """
-            Skipping foo which is not a local branch (perhaps it has been deleted?).
-            Slide it out from the branch layout file? (y, e[dit], N)
-              master *
-        """
+        expected_output = (
+            "Skipping " + E.BOLD + "foo" + E.ENDC_BOLD_DIM +
+            " which is not a local branch (perhaps it has been deleted?).\n" +
+            "Slide it out from the branch layout file? (" +
+            E.GREEN + "y" + E.ENDC + ", " + E.ORANGE + "e[dit]" + E.ENDC + ", " + E.RED + "N" + E.ENDC + ")\n" +
+            "  " + E.BOLD + E.UNDERLINE + "master" + E.ENDC_UNDERLINE + E.ENDC_BOLD_DIM + "\n"
+        )
 
         self.patch_symbol(mocker, "builtins.input", mock_input_returning(""))
         assert_success(["status"], expected_output)
@@ -95,6 +99,8 @@ class TestStatus(BaseTest):
 
     def test_multiple_invalid_branches_interactive_slide_out(self, mocker: MockerFixture) -> None:
         self.patch_symbol(mocker, "git_machete.utils.is_stdout_a_tty", lambda: True)
+        E = SimpleAnsiEscapeCodes()
+        self.patch_symbol(mocker, "git_machete.utils.AE", E)
 
         create_repo()
         new_branch('master')
@@ -115,15 +121,18 @@ class TestStatus(BaseTest):
             \t\tfeature
             """
         rewrite_branch_layout_file(body)
-        expected_output = """
-            Skipping foo, bar, qux, baz which are not local branches (perhaps they have been deleted?).
-            Slide them out from the branch layout file? (y, e[dit], N)
-              master
-              |
-              o-develop
-
-              feature *
-        """
+        expected_output = (
+            "Skipping " + E.BOLD + "foo" + E.ENDC_BOLD_DIM + ", " + E.BOLD + "bar" + E.ENDC_BOLD_DIM +
+            ", " + E.BOLD + "qux" + E.ENDC_BOLD_DIM + ", " + E.BOLD + "baz" + E.ENDC_BOLD_DIM +
+            " which are not local branches (perhaps they have been deleted?).\n" +
+            "Slide them out from the branch layout file? (" +
+            E.GREEN + "y" + E.ENDC + ", " + E.ORANGE + "e[dit]" + E.ENDC + ", " + E.RED + "N" + E.ENDC + ")\n" +
+            "  " + E.BOLD + "master" + E.ENDC_BOLD_DIM + "\n" +
+            "  " + E.GREEN + "│\n" + E.ENDC +
+            "  " + E.GREEN + "└─" + E.ENDC + E.BOLD + "develop" + E.ENDC_BOLD_DIM + "\n" +
+            "\n" +
+            "  " + E.BOLD + E.UNDERLINE + "feature" + E.ENDC_UNDERLINE + E.ENDC_BOLD_DIM + "\n"
+        )
         self.patch_symbol(mocker, "builtins.input", mock_input_returning_y)
         assert_success(["status"], expected_output)
 


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1611

## Chain of upstream PRs as of 2026-03-12

* PR #1610:
  `develop` ← `refactor/ansi-escape`

  * PR #1611:
    `refactor/ansi-escape` ← `fix/go-int-stdout-tty`

    * **PR #1607 (THIS ONE)**:
      `fix/go-int-stdout-tty` ← `improve/go-interactive-status`

<!-- end git-machete generated -->
