### PR TITLE
fix(create-pr): skip head-branch-exists check when sync just pushed the branch

### DIFF
--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -746,14 +746,15 @@ def launch_internal(orig_args: List[str]) -> None:
                     fail_on_missing_current_user_for_my_open_prs=True)
             elif subcommand == f"create-{pr_or_mr}":
                 current_branch = git.get_current_branch()
-                github_or_gitlab_client.sync_before_creating_pull_request(opt_yes=cli_opts.opt_yes)
+                pushed_to_remote = github_or_gitlab_client.sync_before_creating_pull_request(opt_yes=cli_opts.opt_yes)
                 github_or_gitlab_client.create_pull_request(
                     head=current_branch,
                     opt_base=cli_opts.opt_base,
                     opt_draft=cli_opts.opt_draft,
                     opt_title=cli_opts.opt_title,
                     opt_update_related_descriptions=cli_opts.opt_update_related_descriptions,
-                    opt_yes=cli_opts.opt_yes)
+                    opt_yes=cli_opts.opt_yes,
+                    head_pushed_to_remote=pushed_to_remote)
             elif subcommand == f"restack-{pr_or_mr}":
                 github_or_gitlab_client.restack_pull_request(opt_update_related_descriptions=cli_opts.opt_update_related_descriptions)
             elif subcommand == f"retarget-{pr_or_mr}":

--- a/git_machete/client/with_code_hosting.py
+++ b/git_machete/client/with_code_hosting.py
@@ -117,6 +117,7 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
 
     def sync_before_creating_pull_request(self, *, opt_yes: bool) -> None:
         spec = self.code_hosting_spec
+        self.__head_branch_pushed_by_sync = False
         self.expect_at_least_one_managed_branch()
         self._set_empty_line_status()
 
@@ -157,32 +158,43 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             SyncToRemoteStatus.DIVERGED_FROM_AND_NEWER_THAN_REMOTE)
         if s in statuses_to_push:
             if current_branch not in self.annotations or self.annotations[current_branch].qualifiers.push:
-                if s == SyncToRemoteStatus.AHEAD_OF_REMOTE:
-                    assert remote is not None
-                    self._handle_ahead_state(
-                        current_branch=current_branch,
-                        remote=remote,
-                        is_called_from_traverse=False,
-                        opt_push_tracked=True,
-                        opt_yes=opt_yes)
-                elif s == SyncToRemoteStatus.UNTRACKED:
-                    self._handle_untracked_state(
-                        branch=current_branch,
-                        is_called_from_traverse=False,
-                        is_called_from_code_hosting=True,
-                        opt_push_tracked=True,
-                        opt_push_untracked=True,
-                        opt_yes=opt_yes)
-                elif s == SyncToRemoteStatus.DIVERGED_FROM_AND_NEWER_THAN_REMOTE:
-                    assert remote is not None
-                    self._handle_diverged_and_newer_state(
-                        current_branch=current_branch,
-                        remote=remote,
-                        is_called_from_traverse=False,
-                        opt_push_tracked=True,
-                        opt_yes=opt_yes)
-                else:
-                    raise UnexpectedMacheteException(f"Invalid sync to remote status: `{s}`.")
+                original_push = self._git.push
+
+                def push_and_mark(*args, **kwargs):  # type: ignore[no-untyped-def]
+                    result = original_push(*args, **kwargs)
+                    self.__head_branch_pushed_by_sync = True
+                    return result
+
+                self._git.push = push_and_mark  # type: ignore[method-assign]
+                try:
+                    if s == SyncToRemoteStatus.AHEAD_OF_REMOTE:
+                        assert remote is not None
+                        self._handle_ahead_state(
+                            current_branch=current_branch,
+                            remote=remote,
+                            is_called_from_traverse=False,
+                            opt_push_tracked=True,
+                            opt_yes=opt_yes)
+                    elif s == SyncToRemoteStatus.UNTRACKED:
+                        self._handle_untracked_state(
+                            branch=current_branch,
+                            is_called_from_traverse=False,
+                            is_called_from_code_hosting=True,
+                            opt_push_tracked=True,
+                            opt_push_untracked=True,
+                            opt_yes=opt_yes)
+                    elif s == SyncToRemoteStatus.DIVERGED_FROM_AND_NEWER_THAN_REMOTE:
+                        assert remote is not None
+                        self._handle_diverged_and_newer_state(
+                            current_branch=current_branch,
+                            remote=remote,
+                            is_called_from_traverse=False,
+                            opt_push_tracked=True,
+                            opt_yes=opt_yes)
+                    else:
+                        raise UnexpectedMacheteException(f"Invalid sync to remote status: `{s}`.")
+                finally:
+                    self._git.push = original_push  # type: ignore[method-assign]
 
                 self._print_new_line(False)
                 self.status(
@@ -231,6 +243,8 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             opt_update_related_descriptions: bool,
             opt_yes: bool
     ) -> None:
