### PR TITLE
tests: split mockers.py and rename mockers_git_repository.py

### DIFF
--- a/ci/checks/prohibit-sleep-in-python.sh
+++ b/ci/checks/prohibit-sleep-in-python.sh
@@ -2,12 +2,12 @@
 
 set -e -o pipefail -u
 
-if git grep -n -P '\bsleep\(' -- '*.py' ':!tests/mockers.py'; then
+if git grep -n -P '\bsleep\(' -- '*.py' ':!tests/git_repository.py'; then
   echo
-  echo 'Do not use sleep() in Python code outside of tests/mockers.py.'
+  echo 'Do not use sleep() in Python code outside of tests/git_repository.py.'
   echo 'Real-time sleeps make tests slow and flaky (e.g. clock slewing on macOS CI'
   echo 'runners can leave consecutive commits on the same committer-second).'
   echo 'If you need to ensure two consecutive commits land on different'
-  echo 'committer-seconds, use tests.mockers.wait_to_bump_commit_timestamp instead.'
+  echo 'committer-seconds, use tests.git_repository.wait_to_bump_commit_timestamp instead.'
   exit 1
 fi

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
 import pytest
 
 # See https://docs.pytest.org/en/latest/how-to/writing_plugins.html#assertion-rewriting
-pytest.register_assert_rewrite("tests.mockers")
+pytest.register_assert_rewrite("tests.cli_runner")

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -27,11 +27,11 @@ class BaseTest:
             mocker.patch(symbol, target)
 
     def teardown_method(self) -> None:
+        # Chdir into an empty directory which is NOT a git repository.
+        # This way, no test can accidentally use a repository set up by a previous test.
+        os.chdir(BaseTest.empty_temp_dir)
+
         if len(self.expected_mock_methods) == 1:
             raise Exception("Patched method has never been called: " + list(self.expected_mock_methods)[0])
         elif len(self.expected_mock_methods) > 1:
             raise Exception("Patched methods have never been called: " + ", ".join(self.expected_mock_methods))
-
-        # Chdir into an empty directory which is NOT a git repository.
-        # This way, no test can accidentally use a repository set up by a previous test.
-        os.chdir(BaseTest.empty_temp_dir)

--- a/tests/cli_runner.py
+++ b/tests/cli_runner.py
@@ -1,0 +1,79 @@
+import io
+import re
+import textwrap
+from contextlib import redirect_stderr, redirect_stdout
+from typing import Iterable, Optional, Tuple, Type
+
+from git_machete import cli, utils
+from git_machete.utils import MacheteException
+
+
+def launch_command_capturing_output_and_exception(*cmd_and_args: str) -> Tuple[Optional[str], Optional[BaseException]]:
+    with io.StringIO() as out:
+        try:
+            with redirect_stdout(out):
+                with redirect_stderr(out):
+                    utils.displayed_warnings = set()
+                    cli.launch(list(cmd_and_args))
+                output = out.getvalue()
+                return output, None
+        except BaseException as e:
+            output = out.getvalue()
+            return output, e
+
+
+def launch_command(*cmd_and_args: str) -> str:
+    with io.StringIO() as out:
+        with redirect_stdout(out):
+            with redirect_stderr(out):
+                utils.displayed_warnings = set()
+                cli.launch(list(cmd_and_args))
+        output = out.getvalue()
+        return output
+
+
+def strip_trailing_spaces(text: str) -> str:
+    return re.sub(" +$", "", text, flags=re.MULTILINE)
+
+
+def assert_success(cmd_and_args: Iterable[str], expected_result: str) -> None:
+    if expected_result.startswith("\n"):
+        # removeprefix is only available since Python 3.9
+        expected_result = expected_result[1:]
+    expected_result = textwrap.dedent(expected_result)
+    actual_result = strip_trailing_spaces(textwrap.dedent(launch_command(*cmd_and_args)))
+    assert actual_result == expected_result
+
+
+def assert_failure(cmd_and_args: Iterable[str], expected_message: str, expected_type: Type[BaseException] = MacheteException,
+                   expected_output: Optional[str] = None) -> None:
+    if expected_message.startswith("\n"):
+        # removeprefix is only available since Python 3.9
+        expected_message = expected_message[1:]
+    expected_message = textwrap.dedent(expected_message)
+
+    if expected_output is not None:
+        if expected_output.startswith("\n"):
+            expected_output = expected_output[1:]
+        expected_output = textwrap.dedent(expected_output)
+
+    output, e = launch_command_capturing_output_and_exception(*cmd_and_args)
+    assert e is not None, f"Expected {expected_type.__name__} but no exception was raised"
+    assert isinstance(e, expected_type), f"Expected {expected_type.__name__} but got {type(e).__name__}: {e}"
+    error_message = strip_trailing_spaces(e.msg)  # type: ignore[attr-defined]
+    assert error_message == expected_message
+
+    if expected_output is not None:
+        actual_output = strip_trailing_spaces(textwrap.dedent(output or ""))
+        assert actual_output == expected_output
+
+
+def read_branch_layout_file() -> str:
+    with open(".git/machete") as def_file:
+        return def_file.read()
+
+
+def rewrite_branch_layout_file(new_body: str) -> None:
+    new_body = textwrap.dedent(new_body)
+    with open(".git/machete", 'w') as def_file:
+        def_file.writelines(new_body)

--- a/tests/completion_e2e/test_completion_e2e.py
+++ b/tests/completion_e2e/test_completion_e2e.py
@@ -4,10 +4,11 @@ from typing import Dict
 
 import pytest
 
-from tests.mockers import popen, rewrite_branch_layout_file
-from tests.mockers_git_repository import (check_out, commit, create_repo,
-                                          get_current_commit_hash, new_branch,
-                                          set_git_config_key)
+from tests.cli_runner import rewrite_branch_layout_file
+from tests.git_repository import (check_out, commit, create_repo,
+                                  get_current_commit_hash, new_branch,
+                                  set_git_config_key)
+from tests.shell import popen
 
 test_cases: Dict[str, str] = {
     "git machete ":

--- a/tests/git_repository.py
+++ b/tests/git_repository.py
@@ -1,11 +1,12 @@
 import os
 import re
 import subprocess
+import time
 from os import mkdir
 from tempfile import mkdtemp
 from typing import List, Optional, Tuple
 
-from tests.mockers import execute, popen, write_to_file
+from tests.shell import execute, popen, write_to_file
 
 
 def create_repo(name: str = "local", bare: bool = False, switch_dir_to_new_repo: bool = True) -> str:
@@ -168,3 +169,14 @@ def add_worktree(branch: str) -> str:
 def get_worktree_dirs() -> List[str]:
     lines = popen("git worktree list --porcelain").splitlines()
     return [line[len("worktree "):] for line in lines if line.startswith("worktree ")]
+
+
+def wait_to_bump_commit_timestamp() -> None:
+    # Git committer dates have 1-second resolution, so to guarantee that two
+    # consecutive commits land on different committer-seconds we need to wait
+    # strictly more than 1 second of wall-clock time. A plain `time.sleep(1)`
+    # is not enough in practice: on macOS CI runners NTP can slew the wall
+    # clock backwards during the sleep, leaving both commits on the same
+    # committer-second and causing flaky `DIVERGED_FROM_AND_OLDER_THAN_REMOTE`
+    # vs. `DIVERGED_FROM_AND_NEWER_THAN_REMOTE` detection.
+    time.sleep(1.5)

--- a/tests/mockers.py
+++ b/tests/mockers.py
@@ -1,16 +1,10 @@
-import io
 import os
-import re
 import subprocess
 import sys
-import textwrap
-import time
-from contextlib import (AbstractContextManager, contextmanager,
-                        redirect_stderr, redirect_stdout)
-from typing import Any, Callable, Iterable, Iterator, Optional, Tuple, Type
+from contextlib import AbstractContextManager, contextmanager
+from typing import Any, Callable, Iterator, Tuple
 
-from git_machete import cli, utils
-from git_machete.utils import MacheteException, PopenResult
+from git_machete.utils import PopenResult
 
 
 @contextmanager
@@ -35,77 +29,6 @@ def fixed_author_and_committer_date_in_past() -> AbstractContextManager:  # type
     )
 
 
