### PR TITLE
Forbid running interactive go when stdout is not a TTY

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## New in git-machete 3.39.2
 
+- fixed: interactive `git machete go` now fails immediately when stdout is not a TTY (e.g. when piped) instead of behaving chaotically
+
 ## New in git-machete 3.39.1
 
 - changed: whenever git-machete prints a path on Windows, the path is now POSIX-compatible (with `/`)

--- a/docs/man/git-machete.1
+++ b/docs/man/git-machete.1
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GIT-MACHETE" "1" "Mar 11, 2026" "" "git-machete"
+.TH "GIT-MACHETE" "1" "Mar 12, 2026" "" "git-machete"
 .SH NAME
 git-machete \- git-machete 3.39.2
 .sp

--- a/git_machete/client/go_interactive.py
+++ b/git_machete/client/go_interactive.py
@@ -11,7 +11,7 @@ except ImportError:  # pragma: no cover; Windows-specific
 
 from git_machete import utils
 from git_machete.client.base import MacheteClient
-from git_machete.exceptions import UnexpectedMacheteException
+from git_machete.exceptions import MacheteException, UnexpectedMacheteException
 from git_machete.git_operations import LocalBranchShortName
 from git_machete.utils import bold, index_or_none, warn
 
@@ -139,6 +139,8 @@ class GoInteractiveMacheteClient(MacheteClient):
         """
         if termios is None or tty is None:
             raise UnexpectedMacheteException("Interactive mode is not supported on Windows yet")
+        if not utils.is_stdout_a_tty():
+            raise MacheteException("Interactive `git machete go` requires stdout to be a TTY.")
 
         # Get flat list of branches with depths from already-parsed state
         self._managed_branches_with_depths = self._get_branch_list_with_depths()

--- a/tests/test_go_interactive.py
+++ b/tests/test_go_interactive.py
@@ -8,7 +8,7 @@ from pytest_mock import MockerFixture
 from git_machete.utils import AE
 
 from .base_test import BaseTest
-from .mockers import launch_command, rewrite_branch_layout_file
+from .mockers import assert_failure, launch_command, rewrite_branch_layout_file
 from .mockers_git_repository import check_out, commit, create_repo, new_branch
 
 KEY_ENTER = '\r'  # Enter key
@@ -66,6 +66,9 @@ class TestGoInteractive(BaseTest):
         Helper to run an interactive test by mocking stdin and terminal methods.
         Returns the captured stdout.
         """
+        # Mock is_stdout_a_tty so interactive go runs (tests redirect stdout)
+        self.patch_symbol(mocker, 'git_machete.utils.is_stdout_a_tty', lambda: True)
+
         # Mock _get_stdin_fd to return a fake file descriptor
         self.patch_symbol(mocker, 'git_machete.client.go_interactive.GoInteractiveMacheteClient._get_stdin_fd',
                           lambda self: 0)
@@ -301,3 +304,11 @@ class TestGoInteractive(BaseTest):
         # Verify we checked out master (the first branch in the layout)
         current_branch = os.popen("git rev-parse --abbrev-ref HEAD").read().strip()
         assert current_branch == "master"
+
+    def test_go_interactive_requires_tty(self, mocker: MockerFixture) -> None:
+        """Interactive `go` fails immediately when stdout is not a TTY (e.g. piped to cat)."""
+        self.patch_symbol(mocker, 'git_machete.utils.is_stdout_a_tty', lambda: False)
+        assert_failure(
+            ['go'],
+            "Interactive git machete go requires stdout to be a TTY.",
+        )


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1610

## Chain of upstream PRs as of 2026-03-12

* PR #1610:
  `develop` ← `refactor/ansi-escape`

  * **PR #1611 (THIS ONE)**:
    `refactor/ansi-escape` ← `fix/go-int-stdout-tty`

<!-- end git-machete generated -->