+        pushed = getattr(self, '_MacheteClientWithCodeHosting__head_branch_pushed_by_sync', False)
+        self.__head_branch_pushed_by_sync = False
         # Use provided base branch if --base flag is specified (undocumented), otherwise use upstream branch from .git/machete
         base: Optional[LocalBranchShortName] = opt_base or self.up_branch_for(LocalBranchShortName.of(head))
         spec = self.code_hosting_spec
@@ -266,15 +280,19 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
 
         # Check both base and head branches in a single git ls-remote call if they use the same remote
         if base_org_repo_remote.remote == head_org_repo_remote.remote:
-            print_fmt(f"Checking if {spec.head_branch_name} branch <b>{head}</b> "
-                      f"exists in <b>{head_org_repo_remote.remote}</b> remote... ",
-                      newline=False)
+            if pushed:
+                base_branch_found_on_remote = self._git.does_remote_branch_exist(base_org_repo_remote.remote, base)
+                head_branch_found_on_remote = True
+            else:
+                print_fmt(f"Checking if {spec.head_branch_name} branch <b>{head}</b> "
+                          f"exists in <b>{head_org_repo_remote.remote}</b> remote... ",
+                          newline=False)
 
-            branches_existence = self._git.do_remote_branches_exist(base_org_repo_remote.remote, base, head)
-            base_branch_found_on_remote = branches_existence[base]
-            head_branch_found_on_remote = branches_existence[head]
+                branches_existence = self._git.do_remote_branches_exist(base_org_repo_remote.remote, base, head)
+                base_branch_found_on_remote = branches_existence[base]
+                head_branch_found_on_remote = branches_existence[head]
 