-def launch_command_capturing_output_and_exception(*cmd_and_args: str) -> Tuple[Optional[str], Optional[BaseException]]:
-    with io.StringIO() as out:
-        try:
-            with redirect_stdout(out):
-                with redirect_stderr(out):
-                    utils.displayed_warnings = set()
-                    cli.launch(list(cmd_and_args))
-                output = out.getvalue()
-                return output, None
-        except BaseException as e:
-            output = out.getvalue()
-            return output, e
-
-
-def launch_command(*cmd_and_args: str) -> str:
-    with io.StringIO() as out:
-        with redirect_stdout(out):
-            with redirect_stderr(out):
-                utils.displayed_warnings = set()
-                cli.launch(list(cmd_and_args))
-        output = out.getvalue()
-        return output
-
-
-def strip_trailing_spaces(text: str) -> str:
-    return re.sub(" +$", "", text, flags=re.MULTILINE)
-
-
-def assert_success(cmd_and_args: Iterable[str], expected_result: str) -> None:
-    if expected_result.startswith("\n"):
-        # removeprefix is only available since Python 3.9
-        expected_result = expected_result[1:]
-    expected_result = textwrap.dedent(expected_result)
-    actual_result = strip_trailing_spaces(textwrap.dedent(launch_command(*cmd_and_args)))
-    assert actual_result == expected_result
-
-
-def assert_failure(cmd_and_args: Iterable[str], expected_message: str, expected_type: Type[BaseException] = MacheteException,
-                   expected_output: Optional[str] = None) -> None:
-    if expected_message.startswith("\n"):
-        # removeprefix is only available since Python 3.9
-        expected_message = expected_message[1:]
-    expected_message = textwrap.dedent(expected_message)
-
-    if expected_output is not None:
-        if expected_output.startswith("\n"):
-            expected_output = expected_output[1:]
-        expected_output = textwrap.dedent(expected_output)
-
-    output, e = launch_command_capturing_output_and_exception(*cmd_and_args)
-    assert e is not None, f"Expected {expected_type.__name__} but no exception was raised"
-    assert isinstance(e, expected_type), f"Expected {expected_type.__name__} but got {type(e).__name__}: {e}"
-    error_message = strip_trailing_spaces(e.msg)  # type: ignore[attr-defined]
-    assert error_message == expected_message
-
-    if expected_output is not None:
-        actual_output = strip_trailing_spaces(textwrap.dedent(output or ""))
-        assert actual_output == expected_output
-
-
-def read_branch_layout_file() -> str:
-    with open(".git/machete") as def_file:
-        return def_file.read()
-
-
-def rewrite_branch_layout_file(new_body: str) -> None:
-    new_body = textwrap.dedent(new_body)
-    with open(".git/machete", 'w') as def_file:
-        def_file.writelines(new_body)
-
-
 def mock__popen_cmd_with_fixed_results(*results: Tuple[int, str, str]) -> Callable[..., PopenResult]:
     gen = (i for i in results)
 
@@ -115,15 +38,30 @@ def mock__popen_cmd_with_fixed_results(*results: Tuple[int, str, str]) -> Callab
 
 
 def mock__run_cmd_and_forward_stdout(cmd: str, *args: str, **kwargs: Any) -> int:
-    """Execute command in the new subprocess but capture together process's stdout and print it into sys.stdout.
-    This sys.stdout is later being redirected via the `redirect_stdout` in `launch_command()` and gets returned by this function.
-    Below is shown the chain of function calls that presents this mechanism:
-    1. `launch_command()` gets executed in the test case and evokes `cli.launch()`.
-    2. `cli.launch()` executes `utils.run_cmd()` but `utils.run_cmd()` is being mocked by `mock_run_cmd_and_forward_stdout()`
-       so the command's stdout and stderr is loaded into sys.stdout.
-    3. After command execution we go back through `cli.launch()`(2) to `launch_command()`(1) which redirects just updated sys.stdout
-       into variable and returns it."""
-    # capture_output argument is only supported since Python 3.7
+    """Drop-in replacement for `git_machete.utils._run_cmd` that makes a
+    subprocess's stdout observable to the `redirect_stdout(...)` context
+    manager used by `launch_command()` in tests.
+
+    The real `_run_cmd` runs `subprocess.run(..., stdout=None, stderr=None)`,
+    so the subprocess inherits the parent's file descriptors and writes
+    straight to FD 1 / FD 2. `contextlib.redirect_stdout` only rebinds the
+    Python-level `sys.stdout` object and cannot intercept bytes written to
+    FD 1 by a subprocess - which means commands run via `_run_cmd` (e.g.
+    `git diff`, `git log`) would otherwise produce no output that the test
+    helpers can assert on.
+
+    This mock works around that by:
+      1. capturing the subprocess's stdout via `stdout=subprocess.PIPE`,
+      2. decoding it and re-emitting it through `sys.stdout.write(...)`,
+         which IS observable by `redirect_stdout`.
+
+    Stderr is intentionally left inherited (`stderr=None`); subprocess error
+    output still flows to the real stderr.
+
+    Returns the subprocess's exit code, matching the real `_run_cmd`'s
+    contract. The captured stdout itself surfaces in tests indirectly:
+    `launch_command()` returns whatever `redirect_stdout` accumulated, which
+    now includes what this mock wrote into `sys.stdout`."""
     completed_process: subprocess.CompletedProcess[bytes] = subprocess.run(
         [cmd] + list(args), stdout=subprocess.PIPE, stderr=None, **kwargs)
     sys.stdout.write(completed_process.stdout.decode('utf-8'))
@@ -142,47 +80,3 @@ def mock_input_returning(*answers: str) -> Callable[[str], str]:
         print(msg)
         return next(gen)
     return inner
-
-
-def execute_ignoring_exit_code(command: str) -> None:
-    subprocess.call(command, shell=True)
-
-
-def set_file_executable(file_name: str) -> None:
-    os.chmod(file_name, 0o700)
-
-
-def wait_to_bump_commit_timestamp() -> None:
-    # Git committer dates have 1-second resolution, so to guarantee that two
-    # consecutive commits land on different committer-seconds we need to wait
-    # strictly more than 1 second of wall-clock time. A plain `time.sleep(1)`
-    # is not enough in practice: on macOS CI runners NTP can slew the wall
-    # clock backwards during the sleep, leaving both commits on the same
-    # committer-second and causing flaky `DIVERGED_FROM_AND_OLDER_THAN_REMOTE`
-    # vs. `DIVERGED_FROM_AND_NEWER_THAN_REMOTE` detection.
-    time.sleep(1.5)
-
-
-def remove_directory(file_path: str) -> None:
-    execute(f'rm -rf "./{file_path}"')
-
-
-def read_file(file_name: str) -> str:
-    with open(file_name) as f:
-        return f.read()
-
-
-def execute(command: str) -> None:
-    subprocess.check_call(command, shell=True)
-
-
-def write_to_file(file_path: str, file_content: str) -> None:
-    dirname = os.path.dirname(file_path)
-    if dirname:
-        os.makedirs(dirname, exist_ok=True)
-    with open(file_path, 'w') as f:
-        f.write(file_content)
-
-
-def popen(command: str) -> str:
-    return subprocess.check_output(command, shell=True, timeout=5).decode("utf-8").strip()

