### PR TITLE
fix: say 'root' instead of 'first root' when there is only one root

### DIFF
--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -706,7 +706,7 @@ class MacheteClient:
                 if if_unmanaged == PickRoot.FIRST:
                     warn(
                         f"{bold(branch)} is not a managed branch, assuming "
-                        f"{self._state.roots[0]} (the first root) instead as root")
+                        f"{self._state.roots[0]} ({'the first root' if len(self._state.roots) > 1 else 'root'}) instead as root")
                     return self._state.roots[0]
                 else:  # if_unmanaged == PickRoot.LAST
                     warn(

--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -706,12 +706,12 @@ class MacheteClient:
                 if if_unmanaged == PickRoot.FIRST:
                     warn(
                         f"{bold(branch)} is not a managed branch, assuming "
-                        f"{self._state.roots[0]} ({'the first root' if len(self._state.roots) > 1 else 'root'}) instead as root")
+                        f"{self._state.roots[0]}{' (the first root)' if len(self._state.roots) > 1 else ''} instead as root")
                     return self._state.roots[0]
                 else:  # if_unmanaged == PickRoot.LAST
                     warn(
                         f"{bold(branch)} is not a managed branch, assuming "
-                        f"{self._state.roots[-1]} (the last root) instead as root")
+                        f"{self._state.roots[-1]}{' (the last root)' if len(self._state.roots) > 1 else ''} instead as root")
                     return self._state.roots[-1]
             else:
                 self.__raise_no_branches_error()

--- a/git_machete/client/traverse.py
+++ b/git_machete/client/traverse.py
@@ -162,7 +162,8 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
                 # Note that we already ensured that there is at least one managed branch.
                 dest = self.managed_branches[0]
                 self._print_new_line(False)
-                self._switch_branch(dest, custom_checkout_message=f"Checking out the first root branch ({bold(dest)})")
+                root_qualifier = "first root" if len(self._state.roots) > 1 else "root"
+                self._switch_branch(dest, custom_checkout_message=f"Checking out the {root_qualifier} branch ({bold(dest)})")
                 current_branch = dest
             elif opt_start_from == TraverseStartFrom.HERE:
                 current_branch = self._git.get_current_branch()

--- a/tests/test_traverse.py
+++ b/tests/test_traverse.py
@@ -1883,7 +1883,7 @@ class TestTraverse(BaseTest):
         assert_success(
             ["traverse", "-w"],
             """
-            Checking out the first root branch (master)... OK
+            Checking out the root branch (master)... OK
 
             Checking out feature-1... OK
 

--- a/tests/test_traverse_github.py
+++ b/tests/test_traverse_github.py
@@ -121,7 +121,7 @@ class TestTraverseGitHub(BaseTest):
             """
             Fetching origin...
 
-            Checking out the first root branch (develop)... OK
+            Checking out the root branch (develop)... OK
             Checking for open GitHub PRs... OK
 
             Checking out build-chain... OK
@@ -202,7 +202,7 @@ class TestTraverseGitHub(BaseTest):
             """
             Fetching origin...
 
-            Checking out the first root branch (develop)... OK
+            Checking out the root branch (develop)... OK
             Checking for open GitHub PRs... OK
 
             Checking out build-chain... OK

--- a/tests/test_traverse_gitlab.py
+++ b/tests/test_traverse_gitlab.py
@@ -121,7 +121,7 @@ class TestTraverseGitLab(BaseTest):
             """
             Fetching origin...
 
-            Checking out the first root branch (develop)... OK
+            Checking out the root branch (develop)... OK
             Checking for open GitLab MRs... OK
 
             Checking out build-chain... OK
@@ -203,7 +203,7 @@ class TestTraverseGitLab(BaseTest):
             """
             Fetching origin...
 
-            Checking out the first root branch (develop)... OK
+            Checking out the root branch (develop)... OK
             Checking for open GitLab MRs... OK
 
             Checking out build-chain... OK

--- a/tests/test_traverse_worktrees.py
+++ b/tests/test_traverse_worktrees.py
@@ -178,7 +178,7 @@ class TestTraverseWorktrees(BaseTest):
             ["traverse", "-y", "--start-from=first-root"],
             f"""
             Changing directory to main worktree at {normalized_local_path}
-            Checking out the first root branch (root)... OK
+            Checking out the root branch (root)... OK
 
             Checking out branch-2... OK
 


### PR DESCRIPTION
## Summary

When the machete file has a single root branch, user-facing messages now say "root" instead of "first root". The "first root" qualifier is only used when multiple roots exist and the distinction matters.

## Changes

- `git_machete/client/traverse.py`: conditionally use "first root" or "root" based on `len(self._state.roots)`
- `git_machete/client/base.py`: same conditional for the `PickRoot.FIRST` warning message
- Updated test expectations in `test_traverse.py`, `test_traverse_github.py`, `test_traverse_gitlab.py`, and `test_traverse_worktrees.py` for single-root scenarios

The multi-root test case in `test_traverse.py` (develop + master) still uses "first root branch" since the qualifier is needed there.

Closes #1550

This contribution was developed with AI assistance (Claude Code).