-            print_fmt(colored_yes_no(head_branch_found_on_remote))
+                print_fmt(colored_yes_no(head_branch_found_on_remote))
 
             print_fmt(f"Checking if {spec.base_branch_name} branch <b>{base}</b> "
                       f"exists in <b>{base_org_repo_remote.remote}</b> remote... ",
@@ -282,11 +300,14 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             print_fmt(colored_yes_no(base_branch_found_on_remote))
         else:
             # Different remotes, check separately (head first, then base)
-            print_fmt(f"Checking if {spec.head_branch_name} branch <b>{head}</b> "
-                      f"exists in <b>{head_org_repo_remote.remote}</b> remote... ",
-                      newline=False)
-            head_branch_found_on_remote = self._git.does_remote_branch_exist(head_org_repo_remote.remote, head)
-            print_fmt(colored_yes_no(head_branch_found_on_remote))
+            if pushed:
+                head_branch_found_on_remote = True
+            else:
+                print_fmt(f"Checking if {spec.head_branch_name} branch <b>{head}</b> "
+                          f"exists in <b>{head_org_repo_remote.remote}</b> remote... ",
+                          newline=False)
+                head_branch_found_on_remote = self._git.does_remote_branch_exist(head_org_repo_remote.remote, head)
+                print_fmt(colored_yes_no(head_branch_found_on_remote))
 
             print_fmt(f"Checking if {spec.base_branch_name} branch <b>{base}</b> "
                       f"exists in <b>{base_org_repo_remote.remote}</b> remote... ",

--- a/git_machete/client/with_code_hosting.py
+++ b/git_machete/client/with_code_hosting.py
@@ -10,8 +10,9 @@ from git_machete.code_hosting import (CodeHostingClient, CodeHostingSpec,
                                       OrganizationAndRepositoryAndRemote,
                                       PullRequest, is_matching_remote_url)
 from git_machete.config import PRDescriptionIntroStyle, SquashMergeDetection
-from git_machete.git_operations import (GitContext, GitFormatPatterns,
-                                        GitLogEntry, LocalBranchShortName,
+from git_machete.git_operations import (FullCommitHash, GitContext,
+                                        GitFormatPatterns, GitLogEntry,
+                                        LocalBranchShortName,
                                         RemoteBranchShortName,
                                         SyncToRemoteStatus)
 from git_machete.utils import (MacheteException, UnexpectedMacheteException,
@@ -115,9 +116,14 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
                 return remote
         return None
 
-    def sync_before_creating_pull_request(self, *, opt_yes: bool) -> None:
+    def sync_before_creating_pull_request(self, *, opt_yes: bool) -> Optional[str]:
+        """Ensure the current branch is synced with a remote before PR creation.
+
+        Returns the remote the branch was pushed to during this call, or None
+        if no push happened (either because the branch was already in sync or
+        because the user declined the push).
+        """
         spec = self.code_hosting_spec
-        self.__head_branch_pushed_to_remote: Optional[str] = None
         self.expect_at_least_one_managed_branch()
         self._set_empty_line_status()
 
@@ -156,45 +162,54 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             SyncToRemoteStatus.UNTRACKED,
             SyncToRemoteStatus.AHEAD_OF_REMOTE,
             SyncToRemoteStatus.DIVERGED_FROM_AND_NEWER_THAN_REMOTE)
+        pushed_to_remote: Optional[str] = None
         if s in statuses_to_push:
             if current_branch not in self.annotations or self.annotations[current_branch].qualifiers.push:
-                original_push = self._git.push
+                # Snapshot remote-tracking OIDs so a post-call diff reveals which remote
+                # (if any) actually received a push - distinguishing a real push from a
+                # declined prompt or a tracking-only update to a matching branch.
+                def remote_head(r: str) -> Optional[FullCommitHash]:
+                    return self._git.get_commit_hash_by_revision(
+                        RemoteBranchShortName.of(f"{r}/{current_branch}").full_name())
 
-                def push_and_mark(*args, **kwargs):  # type: ignore[no-untyped-def]
-                    result = original_push(*args, **kwargs)
-                    self.__head_branch_pushed_to_remote = args[0] if args else kwargs.get('remote')
-                    return result
+                remote_oids_before: Dict[str, Optional[FullCommitHash]] = {
+                    r: remote_head(r) for r in self._git.get_remotes()
+                }
 
-                self._git.push = push_and_mark  # type: ignore[method-assign]
-                try:
-                    if s == SyncToRemoteStatus.AHEAD_OF_REMOTE:
-                        assert remote is not None
-                        self._handle_ahead_state(
-                            current_branch=current_branch,
-                            remote=remote,
-                            is_called_from_traverse=False,
-                            opt_push_tracked=True,
-                            opt_yes=opt_yes)
-                    elif s == SyncToRemoteStatus.UNTRACKED:
-                        self._handle_untracked_state(
-                            branch=current_branch,
-                            is_called_from_traverse=False,
-                            is_called_from_code_hosting=True,
-                            opt_push_tracked=True,
-                            opt_push_untracked=True,
-                            opt_yes=opt_yes)
-                    elif s == SyncToRemoteStatus.DIVERGED_FROM_AND_NEWER_THAN_REMOTE:
-                        assert remote is not None
-                        self._handle_diverged_and_newer_state(
-                            current_branch=current_branch,
-                            remote=remote,
-                            is_called_from_traverse=False,
-                            opt_push_tracked=True,
-                            opt_yes=opt_yes)
-                    else:
-                        raise UnexpectedMacheteException(f"Invalid sync to remote status: `{s}`.")
-                finally:
-                    self._git.push = original_push  # type: ignore[method-assign]
+                if s == SyncToRemoteStatus.AHEAD_OF_REMOTE:
+                    assert remote is not None
+                    self._handle_ahead_state(
+                        current_branch=current_branch,
+                        remote=remote,
+                        is_called_from_traverse=False,
+                        opt_push_tracked=True,
+                        opt_yes=opt_yes)
+                elif s == SyncToRemoteStatus.UNTRACKED:
+                    self._handle_untracked_state(
+                        branch=current_branch,
+                        is_called_from_traverse=False,
+                        is_called_from_code_hosting=True,
+                        opt_push_tracked=True,
+                        opt_push_untracked=True,
+                        opt_yes=opt_yes)
+                elif s == SyncToRemoteStatus.DIVERGED_FROM_AND_NEWER_THAN_REMOTE:
+                    assert remote is not None
+                    self._handle_diverged_and_newer_state(
+                        current_branch=current_branch,
+                        remote=remote,
+                        is_called_from_traverse=False,
+                        opt_push_tracked=True,
+                        opt_yes=opt_yes)
+                else:
+                    raise UnexpectedMacheteException(f"Invalid sync to remote status: `{s}`.")
+
+                # A single _handle_* call pushes to at most one remote, so the first
+                # changed ref identifies the destination.
+                for r, before_oid in remote_oids_before.items():
+                    after_oid = remote_head(r)
+                    if after_oid is not None and after_oid != before_oid:
+                        pushed_to_remote = r
+                        break
 
                 self._print_new_line(False)
                 self.status(
@@ -204,27 +219,28 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
                     opt_squash_merge_detection=SquashMergeDetection.NONE)
                 self._print_new_line(False)
 
-        else:
-            if s == SyncToRemoteStatus.BEHIND_REMOTE:
-                warn(f"branch <b>{current_branch}</b> is behind its remote counterpart. Consider using `git pull`.")
-                self._print_new_line(False)
-                ans = self.ask_if(f"Proceed with creating {spec.pr_full_name}?" + pretty_choices('y', 'Q'),
-                                  f"Proceeding with {spec.pr_full_name} creation...", opt_yes=opt_yes)
-            elif s == SyncToRemoteStatus.DIVERGED_FROM_AND_OLDER_THAN_REMOTE:
-                warn(f"branch <b>{current_branch}</b> is diverged from and older than its remote counterpart. "
-                     "Consider using `git reset --keep`.")
-                self._print_new_line(False)
-                ans = self.ask_if(f"Proceed with creating {spec.pr_full_name}?" + pretty_choices('y', 'Q'),
-                                  f"Proceeding with {spec.pr_full_name} creation...", opt_yes=opt_yes)
-            elif s == SyncToRemoteStatus.NO_REMOTES:
-                raise MacheteException(
-                    f"Could not create {spec.pr_full_name} - there are no remote repositories!")
-            else:
-                ans = 'y'  # only IN SYNC status is left
+            return pushed_to_remote
 
-            if ans in ('y', 'yes'):
-                return
-            raise MacheteException(f'Interrupted creating {spec.pr_full_name}.')
+        if s == SyncToRemoteStatus.BEHIND_REMOTE:
+            warn(f"branch <b>{current_branch}</b> is behind its remote counterpart. Consider using `git pull`.")
+            self._print_new_line(False)
+            ans = self.ask_if(f"Proceed with creating {spec.pr_full_name}?" + pretty_choices('y', 'Q'),
+                              f"Proceeding with {spec.pr_full_name} creation...", opt_yes=opt_yes)
+        elif s == SyncToRemoteStatus.DIVERGED_FROM_AND_OLDER_THAN_REMOTE:
+            warn(f"branch <b>{current_branch}</b> is diverged from and older than its remote counterpart. "
+                 "Consider using `git reset --keep`.")
+            self._print_new_line(False)
+            ans = self.ask_if(f"Proceed with creating {spec.pr_full_name}?" + pretty_choices('y', 'Q'),
+                              f"Proceeding with {spec.pr_full_name} creation...", opt_yes=opt_yes)
+        elif s == SyncToRemoteStatus.NO_REMOTES:
+            raise MacheteException(
+                f"Could not create {spec.pr_full_name} - there are no remote repositories!")
+        else:
+            ans = 'y'  # only IN SYNC status is left
+
+        if ans in ('y', 'yes'):
+            return None
+        raise MacheteException(f'Interrupted creating {spec.pr_full_name}.')
 
     def sync_annotations_to_prs(self, *, include_urls: bool) -> None:
         self._init_code_hosting_client()
@@ -241,10 +257,9 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             opt_draft: bool,
             opt_title: Optional[str],
             opt_update_related_descriptions: bool,
-            opt_yes: bool
+            opt_yes: bool,
+            head_pushed_to_remote: Optional[str] = None
     ) -> None:
-        pushed_remote = getattr(self, '_MacheteClientWithCodeHosting__head_branch_pushed_to_remote', None)
-        self.__head_branch_pushed_to_remote = None
         # Use provided base branch if --base flag is specified (undocumented), otherwise use upstream branch from .git/machete
         base: Optional[LocalBranchShortName] = opt_base or self.up_branch_for(LocalBranchShortName.of(head))
         spec = self.code_hosting_spec
@@ -278,7 +293,7 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
         base_remote_branch = RemoteBranchShortName(f"{base_org_repo_remote.remote}/{base}")
         remote_base_branch_exists_locally = base_remote_branch in self._git.get_remote_branches()
         head_branch_was_pushed_to_code_hosting_remote = (
-            pushed_remote is not None and pushed_remote == head_org_repo_remote.remote
+            head_pushed_to_remote is not None and head_pushed_to_remote == head_org_repo_remote.remote
         )
 
         # Check both base and head branches in a single git ls-remote call if they use the same remote

--- a/git_machete/client/with_code_hosting.py
+++ b/git_machete/client/with_code_hosting.py
@@ -117,7 +117,7 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
 
     def sync_before_creating_pull_request(self, *, opt_yes: bool) -> None:
         spec = self.code_hosting_spec
-        self.__head_branch_pushed_by_sync = False
+        self.__head_branch_pushed_to_remote: Optional[str] = None
         self.expect_at_least_one_managed_branch()
         self._set_empty_line_status()
 
@@ -162,7 +162,7 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
 
                 def push_and_mark(*args, **kwargs):  # type: ignore[no-untyped-def]
                     result = original_push(*args, **kwargs)
-                    self.__head_branch_pushed_by_sync = True
+                    self.__head_branch_pushed_to_remote = args[0] if args else kwargs.get('remote')
                     return result
 
                 self._git.push = push_and_mark  # type: ignore[method-assign]
@@ -243,8 +243,8 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             opt_update_related_descriptions: bool,
             opt_yes: bool
     ) -> None:
-        pushed = getattr(self, '_MacheteClientWithCodeHosting__head_branch_pushed_by_sync', False)
-        self.__head_branch_pushed_by_sync = False
+        pushed_remote = getattr(self, '_MacheteClientWithCodeHosting__head_branch_pushed_to_remote', None)
+        self.__head_branch_pushed_to_remote = None
         # Use provided base branch if --base flag is specified (undocumented), otherwise use upstream branch from .git/machete
         base: Optional[LocalBranchShortName] = opt_base or self.up_branch_for(LocalBranchShortName.of(head))
         spec = self.code_hosting_spec
@@ -277,10 +277,13 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
         remote_head_branch_exists_locally = head_remote_branch in self._git.get_remote_branches()
         base_remote_branch = RemoteBranchShortName(f"{base_org_repo_remote.remote}/{base}")
         remote_base_branch_exists_locally = base_remote_branch in self._git.get_remote_branches()
+        head_branch_was_pushed_to_code_hosting_remote = (
+            pushed_remote is not None and pushed_remote == head_org_repo_remote.remote
+        )
 
         # Check both base and head branches in a single git ls-remote call if they use the same remote
         if base_org_repo_remote.remote == head_org_repo_remote.remote:
-            if pushed:
+            if head_branch_was_pushed_to_code_hosting_remote:
                 base_branch_found_on_remote = self._git.does_remote_branch_exist(base_org_repo_remote.remote, base)
                 head_branch_found_on_remote = True
             else:
@@ -300,7 +303,7 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             print_fmt(colored_yes_no(base_branch_found_on_remote))
         else:
             # Different remotes, check separately (head first, then base)
-            if pushed:
+            if head_branch_was_pushed_to_code_hosting_remote:
                 head_branch_found_on_remote = True
             else:
                 print_fmt(f"Checking if {spec.head_branch_name} branch <b>{head}</b> "

--- a/tests/test_github_create_pr.py
+++ b/tests/test_github_create_pr.py
@@ -150,7 +150,6 @@ class TestGitHubCreatePR(BaseTest):
                 |
                 x-drop-constraint (untracked)
 
-            Checking if head branch chore/fields exists in origin remote... YES
             Checking if base branch ignore-trailing exists in origin remote... YES
             Creating a draft PR from chore/fields to ignore-trailing... OK, see www.github.com
             Checking for open GitHub PRs... OK
@@ -239,7 +238,6 @@ class TestGitHubCreatePR(BaseTest):
                 |
                 x-drop-constraint (untracked)
 
-            Checking if head branch hotfix/add-trigger exists in origin remote... YES
             Checking if base branch master exists in origin remote... YES
             Creating a PR from hotfix/add-trigger to master... OK, see www.github.com
             Updating description of PR #6 to include the chain of PRs... OK
@@ -337,7 +335,6 @@ class TestGitHubCreatePR(BaseTest):
               |
               o-testing/endpoints
 
-            Checking if head branch allow-ownership-link exists in origin remote... YES
             Checking if base branch develop exists in origin remote... YES
             Creating a PR from allow-ownership-link to develop... OK, see www.github.com
             Setting milestone of PR #7 to 42... OK
@@ -732,7 +729,6 @@ class TestGitHubCreatePR(BaseTest):
               |
               o-feature_2 *
 
-        Checking if head branch feature_2 exists in origin_1 remote... YES
         Checking if base branch feature exists in origin_1 remote... YES
         Creating a PR from feature_2 to feature... OK, see www.github.com
         Checking for open GitHub PRs... OK
@@ -1134,3 +1130,31 @@ class TestGitHubCreatePR(BaseTest):
             "Do you really want to create a PR for this branch?"
         )
         assert_failure(['github', 'create-pr'], expected_error_message)
+
+    def test_github_create_pr_skips_head_branch_check_after_sync_push(self, mocker: MockerFixture) -> None:
+        self.patch_symbol(mocker, 'builtins.input', mock_input_returning_y)
+        self.patch_symbol(mocker, 'git_machete.code_hosting.OrganizationAndRepository.from_url', mock_from_url)
+        self.patch_symbol(mocker, 'git_machete.github.GitHubToken.for_domain', mock_github_token_for_domain_none)
+        github_api_state = MockGitHubAPIState.with_prs()
+        self.patch_symbol(mocker, 'urllib.request.urlopen', mock_urlopen(github_api_state))
+
+        create_repo_with_remote()
+
+        new_branch("master")
+        commit("master commit")
+        push()
+
+        new_branch("develop")
+        commit("develop commit")
+
+        rewrite_branch_layout_file("master\n\tdevelop")
+
+        output = launch_command("github", "create-pr")
+
+        assert "Checking if head branch" not in output
+        assert "Checking if base branch master exists in origin remote... YES" in output
+
+        pr = github_api_state.get_pull_by_number(1)
+        assert pr is not None
+        assert pr['head']['ref'] == 'develop'
+        assert pr['base']['ref'] == 'master'

--- a/tests/test_github_create_pr.py
+++ b/tests/test_github_create_pr.py
@@ -1158,3 +1158,40 @@ class TestGitHubCreatePR(BaseTest):
         assert pr is not None
         assert pr['head']['ref'] == 'develop'
         assert pr['base']['ref'] == 'master'
+
+    def test_github_create_pr_checks_head_branch_after_sync_push_to_different_remote(
+            self, mocker: MockerFixture) -> None:
+        self.patch_symbol(mocker, 'builtins.input', mock_input_returning_y)
+        self.patch_symbol(mocker, 'git_machete.code_hosting.OrganizationAndRepository.from_url', mock_from_url)
+        self.patch_symbol(mocker, 'git_machete.github.GitHubToken.for_domain', mock_github_token_for_domain_none)
+        github_api_state = MockGitHubAPIState.with_prs()
+        self.patch_symbol(mocker, 'urllib.request.urlopen', mock_urlopen(github_api_state))
+
+        create_repo_with_remote()
+        origin_2_remote_path = create_repo("remote-2", bare=True, switch_dir_to_new_repo=False)
+        add_remote("origin_2", origin_2_remote_path)
+
+        new_branch("master")
+        commit("master commit")
+        push(remote='origin')
+        push(remote='origin_2')
+
+        new_branch("develop")
+        commit("develop commit")
+        push(remote='origin')
+        push(remote='origin_2')
+        commit("develop follow-up commit")
+
+        set_git_config_key("machete.github.remote", "origin")
+        rewrite_branch_layout_file("master\n\tdevelop")
+
+        output = launch_command("github", "create-pr")
+
+        assert "Push develop to origin_2? (y, N, q)" in output
+        assert "Checking if head branch develop exists in origin remote... YES" in output
+        assert "Checking if base branch master exists in origin remote... YES" in output
+
+        pr = github_api_state.get_pull_by_number(1)
+        assert pr is not None
+        assert pr['head']['ref'] == 'develop'
+        assert pr['base']['ref'] == 'master'

--- a/tests/test_gitlab_create_mr.py
+++ b/tests/test_gitlab_create_mr.py
@@ -150,7 +150,6 @@ class TestGitLabCreateMR(BaseTest):
                 |
                 x-drop-constraint (untracked)
 
-            Checking if source branch chore/fields exists in origin remote... YES
             Checking if target branch ignore-trailing exists in origin remote... YES
             Creating a draft MR from chore/fields to ignore-trailing... OK, see www.gitlab.com
             Checking for open GitLab MRs... OK
@@ -238,7 +237,6 @@ class TestGitLabCreateMR(BaseTest):
                 |
                 x-drop-constraint (untracked)
 
-            Checking if source branch hotfix/add-trigger exists in origin remote... YES
             Checking if target branch master exists in origin remote... YES
             Creating an MR from hotfix/add-trigger to master... OK, see www.gitlab.com
             Updating description of MR !6 to include the chain of MRs... OK
@@ -335,7 +333,6 @@ class TestGitLabCreateMR(BaseTest):
               |
               o-testing/endpoints
 
-            Checking if source branch allow-ownership-link exists in origin remote... YES
             Checking if target branch develop exists in origin remote... YES
             Creating an MR from allow-ownership-link to develop... OK, see www.gitlab.com
             Setting milestone of MR !7 to 42... OK
@@ -712,7 +709,6 @@ class TestGitLabCreateMR(BaseTest):
               |
               o-feature_2 *
 
-        Checking if source branch feature_2 exists in origin_1 remote... YES
         Checking if target branch feature exists in origin_1 remote... YES
         Creating an MR from feature_2 to feature... OK, see www.gitlab.com
         Checking for open GitLab MRs... OK


### PR DESCRIPTION
## Summary

Skip the redundant `Checking if head branch <X> exists in <remote> remote...` progress line and its accompanying `ls-remote` call in `create-pr` / `create-mr` when `sync_before_creating_pull_request` just pushed the same branch to the code-hosting remote. Addresses #1591.

## Why this matters

`create-pr` runs `sync_before_creating_pull_request` first, which pushes the current branch to the relevant remote if it is `UNTRACKED`, `AHEAD_OF_REMOTE`, or `DIVERGED_FROM_AND_NEWER_THAN_REMOTE`. The inline comment at `git_machete/client/with_code_hosting.py:323` already acknowledges this:

```python
# (sync_before_creating_pull_request ensures the branch is pushed,
#  so if it's missing here, it must have been removed)
```

But the progress line and `ls-remote` still run unconditionally. That is pure noise right after a fresh push: we know the branch is there because this same process just put it there.

The check still makes sense in the other direction, when the remote-tracking ref exists locally but the branch was deleted on the server since the last fetch/push. Only the just-pushed path is redundant.

## Changes

Two files: `git_machete/client/with_code_hosting.py` for the behavior change, `git_machete/cli.py` for the caller wiring.

- `sync_before_creating_pull_request` now returns `Optional[str]`, the remote it pushed to (or `None` if no push happened). Detection works by snapshotting each remote's tracking-ref OID via `get_commit_hash_by_revision` before the `_handle_*_state` call and diffing afterwards. The first remote whose OID changed is the push destination.
- `create_pull_request` accepts `head_pushed_to_remote: Optional[str] = None` and gates the `Checking if head branch ...` skip on `head_pushed_to_remote == head_org_repo_remote.remote`. The kwarg stays optional because `TraverseMacheteClient` also calls `create_pull_request` without a prior `sync_before_creating_pull_request` pass.
- `cli.py` captures the return value from `sync_before_creating_pull_request` and threads it through to `create_pull_request`.
- The base-branch check is unchanged. The fail-fast "branch removed from remote since last fetch/push" path is unchanged.
- In multi-remote setups where `machete.github.remote` / `machete.gitlab.remote` points at a different remote than the one sync pushed to, the remotes do not match, the gate is false, and the existing preflight runs like before.

### Why OID-diff instead of wrapping `self._git.push`

An earlier revision wrapped `self._git.push` to capture the remote name as it was called. That approach conflated two outcomes that look the same from the push wrapper's point of view but differ in reality:

1. `UNTRACKED` branch where the user answers `y` to "Push `<branch>` to `<remote>`?" (push happens, remote ref gets a new OID).
2. `UNTRACKED` branch whose remote counterpart already exists at the same commit, where the user answers `y` to "Set the remote of `<branch>` to `<remote>` without pushing or pulling?" (tracking gets set, no push, remote ref is untouched).

In case 2 the old wrapper also marked the branch as "pushed" and skipped the existence check, which was wrong because the skip was meant as "we just put it there" rather than "the branch happens to be in sync." Comparing remote-tracking OIDs before and after the `_handle_*_state` call makes this distinction trivially: a real push changes the remote-tracking OID, a set-tracking does not.

It also sidesteps the name-mangled `getattr(self, '_MacheteClientWithCodeHosting__head_branch_pushed_to_remote', None)` read that the wrapper approach needed, which `@PawelLipski` flagged as ugly in review.

## Testing

- `pytest tests/test_github_create_pr.py tests/test_gitlab_create_mr.py tests/test_traverse_github.py` -> 36 passed. Existing tests that set up a branch already on the remote expect both progress lines and still see them. Existing tests whose scenarios push an untracked branch in-line had the now-redundant `Checking if {head_branch_name} branch ...` line removed from their expected output (one removed line per affected test, no assertion semantics changed beyond the string).
- `test_github_create_pr_skips_head_branch_check_after_sync_push` covers the single-remote happy path: branch is `UNTRACKED`, sync pushes it, output contains `Checking if base branch ...` but not `Checking if head branch ...`, and the PR still lands.
- The existing `test_github_create_pr_with_multiple_non_origin_remotes` test covers the set-tracking-without-push case: user answers `y` to "Set remote of feature to origin_1 without pushing or pulling", output still contains `Checking if head branch feature exists in origin_1 remote... YES`. This test would have failed under the old monkey-patch approach.
- New test covering the multi-remote-mismatch case: two remotes configured, `machete.github.remote` points at remote B, sync pushes to remote A, so the gate is false and the `Checking if head branch ...` preflight still runs.
- Full suite (excluding env-specific zsh-completion tests): 379 passed, 1 skipped.

Fixes #1591

This contribution was developed with AI assistance (Codex).

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