--- a/tests/shell.py
+++ b/tests/shell.py
@@ -1,0 +1,35 @@
+import os
+import subprocess
+
+
+def execute(command: str) -> None:
+    subprocess.check_call(command, shell=True)
+
+
+def execute_ignoring_exit_code(command: str) -> None:
+    subprocess.call(command, shell=True)
+
+
+def popen(command: str) -> str:
+    return subprocess.check_output(command, shell=True, timeout=5).decode("utf-8").strip()
+
+
+def read_file(file_name: str) -> str:
+    with open(file_name) as f:
+        return f.read()
+
+
+def write_to_file(file_path: str, file_content: str) -> None:
+    dirname = os.path.dirname(file_path)
+    if dirname:
+        os.makedirs(dirname, exist_ok=True)
+    with open(file_path, 'w') as f:
+        f.write(file_content)
+
+
+def set_file_executable(file_name: str) -> None:
+    os.chmod(file_name, 0o700)
+
+
+def remove_directory(file_path: str) -> None:
+    execute(f'rm -rf "./{file_path}"')

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -2,13 +2,13 @@
 from pytest_mock import MockerFixture
 
 from .base_test import BaseTest
-from .mockers import (assert_failure, assert_success, mock_input_returning,
-                      mock_input_returning_y, read_branch_layout_file,
-                      rewrite_branch_layout_file)
-from .mockers_git_repository import (check_out, commit, create_repo,
-                                     create_repo_with_remote, delete_branch,
-                                     get_commit_hash, get_current_commit_hash,
-                                     new_branch, push)
+from .cli_runner import (assert_failure, assert_success,
+                         read_branch_layout_file, rewrite_branch_layout_file)
+from .git_repository import (check_out, commit, create_repo,
+                             create_repo_with_remote, delete_branch,
+                             get_commit_hash, get_current_commit_hash,
+                             new_branch, push)
+from .mockers import mock_input_returning, mock_input_returning_y
 
 
 class TestAdd(BaseTest):

--- a/tests/test_advance.py
+++ b/tests/test_advance.py
@@ -7,15 +7,14 @@ from git_machete.utils import (ExitCode, FullTerminalAnsiOutputCodes,
                                UnderlyingGitException)
 
 from .base_test import BaseTest
-from .mockers import (assert_failure, assert_success, launch_command,
-                      launch_command_capturing_output_and_exception,
-                      mock_input_returning, mock_input_returning_y,
-                      rewrite_branch_layout_file,
-                      wait_to_bump_commit_timestamp)
-from .mockers_git_repository import (check_out, commit, create_repo,
-                                     create_repo_with_remote, fetch,
-                                     get_commit_hash, get_current_commit_hash,
-                                     new_branch, push, reset_to)
+from .cli_runner import (assert_failure, assert_success, launch_command,
+                         launch_command_capturing_output_and_exception,
+                         rewrite_branch_layout_file)
+from .git_repository import (check_out, commit, create_repo,
+                             create_repo_with_remote, fetch, get_commit_hash,
+                             get_current_commit_hash, new_branch, push,
+                             reset_to, wait_to_bump_commit_timestamp)
+from .mockers import mock_input_returning, mock_input_returning_y
 
 
 class TestAdvance(BaseTest):

--- a/tests/test_anno.py
+++ b/tests/test_anno.py
@@ -2,11 +2,10 @@ from pytest_mock import MockerFixture
 
 from . import mockers_github, mockers_gitlab
 from .base_test import BaseTest
