### PR TITLE
ci(completion-tests): pin `fish` install to its PPA to avoid silent 3.7.0 fallback

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,8 +97,24 @@ jobs:
             echo "deb     $url jammy main" | sudo tee -a /etc/apt/sources.list
             echo "deb-src $url jammy main" | sudo tee -a /etc/apt/sources.list
             sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 73C9FCC9E2BB48DA
-            sudo apt-get update
-            sudo apt-get install fish
+
+            # ppa.launchpadcontent.net occasionally times out from CI runners.
+            # Without pinning, a failed PPA fetch makes `apt-get install fish`
+            # silently fall back to Ubuntu's older `fish` (e.g. 3.7.0 from
+            # noble/universe), which then fails `test_fish_version`.
+            # Pinning forces apt to install ONLY from the PPA, so a missing
+            # PPA index produces a loud install failure - which the retry loop
+            # below can recover from.
+            printf 'Package: fish fish-common\nPin: origin ppa.launchpadcontent.net\nPin-Priority: 1001\n' \
+              | sudo tee /etc/apt/preferences.d/fish-shell-release-ppa
+
+            for attempt in 1 2 3; do
+              sudo apt-get update -o Acquire::Retries=3 \
+                && sudo apt-get install -y fish \
+                && break
+              echo "fish install attempt $attempt failed (likely transient PPA timeout); retrying..."
+              sleep $((attempt * 5))
+            done
             fish --version
 
             sudo apt-get install zsh


### PR DESCRIPTION
`ppa.launchpadcontent.net` occasionally times out from CI runners. Without
pinning, a failed PPA fetch makes `apt-get update` quietly skip the PPA
and `apt-get install fish` fall back to Ubuntu's older `fish` from
noble/universe (e.g. 3.7.0), which then trips `test_fish_version`'s
`>= 4.0.2` floor. This produced spurious red builds with no signal that
the install path actually used a different source than the previous
green build.

Add an APT preferences entry that pins both `fish` and `fish-common` to
`origin ppa.launchpadcontent.net` with priority 1001, so apt either
installs from the PPA or fails outright. Wrap the `apt-get update + install`
in a small retry loop so transient PPA timeouts (the actual root cause)
auto-recover.