### PR TITLE
Fix tests for temporary worktrees on NixOS

### DIFF
--- a/git_machete/client/traverse.py
+++ b/git_machete/client/traverse.py
@@ -113,7 +113,7 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
             config_value = self._config.traverse_when_branch_not_checked_out_in_any_worktree()
 
             if config_value == TraverseWhenBranchNotCheckedOutInAnyWorktree.CD_INTO_TEMPORARY_WORKTREE:
-                temp_worktree_path = tempfile.mkdtemp(prefix="git-machete-")
+                temp_worktree_path = tempfile.mkdtemp(prefix="git-machete-worktree-")
                 print_no_newline(f"Creating a temporary worktree to check out {bold(target_branch)}... ")
                 self._git.worktree_add(temp_worktree_path, target_branch)
                 print(green_ok())

--- a/tests/test_traverse_worktrees.py
+++ b/tests/test_traverse_worktrees.py
@@ -605,7 +605,7 @@ class TestTraverseWorktrees(BaseTest):
 
         # Verify no temporary worktree lingers after traverse
         assert len(get_worktree_dirs()) == 2
-        assert "git-machete-" not in " ".join(get_worktree_dirs())
+        assert "git-machete-worktree-" not in " ".join(get_worktree_dirs())
 
     def test_traverse_cd_into_temporary_worktree_with_rebase(self) -> None:
         """Test that traverse with temporary worktrees correctly performs rebase operations."""
@@ -658,7 +658,7 @@ class TestTraverseWorktrees(BaseTest):
 
         # Verify no temporary worktree lingers after traverse
         assert len(get_worktree_dirs()) == 1
-        assert "git-machete-" not in " ".join(get_worktree_dirs())
+        assert "git-machete-worktree-" not in " ".join(get_worktree_dirs())
 
     def test_traverse_cd_into_temporary_worktree_warns_when_started_from_linked_worktree(self) -> None:
         """Test that the end-of-traverse warning fires when temp worktree cleanup lands us in main worktree,
@@ -729,7 +729,7 @@ class TestTraverseWorktrees(BaseTest):
 
         # Verify no temporary worktree lingers after traverse
         assert len(get_worktree_dirs()) == 2
-        assert "git-machete-" not in " ".join(get_worktree_dirs())
+        assert "git-machete-worktree-" not in " ".join(get_worktree_dirs())
 
     # The expected error message includes `--empty=drop` which is only passed on git >= 2.26.0.
     @pytest.mark.skipif(get_git_version() < (2, 26, 0), reason="--empty=drop is only passed to git rebase since git 2.26.0")


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1628

## Chain of upstream PRs as of 2026-03-31

* PR #1628:
  `master` ← `develop`

  * **PR #1629 (THIS ONE)**:
    `develop` ← `fix/nix-traverse-worktrees`

<!-- end git-machete generated -->