-from .mockers import (assert_failure, assert_success, launch_command,
-                      rewrite_branch_layout_file)
-from .mockers_git_repository import (add_remote, check_out, commit,
-                                     create_repo, create_repo_with_remote,
-                                     new_branch)
+from .cli_runner import (assert_failure, assert_success, launch_command,
+                         rewrite_branch_layout_file)
+from .git_repository import (add_remote, check_out, commit, create_repo,
+                             create_repo_with_remote, new_branch)
 from .mockers_github import (MockGitHubAPIState,
                              mock_github_token_for_domain_fake)
 from .mockers_gitlab import (MockGitLabAPIState,

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,11 +1,12 @@
 from pytest_mock import MockerFixture
 
 from .base_test import BaseTest
-from .mockers import (assert_success, launch_command, mock_input_returning_y,
-                      read_branch_layout_file, rewrite_branch_layout_file)
-from .mockers_git_repository import (add_remote, check_out, commit,
-                                     create_repo, create_repo_with_remote,
-                                     get_local_branches, new_branch, push)
+from .cli_runner import (assert_success, launch_command,
+                         read_branch_layout_file, rewrite_branch_layout_file)
+from .git_repository import (add_remote, check_out, commit, create_repo,
+                             create_repo_with_remote, get_local_branches,
+                             new_branch, push)
+from .mockers import mock_input_returning_y
 from .mockers_github import mock_github_token_for_domain_none
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,15 +9,15 @@ from git_machete.cli import alias_by_command, main
 from git_machete.utils import ExitCode
 
 from .base_test import BaseTest
-from .mockers import launch_command_capturing_output_and_exception
-from .mockers_git_repository import create_repo
+from .cli_runner import launch_command_capturing_output_and_exception
+from .git_repository import create_repo
 
 
 def assert_argparse_failure(cmd_and_args: List[str], expected_output: str) -> None:
     """Run the CLI and assert it exits with `ARGUMENT_ERROR` after emitting
     exactly `expected_output` (a literal multi-line string) on stdout/stderr.
 
-    The shared `assert_failure` helper from `tests.mockers` reads the failure
+    The shared `assert_failure` helper from `tests.cli_runner` reads the failure
     text from `MacheteException.msg`, but argparse failures bubble up as
     `SystemExit` (which carries only an exit code) with the actual message
     written to stdout/stderr - hence this dedicated helper for `test_cli`.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,9 +5,9 @@ from git_machete.client.base import MacheteClient
 from git_machete.git_operations import GitContext, LocalBranchShortName
 
 from .base_test import BaseTest
-from .mockers import read_branch_layout_file, rewrite_branch_layout_file
-from .mockers_git_repository import (check_out, commit,
-                                     create_repo_with_remote, new_branch, push)
+from .cli_runner import read_branch_layout_file, rewrite_branch_layout_file
+from .git_repository import (check_out, commit, create_repo_with_remote,
+                             new_branch, push)
 
 
 class TestClient(BaseTest):

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,6 +1,6 @@
 
 from .base_test import BaseTest
-from .mockers import launch_command
+from .cli_runner import launch_command
 
 
 # These are mostly smoke-tests which also provide coverage.

--- a/tests/test_delete_unmanaged.py
+++ b/tests/test_delete_unmanaged.py
@@ -1,15 +1,15 @@
 from pytest_mock import MockerFixture
 
 from .base_test import BaseTest
-from .mockers import (assert_success, execute,
-                      fixed_author_and_committer_date_in_past, launch_command,
-                      mock__run_cmd_and_forward_stdout, mock_input_returning,
-                      rewrite_branch_layout_file)
-from .mockers_git_repository import (add_file_and_commit, amend_commit,
-                                     check_out, commit, create_repo,
-                                     create_repo_with_remote,
-                                     get_local_branches, new_branch, push,
-                                     set_git_config_key)
+from .cli_runner import (assert_success, launch_command,
+                         rewrite_branch_layout_file)
+from .git_repository import (add_file_and_commit, amend_commit, check_out,
+                             commit, create_repo, create_repo_with_remote,
+                             get_local_branches, new_branch, push,
+                             set_git_config_key)
+from .mockers import (fixed_author_and_committer_date_in_past,
+                      mock__run_cmd_and_forward_stdout, mock_input_returning)
+from .shell import execute
 
 
 class TestDeleteUnmanaged(BaseTest):

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,10 +1,11 @@
 from pytest_mock import MockerFixture
 
 from .base_test import BaseTest
-from .mockers import (assert_success, mock__run_cmd_and_forward_stdout,
-                      write_to_file)
-from .mockers_git_repository import (add_file_and_commit,
-                                     create_repo_with_remote, new_branch, push)
+from .cli_runner import assert_success
+from .git_repository import (add_file_and_commit, create_repo_with_remote,
+                             new_branch, push)
+from .mockers import mock__run_cmd_and_forward_stdout
+from .shell import write_to_file
 
 
 class TestDiff(BaseTest):

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -7,12 +7,12 @@ from pytest_mock import MockerFixture
 from git_machete.utils import FullTerminalAnsiOutputCodes
 
 from .base_test import BaseTest
-from .mockers import (assert_failure, assert_success, launch_command,
-                      mock_input_returning, overridden_environment, read_file,
-                      rewrite_branch_layout_file)
-from .mockers_git_repository import (check_out, commit, create_repo,
-                                     create_repo_with_remote, merge,
-                                     new_branch, push)
+from .cli_runner import (assert_failure, assert_success, launch_command,
+                         rewrite_branch_layout_file)
+from .git_repository import (check_out, commit, create_repo,
+                             create_repo_with_remote, merge, new_branch, push)
+from .mockers import mock_input_returning, overridden_environment
+from .shell import read_file
 
 
 class TestDiscover(BaseTest):

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -4,9 +4,10 @@ import pytest
 from pytest_mock import MockerFixture
 
 from .base_test import BaseTest
-from .mockers import (assert_failure, assert_success, launch_command,
-                      overridden_environment, read_file)
-from .mockers_git_repository import create_repo, set_git_config_key
+from .cli_runner import assert_failure, assert_success, launch_command
+from .git_repository import create_repo, set_git_config_key
+from .mockers import overridden_environment
+from .shell import read_file
 
 dummy_editor = "sh -c 'echo foo > $1' 'ignored_$0'"
 

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -5,9 +5,10 @@ from tempfile import mkdtemp
 from git_machete.utils import UnderlyingGitException
 
 from .base_test import BaseTest
-from .mockers import assert_failure, execute, launch_command
-from .mockers_git_repository import (commit, create_repo, get_git_version,
-                                     new_branch, set_git_config_key)
+from .cli_runner import assert_failure, launch_command
+from .git_repository import (commit, create_repo, get_git_version, new_branch,
+                             set_git_config_key)
+from .shell import execute
 
 
 class TestFile(BaseTest):

--- a/tests/test_fork_point.py
+++ b/tests/test_fork_point.py
@@ -1,15 +1,15 @@
 import os
 
 from .base_test import BaseTest
-from .mockers import (assert_failure, assert_success, execute,
-                      fixed_author_and_committer_date_in_past, launch_command,
-                      remove_directory, rewrite_branch_layout_file)
-from .mockers_git_repository import (add_remote, check_out, commit,
-                                     create_repo, create_repo_with_remote,
-                                     delete_branch, fetch, get_commit_hash,
-                                     get_current_commit_hash, new_branch,
-                                     new_orphan_branch, pull, push, reset_to,
-                                     set_git_config_key)
+from .cli_runner import (assert_failure, assert_success, launch_command,
+                         rewrite_branch_layout_file)
+from .git_repository import (add_remote, check_out, commit, create_repo,
+                             create_repo_with_remote, delete_branch, fetch,
+                             get_commit_hash, get_current_commit_hash,
+                             new_branch, new_orphan_branch, pull, push,
+                             reset_to, set_git_config_key)
+from .mockers import fixed_author_and_committer_date_in_past
+from .shell import execute, remove_directory
 
 
 class TestForkPoint(BaseTest):

--- a/tests/test_git_operations.py
+++ b/tests/test_git_operations.py
@@ -5,12 +5,11 @@ from git_machete.git_operations import (AnyBranchName, AnyRevision,
                                         LocalBranchShortName)
 
 from .base_test import BaseTest
-from .mockers import read_file, write_to_file
-from .mockers_git_repository import (add_worktree, check_out, commit,
-                                     create_repo, get_current_commit_hash,
-                                     get_git_version, is_ancestor_or_equal,
-                                     new_branch, new_orphan_branch,
-                                     set_git_config_key)
+from .git_repository import (add_worktree, check_out, commit, create_repo,
+                             get_current_commit_hash, get_git_version,
+                             is_ancestor_or_equal, new_branch,
+                             new_orphan_branch, set_git_config_key)
+from .shell import read_file, write_to_file
 
 
 class TestGitOperations(BaseTest):
@@ -277,7 +276,7 @@ class TestGitOperations(BaseTest):
         # This tests the bug fix where multiple detached HEADs would overwrite each other with None key
         from tempfile import mkdtemp
 
-        from .mockers import execute
+        from .shell import execute
         feature3_worktree = mkdtemp()
         execute(f"git worktree add -f --detach {feature3_worktree} feature-3")
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -8,16 +8,15 @@ from pytest_mock import MockerFixture
 from git_machete.code_hosting import OrganizationAndRepository
 from git_machete.github import GitHubClient, GitHubToken
 from tests.base_test import BaseTest
-from tests.mockers import (assert_failure, assert_success, launch_command,
-                           mock__popen_cmd_with_fixed_results,
-                           mock_input_returning_y, overridden_environment,
-                           rewrite_branch_layout_file)
+from tests.cli_runner import (assert_failure, assert_success, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (add_remote, check_out, commit, create_repo,
+                                  create_repo_with_remote, delete_branch,
+                                  new_branch, push, set_git_config_key,
+                                  unset_git_config_key)
+from tests.mockers import (mock__popen_cmd_with_fixed_results,
+                           mock_input_returning_y, overridden_environment)
 from tests.mockers_code_hosting import mock_from_url, mock_shutil_which
-from tests.mockers_git_repository import (add_remote, check_out, commit,
-                                          create_repo, create_repo_with_remote,
-                                          delete_branch, new_branch, push,
-                                          set_git_config_key,
-                                          unset_git_config_key)
 from tests.mockers_github import (MockGitHubAPIState,
                                   mock_github_token_for_domain_fake,
                                   mock_github_token_for_domain_none,

--- a/tests/test_github_anno_prs.py
+++ b/tests/test_github_anno_prs.py
@@ -1,15 +1,13 @@
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.mockers import (assert_failure, assert_success, launch_command,
-                           rewrite_branch_layout_file,
-                           wait_to_bump_commit_timestamp)
-from tests.mockers_git_repository import (add_remote, amend_commit, check_out,
-                                          commit, create_repo,
-                                          create_repo_with_remote,
-                                          delete_branch, new_branch, push,
-                                          remove_remote, reset_to,
-                                          set_git_config_key)
+from tests.cli_runner import (assert_failure, assert_success, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (add_remote, amend_commit, check_out, commit,
+                                  create_repo, create_repo_with_remote,
+                                  delete_branch, new_branch, push,
+                                  remove_remote, reset_to, set_git_config_key,
+                                  wait_to_bump_commit_timestamp)
 from tests.mockers_github import (MockGitHubAPIState,
                                   mock_github_token_for_domain_fake,
                                   mock_pr_json, mock_urlopen)

--- a/tests/test_github_checkout_prs.py
+++ b/tests/test_github_checkout_prs.py
@@ -6,18 +6,18 @@ from pytest_mock import MockerFixture
 from git_machete.code_hosting import OrganizationAndRepository
 from git_machete.github import GitHubClient
 from tests.base_test import BaseTest
-from tests.mockers import (assert_failure, assert_success, execute,
-                           launch_command, rewrite_branch_layout_file)
+from tests.cli_runner import (assert_failure, assert_success, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (add_remote, check_out, commit, create_repo,
+                                  create_repo_with_remote, delete_branch,
+                                  new_branch, push, remove_remote,
+                                  set_git_config_key, set_remote_url)
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_git_repository import (add_remote, check_out, commit,
-                                          create_repo, create_repo_with_remote,
-                                          delete_branch, new_branch, push,
-                                          remove_remote, set_git_config_key,
-                                          set_remote_url)
 from tests.mockers_github import (MockGitHubAPIState,
                                   mock_github_token_for_domain_fake,
                                   mock_github_token_for_domain_none,
                                   mock_pr_json, mock_urlopen)
+from tests.shell import execute
 
 
 class TestGitHubCheckoutPRs(BaseTest):

--- a/tests/test_github_create_pr.py
+++ b/tests/test_github_create_pr.py
@@ -4,22 +4,22 @@ import textwrap
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.mockers import (assert_failure, assert_success, execute,
-                           fixed_author_and_committer_date_in_past,
-                           launch_command, mock_input_returning,
-                           mock_input_returning_y, rewrite_branch_layout_file,
-                           wait_to_bump_commit_timestamp, write_to_file)
+from tests.cli_runner import (assert_failure, assert_success, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (add_remote, amend_commit, check_out, commit,
+                                  create_repo, create_repo_with_remote,
+                                  delete_branch, delete_remote_branch,
+                                  new_branch, push, remove_remote, reset_to,
+                                  set_git_config_key,
+                                  wait_to_bump_commit_timestamp)
+from tests.mockers import (fixed_author_and_committer_date_in_past,
+                           mock_input_returning, mock_input_returning_y)
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_git_repository import (add_remote, amend_commit, check_out,
-                                          commit, create_repo,
-                                          create_repo_with_remote,
-                                          delete_branch, delete_remote_branch,
-                                          new_branch, push, remove_remote,
-                                          reset_to, set_git_config_key)
 from tests.mockers_github import (MockGitHubAPIState,
                                   mock_github_token_for_domain_fake,
                                   mock_github_token_for_domain_none,
                                   mock_pr_json, mock_urlopen)
+from tests.shell import execute, write_to_file
 
 
 class TestGitHubCreatePR(BaseTest):

--- a/tests/test_github_restack_pr.py
+++ b/tests/test_github_restack_pr.py
@@ -3,13 +3,13 @@ import textwrap
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.mockers import (assert_failure, assert_success,
-                           fixed_author_and_committer_date_in_past,
-                           rewrite_branch_layout_file)
+from tests.cli_runner import (assert_failure, assert_success,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (amend_commit, commit,
+                                  create_repo_with_remote, new_branch, push,
+                                  reset_to, set_git_config_key)
+from tests.mockers import fixed_author_and_committer_date_in_past
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_git_repository import (amend_commit, commit,
-                                          create_repo_with_remote, new_branch,
-                                          push, reset_to, set_git_config_key)
 from tests.mockers_github import (MockGitHubAPIState,
                                   mock_github_token_for_domain_fake,
                                   mock_pr_json, mock_urlopen)

--- a/tests/test_github_retarget_pr.py
+++ b/tests/test_github_retarget_pr.py
@@ -3,14 +3,13 @@ import textwrap
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.mockers import (assert_failure, assert_success, launch_command,
-                           rewrite_branch_layout_file)
+from tests.cli_runner import (assert_failure, assert_success, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (add_remote, check_out, commit, create_repo,
+                                  create_repo_with_remote, new_branch, push,
+                                  remove_remote, set_git_config_key,
+                                  unset_git_config_key)
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_git_repository import (add_remote, check_out, commit,
-                                          create_repo, create_repo_with_remote,
-                                          new_branch, push, remove_remote,
-                                          set_git_config_key,
-                                          unset_git_config_key)
 from tests.mockers_github import (MockGitHubAPIState,
                                   mock_github_token_for_domain_fake,
                                   mock_pr_json, mock_urlopen)

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -1,12 +1,12 @@
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.mockers import (assert_success, launch_command,
-                           mock_input_returning_y, rewrite_branch_layout_file)
+from tests.cli_runner import (assert_success, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (check_out, commit, create_repo_with_remote,
+                                  get_local_branches, new_branch, push)
+from tests.mockers import mock_input_returning_y
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_git_repository import (check_out, commit,
-                                          create_repo_with_remote,
-                                          get_local_branches, new_branch, push)
 from tests.mockers_github import (MockGitHubAPIState,
                                   mock_github_token_for_domain_fake,
                                   mock_pr_json, mock_urlopen)

--- a/tests/test_github_update_pr_descriptions.py
+++ b/tests/test_github_update_pr_descriptions.py
@@ -4,13 +4,12 @@ from typing import Any, Dict, List
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.mockers import (assert_failure, assert_success, launch_command,
-                           rewrite_branch_layout_file)
+from tests.cli_runner import (assert_failure, assert_success, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (check_out, commit, create_repo_with_remote,
+                                  delete_branch, new_branch, push,
+                                  set_git_config_key)
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_git_repository import (check_out, commit,
-                                          create_repo_with_remote,
-                                          delete_branch, new_branch, push,
-                                          set_git_config_key)
 from tests.mockers_github import (MockGitHubAPIState,
                                   mock_github_token_for_domain_fake,
                                   mock_github_token_for_domain_none,

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -7,16 +7,15 @@ from pytest_mock import MockerFixture
 from git_machete.code_hosting import OrganizationAndRepository
 from git_machete.gitlab import GitLabClient, GitLabToken
 from tests.base_test import BaseTest
-from tests.mockers import (assert_failure, assert_success, launch_command,
-                           mock__popen_cmd_with_fixed_results,
-                           mock_input_returning_y, overridden_environment,
-                           rewrite_branch_layout_file)
+from tests.cli_runner import (assert_failure, assert_success, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (add_remote, check_out, commit, create_repo,
+                                  create_repo_with_remote, delete_branch,
+                                  new_branch, push, set_git_config_key,
+                                  unset_git_config_key)
+from tests.mockers import (mock__popen_cmd_with_fixed_results,
+                           mock_input_returning_y, overridden_environment)
 from tests.mockers_code_hosting import mock_from_url, mock_shutil_which
-from tests.mockers_git_repository import (add_remote, check_out, commit,
-                                          create_repo, create_repo_with_remote,
-                                          delete_branch, new_branch, push,
-                                          set_git_config_key,
-                                          unset_git_config_key)
 from tests.mockers_gitlab import (MockGitLabAPIState,
                                   mock_gitlab_token_for_domain_fake,
                                   mock_gitlab_token_for_domain_none,

--- a/tests/test_gitlab_anno_mrs.py
+++ b/tests/test_gitlab_anno_mrs.py
@@ -1,15 +1,13 @@
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.mockers import (assert_failure, assert_success, launch_command,
-                           rewrite_branch_layout_file,
-                           wait_to_bump_commit_timestamp)
-from tests.mockers_git_repository import (add_remote, amend_commit, check_out,
-                                          commit, create_repo,
-                                          create_repo_with_remote,
-                                          delete_branch, new_branch, push,
-                                          remove_remote, reset_to,
-                                          set_git_config_key)
+from tests.cli_runner import (assert_failure, assert_success, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (add_remote, amend_commit, check_out, commit,
+                                  create_repo, create_repo_with_remote,
+                                  delete_branch, new_branch, push,
+                                  remove_remote, reset_to, set_git_config_key,
+                                  wait_to_bump_commit_timestamp)
 from tests.mockers_gitlab import (MockGitLabAPIState,
                                   mock_gitlab_token_for_domain_fake,
                                   mock_mr_json, mock_urlopen)

--- a/tests/test_gitlab_checkout_mrs.py
+++ b/tests/test_gitlab_checkout_mrs.py
@@ -6,17 +6,18 @@ from pytest_mock import MockerFixture
 from git_machete.code_hosting import OrganizationAndRepository
 from git_machete.gitlab import GitLabClient
 from tests.base_test import BaseTest
-from tests.mockers import (assert_failure, assert_success, execute,
-                           launch_command, rewrite_branch_layout_file)
+from tests.cli_runner import (assert_failure, assert_success, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (add_remote, check_out, commit, create_repo,
+                                  create_repo_with_remote, delete_branch,
+                                  new_branch, push, set_git_config_key,
+                                  set_remote_url)
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_git_repository import (add_remote, check_out, commit,
-                                          create_repo, create_repo_with_remote,
-                                          delete_branch, new_branch, push,
-                                          set_git_config_key, set_remote_url)
 from tests.mockers_gitlab import (MockGitLabAPIState,
                                   mock_gitlab_token_for_domain_fake,
                                   mock_gitlab_token_for_domain_none,
                                   mock_mr_json, mock_urlopen)
+from tests.shell import execute
 
 
 class TestGitLabCheckoutMRs(BaseTest):

--- a/tests/test_gitlab_create_mr.py
+++ b/tests/test_gitlab_create_mr.py
@@ -4,22 +4,22 @@ import textwrap
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.mockers import (assert_failure, assert_success, execute,
-                           fixed_author_and_committer_date_in_past,
-                           launch_command, mock_input_returning,
-                           mock_input_returning_y, rewrite_branch_layout_file,
-                           wait_to_bump_commit_timestamp, write_to_file)
+from tests.cli_runner import (assert_failure, assert_success, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (add_remote, amend_commit, check_out, commit,
+                                  create_repo, create_repo_with_remote,
+                                  delete_branch, delete_remote_branch,
+                                  new_branch, push, remove_remote, reset_to,
+                                  set_git_config_key,
+                                  wait_to_bump_commit_timestamp)
+from tests.mockers import (fixed_author_and_committer_date_in_past,
+                           mock_input_returning, mock_input_returning_y)
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_git_repository import (add_remote, amend_commit, check_out,
-                                          commit, create_repo,
-                                          create_repo_with_remote,
-                                          delete_branch, delete_remote_branch,
-                                          new_branch, push, remove_remote,
-                                          reset_to, set_git_config_key)
 from tests.mockers_gitlab import (MockGitLabAPIState,
                                   mock_gitlab_token_for_domain_fake,
                                   mock_gitlab_token_for_domain_none,
                                   mock_mr_json, mock_urlopen)
+from tests.shell import execute, write_to_file
 
 
 class TestGitLabCreateMR(BaseTest):

--- a/tests/test_gitlab_restack_mr.py
+++ b/tests/test_gitlab_restack_mr.py
@@ -3,13 +3,13 @@ import textwrap
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.mockers import (assert_failure, assert_success,
-                           fixed_author_and_committer_date_in_past,
-                           rewrite_branch_layout_file)
+from tests.cli_runner import (assert_failure, assert_success,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (amend_commit, commit,
+                                  create_repo_with_remote, new_branch, push,
+                                  reset_to, set_git_config_key)
+from tests.mockers import fixed_author_and_committer_date_in_past
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_git_repository import (amend_commit, commit,
-                                          create_repo_with_remote, new_branch,
-                                          push, reset_to, set_git_config_key)
 from tests.mockers_gitlab import (MockGitLabAPIState,
                                   mock_gitlab_token_for_domain_fake,
                                   mock_mr_json, mock_urlopen)

--- a/tests/test_gitlab_retarget_mr.py
+++ b/tests/test_gitlab_retarget_mr.py
@@ -3,13 +3,13 @@ import textwrap
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.mockers import (assert_failure, assert_success, launch_command,
-                           rewrite_branch_layout_file)
+from tests.cli_runner import (assert_failure, assert_success, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (add_remote, check_out, commit, create_repo,
+                                  create_repo_with_remote, new_branch, push,
+                                  remove_remote, set_git_config_key,
+                                  set_remote_url)
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_git_repository import (add_remote, check_out, commit,
-                                          create_repo, create_repo_with_remote,
-                                          new_branch, push, remove_remote,
-                                          set_git_config_key, set_remote_url)
 from tests.mockers_gitlab import (MockGitLabAPIState,
                                   mock_gitlab_token_for_domain_fake,
                                   mock_mr_json, mock_urlopen)

--- a/tests/test_gitlab_update_mr_descriptions.py
+++ b/tests/test_gitlab_update_mr_descriptions.py
@@ -4,13 +4,12 @@ from typing import Any, Dict, List
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.mockers import (assert_failure, assert_success, launch_command,
-                           rewrite_branch_layout_file)
+from tests.cli_runner import (assert_failure, assert_success, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (check_out, commit, create_repo_with_remote,
+                                  delete_branch, new_branch, push,
+                                  set_git_config_key)
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_git_repository import (check_out, commit,
-                                          create_repo_with_remote,
-                                          delete_branch, new_branch, push,
-                                          set_git_config_key)
 from tests.mockers_gitlab import (MockGitLabAPIState,
                                   mock_gitlab_token_for_domain_fake,
                                   mock_gitlab_token_for_domain_none,

--- a/tests/test_go.py
+++ b/tests/test_go.py
@@ -3,13 +3,13 @@ import os
 from pytest_mock import MockerFixture
 
 from .base_test import BaseTest
-from .mockers import (assert_failure, assert_success, launch_command,
-                      launch_command_capturing_output_and_exception,
-                      mock_input_returning, rewrite_branch_layout_file)
-from .mockers_git_repository import (add_worktree, check_out, commit,
-                                     create_repo, get_commit_hash,
-                                     get_git_version, new_branch,
-                                     new_orphan_branch)
+from .cli_runner import (assert_failure, assert_success, launch_command,
+                         launch_command_capturing_output_and_exception,
+                         rewrite_branch_layout_file)
+from .git_repository import (add_worktree, check_out, commit, create_repo,
+                             get_commit_hash, get_git_version, new_branch,
+                             new_orphan_branch)
+from .mockers import mock_input_returning
 
 
 class TestGo(BaseTest):

--- a/tests/test_go_interactive.py
+++ b/tests/test_go_interactive.py
@@ -10,8 +10,9 @@ from pytest_mock import MockerFixture
 from git_machete.utils import AnsiInputCodes, FullTerminalAnsiOutputCodes
 
 from .base_test import BaseTest
-from .mockers import assert_failure, launch_command, rewrite_branch_layout_file
-from .mockers_git_repository import check_out, commit, create_repo, new_branch
+from .cli_runner import (assert_failure, launch_command,
+                         rewrite_branch_layout_file)
+from .git_repository import check_out, commit, create_repo, new_branch
 
 AI = AnsiInputCodes
 KEY_ENTER = '\r'

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -4,9 +4,9 @@ from git_machete.cli import commands_and_aliases
 from git_machete.utils import ExitCode
 
 from .base_test import BaseTest
-from .mockers import (launch_command,
-                      launch_command_capturing_output_and_exception)
-from .mockers_git_repository import create_repo, set_git_config_key
+from .cli_runner import (launch_command,
+                         launch_command_capturing_output_and_exception)
+from .git_repository import create_repo, set_git_config_key
 
 
 class TestHelp(BaseTest):

--- a/tests/test_is_managed.py
+++ b/tests/test_is_managed.py
@@ -1,8 +1,8 @@
 import pytest
 
 from .base_test import BaseTest
-from .mockers import launch_command, rewrite_branch_layout_file
-from .mockers_git_repository import check_out, commit, create_repo, new_branch
+from .cli_runner import launch_command, rewrite_branch_layout_file
+from .git_repository import check_out, commit, create_repo, new_branch
 
 
 class TestIsManaged(BaseTest):

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,9 +1,8 @@
 from .base_test import BaseTest
-from .mockers import (assert_failure, assert_success, launch_command,
-                      rewrite_branch_layout_file)
-from .mockers_git_repository import (check_out, commit,
-                                     create_repo_with_remote, delete_branch,
-                                     new_branch, push)
+from .cli_runner import (assert_failure, assert_success, launch_command,
+                         rewrite_branch_layout_file)
+from .git_repository import (check_out, commit, create_repo_with_remote,
+                             delete_branch, new_branch, push)
 
 
 class TestList(BaseTest):

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,10 +1,11 @@
 from pytest_mock import MockerFixture
 
 from .base_test import BaseTest
-from .mockers import (assert_success, fixed_author_and_committer_date_in_past,
-                      launch_command, mock__run_cmd_and_forward_stdout)
-from .mockers_git_repository import (commit, create_repo,
-                                     get_current_commit_hash, new_branch)
+from .cli_runner import assert_success, launch_command
+from .git_repository import (commit, create_repo, get_current_commit_hash,
+                             new_branch)
+from .mockers import (fixed_author_and_committer_date_in_past,
+                      mock__run_cmd_and_forward_stdout)
 
 
 class TestLog(BaseTest):

--- a/tests/test_reapply.py
+++ b/tests/test_reapply.py
@@ -1,8 +1,9 @@
 from .base_test import BaseTest
-from .mockers import (assert_failure, assert_success,
-                      fixed_author_and_committer_date_in_past, launch_command,
-                      overridden_environment, rewrite_branch_layout_file)
-from .mockers_git_repository import check_out, commit, create_repo, new_branch
+from .cli_runner import (assert_failure, assert_success, launch_command,
+                         rewrite_branch_layout_file)
+from .git_repository import check_out, commit, create_repo, new_branch
+from .mockers import (fixed_author_and_committer_date_in_past,
+                      overridden_environment)
 
 
 class TestReapply(BaseTest):

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -1,11 +1,12 @@
 import os
 
 from .base_test import BaseTest
-from .mockers import (assert_failure, assert_success, execute, launch_command,
-                      remove_directory, rewrite_branch_layout_file)
-from .mockers_git_repository import (check_out, commit, create_repo,
-                                     create_repo_with_remote, new_branch,
-                                     new_orphan_branch, pull, push)
+from .cli_runner import (assert_failure, assert_success, launch_command,
+                         rewrite_branch_layout_file)
+from .git_repository import (check_out, commit, create_repo,
+                             create_repo_with_remote, new_branch,
+                             new_orphan_branch, pull, push)
+from .shell import execute, remove_directory
 
 
 class TestShow(BaseTest):

--- a/tests/test_slide_out.py
+++ b/tests/test_slide_out.py
@@ -3,16 +3,15 @@ import pytest
 from pytest_mock import MockerFixture
 
 from .base_test import BaseTest
-from .mockers import (assert_failure, assert_success,
-                      fixed_author_and_committer_date_in_past, launch_command,
-                      mock_input_returning_y, read_branch_layout_file,
-                      read_file, rewrite_branch_layout_file,
-                      set_file_executable, write_to_file)
-from .mockers_git_repository import (amend_commit, check_out, commit,
-                                     create_repo, create_repo_with_remote,
-                                     delete_remote_branch, get_current_branch,
-                                     get_current_commit_hash,
-                                     get_local_branches, new_branch, push)
+from .cli_runner import (assert_failure, assert_success, launch_command,
+                         read_branch_layout_file, rewrite_branch_layout_file)
+from .git_repository import (amend_commit, check_out, commit, create_repo,
+                             create_repo_with_remote, delete_remote_branch,
+                             get_current_branch, get_current_commit_hash,
+                             get_local_branches, new_branch, push)
+from .mockers import (fixed_author_and_committer_date_in_past,
+                      mock_input_returning_y)
+from .shell import read_file, set_file_executable, write_to_file
 
 
 class TestSlideOut(BaseTest):

--- a/tests/test_squash.py
+++ b/tests/test_squash.py
@@ -1,10 +1,11 @@
 
 from .base_test import BaseTest
-from .mockers import (assert_failure, assert_success,
-                      fixed_author_and_committer_date_in_past,
-                      overridden_environment, popen)
-from .mockers_git_repository import (check_out, commit, create_repo,
-                                     get_current_commit_hash, new_branch)
+from .cli_runner import assert_failure, assert_success
+from .git_repository import (check_out, commit, create_repo,
+                             get_current_commit_hash, new_branch)
+from .mockers import (fixed_author_and_committer_date_in_past,
+                      overridden_environment)
+from .shell import popen
 
 
 class TestSquash(BaseTest):

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -8,19 +8,19 @@ from pytest_mock import MockerFixture
 from git_machete.utils import FullTerminalAnsiOutputCodes, abspath_posix
 
 from .base_test import BaseTest
-from .mockers import (assert_failure, assert_success, execute,
-                      execute_ignoring_exit_code,
-                      fixed_author_and_committer_date_in_past, launch_command,
+from .cli_runner import (assert_failure, assert_success, launch_command,
+                         rewrite_branch_layout_file)
+from .git_repository import (add_file_and_commit, add_remote, check_out,
+                             commit, commit_n_times, create_repo,
+                             create_repo_with_remote, delete_branch,
+                             delete_remote_branch, new_branch,
+                             new_orphan_branch, push, set_git_config_key,
+                             unset_git_config_key)
+from .mockers import (fixed_author_and_committer_date_in_past,
                       mock_input_returning, mock_input_returning_y,
-                      overridden_environment, popen, remove_directory,
-                      rewrite_branch_layout_file, set_file_executable,
-                      write_to_file)
-from .mockers_git_repository import (add_file_and_commit, add_remote,
-                                     check_out, commit, commit_n_times,
-                                     create_repo, create_repo_with_remote,
-                                     delete_branch, delete_remote_branch,
-                                     new_branch, new_orphan_branch, push,
-                                     set_git_config_key, unset_git_config_key)
+                      overridden_environment)
+from .shell import (execute, execute_ignoring_exit_code, popen,
+                    remove_directory, set_file_executable, write_to_file)
 
 
 class TestStatus(BaseTest):

--- a/tests/test_traverse.py
+++ b/tests/test_traverse.py
@@ -9,18 +9,18 @@ from git_machete.utils import (FullTerminalAnsiOutputCodes,
                                UnderlyingGitException)
 
 from .base_test import BaseTest
-from .mockers import (assert_failure, assert_success,
-                      fixed_author_and_committer_date_in_past, launch_command,
+from .cli_runner import (assert_failure, assert_success, launch_command,
+                         rewrite_branch_layout_file)
+from .git_repository import (add_file_and_commit, add_remote, amend_commit,
+                             check_out, commit, create_repo,
+                             create_repo_with_remote, delete_branch,
+                             get_current_branch, get_git_version, merge,
+                             new_branch, push, remove_remote, reset_to,
+                             set_git_config_key, wait_to_bump_commit_timestamp)
+from .mockers import (fixed_author_and_committer_date_in_past,
                       mock_input_returning, mock_input_returning_y,
-                      overridden_environment, rewrite_branch_layout_file,
-                      wait_to_bump_commit_timestamp, write_to_file)
-from .mockers_git_repository import (add_file_and_commit, add_remote,
-                                     amend_commit, check_out, commit,
-                                     create_repo, create_repo_with_remote,
-                                     delete_branch, get_current_branch,
-                                     get_git_version, merge, new_branch, push,
-                                     remove_remote, reset_to,
-                                     set_git_config_key)
+                      overridden_environment)
+from .shell import write_to_file
 
 
 class TestTraverse(BaseTest):

--- a/tests/test_traverse_github.py
+++ b/tests/test_traverse_github.py
@@ -3,11 +3,12 @@ import textwrap
 from pytest_mock import MockerFixture
 
 from .base_test import BaseTest
-from .mockers import (assert_failure, assert_success, mock_input_returning,
-                      rewrite_branch_layout_file)
+from .cli_runner import (assert_failure, assert_success,
+                         rewrite_branch_layout_file)
+from .git_repository import (check_out, commit, create_repo_with_remote,
+                             new_branch, push)
+from .mockers import mock_input_returning
 from .mockers_code_hosting import mock_from_url
-from .mockers_git_repository import (check_out, commit,
-                                     create_repo_with_remote, new_branch, push)
 from .mockers_github import (MockGitHubAPIState,
                              mock_github_token_for_domain_fake, mock_pr_json,
                              mock_urlopen)

--- a/tests/test_traverse_gitlab.py
+++ b/tests/test_traverse_gitlab.py
@@ -3,11 +3,12 @@ import textwrap
 from pytest_mock import MockerFixture
 
 from .base_test import BaseTest
-from .mockers import (assert_failure, assert_success, mock_input_returning,
-                      rewrite_branch_layout_file)
+from .cli_runner import (assert_failure, assert_success,
+                         rewrite_branch_layout_file)
+from .git_repository import (check_out, commit, create_repo_with_remote,
+                             new_branch, push)
+from .mockers import mock_input_returning
 from .mockers_code_hosting import mock_from_url
-from .mockers_git_repository import (check_out, commit,
-                                     create_repo_with_remote, new_branch, push)
 from .mockers_gitlab import (MockGitLabAPIState,
                              mock_gitlab_token_for_domain_fake, mock_mr_json,
                              mock_urlopen)

--- a/tests/test_traverse_worktrees.py
+++ b/tests/test_traverse_worktrees.py
@@ -7,15 +7,15 @@ from pytest_mock import MockerFixture
 from git_machete.utils import UnderlyingGitException, abspath_posix
 
 from .base_test import BaseTest
-from .mockers import (assert_failure, assert_success,
-                      fixed_author_and_committer_date_in_past, launch_command,
-                      mock_input_returning, rewrite_branch_layout_file)
-from .mockers_git_repository import (add_file_and_commit, add_worktree,
-                                     check_out, commit,
-                                     create_repo_with_remote,
-                                     get_current_branch, get_git_version,
-                                     get_worktree_dirs, new_branch, push,
-                                     set_git_config_key)
+from .cli_runner import (assert_failure, assert_success, launch_command,
+                         rewrite_branch_layout_file)
+from .git_repository import (add_file_and_commit, add_worktree, check_out,
+                             commit, create_repo_with_remote,
+                             get_current_branch, get_git_version,
+                             get_worktree_dirs, new_branch, push,
+                             set_git_config_key)
+from .mockers import (fixed_author_and_committer_date_in_past,
+                      mock_input_returning)
 
 # pytestmark is a special variable that pytest recognizes automatically.
 # It applies the specified marks to all test functions in this module.
@@ -30,7 +30,7 @@ class TestTraverseWorktrees(BaseTest):
 
     def test_traverse_with_worktrees(self) -> None:
         """Test that traverse can handle branches checked out in separate worktrees."""
-        from .mockers import execute
+        from .shell import execute
 
         create_repo_with_remote()
         new_branch("develop")

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -4,18 +4,18 @@ from git_machete.utils import (FullTerminalAnsiOutputCodes,
                                UnderlyingGitException)
 
 from .base_test import BaseTest
-from .mockers import (assert_failure, assert_success, execute,
-                      execute_ignoring_exit_code,
-                      fixed_author_and_committer_date_in_past, launch_command,
+from .cli_runner import (assert_failure, assert_success, launch_command,
+                         rewrite_branch_layout_file)
+from .git_repository import (add_file_and_commit, check_out, commit,
+                             create_repo, get_commit_hash,
+                             get_current_commit_hash, get_git_version,
+                             is_ancestor_or_equal, new_branch,
+                             new_orphan_branch)
+from .mockers import (fixed_author_and_committer_date_in_past,
                       mock_input_returning, mock_input_returning_y,
-                      overridden_environment, popen, read_file,
-                      rewrite_branch_layout_file, set_file_executable,
-                      write_to_file)
-from .mockers_git_repository import (add_file_and_commit, check_out, commit,
-                                     create_repo, get_commit_hash,
-                                     get_current_commit_hash, get_git_version,
-                                     is_ancestor_or_equal, new_branch,
-                                     new_orphan_branch)
+                      overridden_environment)
+from .shell import (execute, execute_ignoring_exit_code, popen, read_file,
+                    set_file_executable, write_to_file)
 
 
 class TestUpdate(BaseTest):

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,7 +1,7 @@
 
 from git_machete import __version__
 
-from .mockers import assert_success
+from .cli_runner import assert_success
 
 
 class TestVersion:


### PR DESCRIPTION
Most helpers in tests/mockers.py weren't actually mocks (CLI runner,
output assertions, shell/FS utilities, branch-layout-file readers), and
mockers_git_repository.py contained pure git-CLI wrappers - none of them
mocking anything. Split/rename so module names reflect contents:

- tests/mockers.py: trimmed to real stubs only (mock_*, env-override
  context managers fixed_author_and_committer_date_in_past,
  overridden_environment).
- tests/cli_runner.py (new): in-process git-machete runner + output
  assertions (launch_command, assert_success, assert_failure, ...) +
  branch-layout-file helpers.
- tests/shell.py (new): generic shell/FS utilities (execute, popen,
  read_file, write_to_file, ...).
- tests/mockers_git_repository.py -> tests/git_repository.py; also
  absorbed wait_to_bump_commit_timestamp from mockers.py.

Imports updated across all 30+ test files, plus tests/__init__.py
(register_assert_rewrite -> tests.cli_runner) and the
prohibit-sleep-in-python.sh check (allowlist now points at
tests/git_repository.py).

Also:
- Reorder teardown_method in BaseTest so the chdir into the empty temp
  dir runs *before* the patched-method-never-called assertion - that way
  a failing assertion can't leave a later test pinned to a stale cwd.
- Rewrite mock__run_cmd_and_forward_stdout's docstring: it patches
  git_machete.utils._run_cmd (not utils.run_cmd as previously claimed),
  it does NOT capture stderr (stderr=None means inherited), and it
  returns the exit code (the captured stdout reaches the test only
  indirectly via launch_command's redirect_stdout).