### PR TITLE
tests: replace shutil.which / _popen_cmd mocks with fake executables on PATH

### DIFF
--- a/ci/checks/enforce-mocking-only-whitelisted-methods.sh
+++ b/ci/checks/enforce-mocking-only-whitelisted-methods.sh
@@ -16,7 +16,6 @@ git_machete.github.GitHubClient.MAX_PULLS_PER_PAGE_COUNT
 git_machete.github.GitHubToken.for_domain
 git_machete.gitlab.GitLabClient.MAX_PULLS_PER_PAGE_COUNT
 git_machete.gitlab.GitLabToken.for_domain
-git_machete.utils._popen_cmd
 git_machete.utils._run_cmd
 git_machete.utils.find_executable
 git_machete.utils.get_current_date
@@ -24,7 +23,6 @@ git_machete.utils.get_terminal_height
 git_machete.utils.is_stderr_a_tty
 git_machete.utils.is_stdout_a_tty
 git_machete.utils.is_terminal_fully_fledged
-shutil.which
 sys.argv
 termios.tcgetattr
 termios.tcsetattr

--- a/tests/mockers.py
+++ b/tests/mockers.py
@@ -3,9 +3,9 @@ import subprocess
 import sys
 from contextlib import AbstractContextManager, contextmanager
 from tempfile import mkdtemp
-from typing import Any, Callable, Iterator, Tuple
+from typing import Any, Callable, Iterator
 
-from git_machete.utils import PopenResult
+from tests.shell import set_file_executable, write_to_file
 
 
 @contextmanager
@@ -46,12 +46,47 @@ def temporary_home_directory() -> Iterator[str]:
         yield home
 
 
-def mock__popen_cmd_with_fixed_results(*results: Tuple[int, str, str]) -> Callable[..., PopenResult]:
-    gen = (i for i in results)
+@contextmanager
+def fake_executables_on_path(**executables: str) -> Iterator[str]:
+    """For the duration of the with-block, write fake executables to a
+    fresh temporary directory and PREPEND that directory to `PATH`.
 
-    def inner(*args: Any, **kwargs: Any) -> PopenResult:  # noqa: U100
-        return PopenResult(*next(gen))
-    return inner
+    Each keyword argument maps an executable name (e.g. `gh`, `glab`) to a
+    Python script body. The wrappers invoke the body with the original CLI
+    args, so the body can inspect `sys.argv[1:]`, `print()` to
+    stdout/stderr, and set the exit code via `sys.exit(...)` - mimicking a
+    real CLI tool from the SUT's perspective.
+
+    Two wrappers are written per executable so `shutil.which(name)` finds
+    the fake on either platform:
+      - POSIX: an extensionless `name` shell script with the executable
+        bit set.
+      - Windows: a `name.cmd` batch file (Windows resolves the `.cmd`
+        extension via `PATHEXT`).
+
+    Both wrappers force `PYTHONIOENCODING=utf-8` so `print()` works
+    consistently across hosts (especially Windows, whose default stdio
+    encoding is locale-dependent).
+
+    `PATH` is only PREPENDED to (not replaced), so other tools the test
+    relies on - notably `git` - keep working through the rest of `PATH`.
+    Yields the path of the bin directory in case the test needs to inspect
+    or amend it."""
+    bin_dir = mkdtemp()
+    py = sys.executable
+    for name, body in executables.items():
+        impl_path = os.path.join(bin_dir, f'{name}_impl.py')
+        write_to_file(impl_path, body)
+        posix_path = os.path.join(bin_dir, name)
+        write_to_file(posix_path,
+                      f'#!/bin/sh\nPYTHONIOENCODING=utf-8 exec "{py}" "{impl_path}" "$@"\n')
+        set_file_executable(posix_path)
+        windows_path = os.path.join(bin_dir, f'{name}.cmd')
+        write_to_file(windows_path,
+                      f'@echo off\r\nset PYTHONIOENCODING=utf-8\r\n"{py}" "{impl_path}" %*\r\n')
+    new_path = bin_dir + os.pathsep + os.environ.get('PATH', '')
+    with overridden_environment(PATH=new_path):
+        yield bin_dir
 
 
 def mock__run_cmd_and_forward_stdout(cmd: str, *args: str, **kwargs: Any) -> int:

--- a/tests/mockers_code_hosting.py
+++ b/tests/mockers_code_hosting.py
@@ -1,7 +1,7 @@
 import json
 import os
 from collections import defaultdict
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Dict, List, Union
 from urllib.error import HTTPError
 
 from git_machete.code_hosting import OrganizationAndRepository
@@ -45,7 +45,3 @@ def mock_from_url(domain: str, url: str) -> "OrganizationAndRepository":  # noqa
     }
     dir = url.split(os.path.sep)[-1]
     return OrganizationAndRepository("example-org", dir_to_repo[dir])
-
-
-def mock_shutil_which(path: Optional[str]) -> Callable[[Any], Optional[str]]:
-    return lambda _cmd: path

--- a/tests/shell.py
+++ b/tests/shell.py
@@ -15,7 +15,7 @@ def popen(command: str) -> str:
 
 
 def read_file(file_name: str) -> str:
-    with open(file_name) as f:
+    with open(file_name, encoding='utf-8') as f:
         return f.read()
 
 
@@ -23,7 +23,7 @@ def write_to_file(file_path: str, file_content: str) -> None:
     dirname = os.path.dirname(file_path)
     if dirname:
         os.makedirs(dirname, exist_ok=True)
-    with open(file_path, 'w') as f:
+    with open(file_path, 'w', encoding='utf-8') as f:
         f.write(file_content)
 
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,7 +1,7 @@
 import itertools
 import os
+import textwrap
 from contextlib import contextmanager
-from textwrap import dedent
 from typing import Iterator
 
 from pytest_mock import MockerFixture
@@ -15,15 +15,21 @@ from tests.git_repository import (add_remote, check_out, commit, create_repo,
                                   create_repo_with_remote, delete_branch,
                                   new_branch, push, set_git_config_key,
                                   unset_git_config_key)
-from tests.mockers import (mock__popen_cmd_with_fixed_results,
-                           mock_input_returning_y, overridden_environment,
-                           temporary_home_directory)
-from tests.mockers_code_hosting import mock_from_url, mock_shutil_which
+from tests.mockers import (fake_executables_on_path, mock_input_returning_y,
+                           overridden_environment, temporary_home_directory)
+from tests.mockers_code_hosting import mock_from_url
 from tests.mockers_github import (MockGitHubAPIState,
                                   mock_github_token_for_domain_fake,
                                   mock_github_token_for_domain_none,
                                   mock_pr_json, mock_urlopen)
 from tests.shell import write_to_file
+
+# A `gh` fake that fails its very first call (`gh --version`), so callers
+# of `GitHubToken.for_domain(...)` fall through past `__get_token_from_gh`
+# to the next provider in the chain. Used by tests that target a
+# downstream provider (e.g. `~/.github-token`, `~/.config/hub`) and need
+# the gh step to be deterministically out of the way.
+FAKE_GH_ALWAYS_FAILS = 'import sys; sys.exit(1)'
 
 
 class TestGitHub(BaseTest):
@@ -187,7 +193,6 @@ class TestGitHub(BaseTest):
 
     def test_github_token_retrieval_order(self, mocker: MockerFixture) -> None:
         self.patch_symbol(mocker, 'git_machete.code_hosting.OrganizationAndRepository.from_url', mock_from_url)
-        self.patch_symbol(mocker, 'shutil.which', mock_shutil_which(None))
         self.patch_symbol(mocker, 'urllib.request.urlopen', mock_urlopen(self.github_api_state_for_test_github_enterprise_domain()))
 
         create_repo_with_remote()
@@ -209,11 +214,14 @@ class TestGitHub(BaseTest):
                            "__get_token_from_hub(cls=<class 'git_machete.github.GitHubToken'>, domain=github.com): "
                            "4. Trying to find token via hub GitHub CLI..."]
 
-        with temporary_home_directory():
-            assert list(itertools.dropwhile(
+        # Empty home dir + a fake `gh` that always fails ensure every step
+        # in `GitHubToken.for_domain` falls through to the next, so the
+        # debug log records the full retrieval sequence.
+        with temporary_home_directory(), fake_executables_on_path(gh=FAKE_GH_ALWAYS_FAILS):
+            output_lines = itertools.dropwhile(
                 lambda line: '__get_token_from_env' not in line,
-                launch_command('github', 'anno-prs', '--debug').splitlines()
-            ))[:4] == expected_output
+                launch_command('github', 'anno-prs', '--debug').splitlines())
+            assert [line for line in output_lines if line.startswith('__get_token')][:4] == expected_output
 
     def test_github_get_token_from_env_var(self) -> None:
         with overridden_environment(GITHUB_TOKEN='github_token_from_env_var'):
@@ -233,7 +241,11 @@ class TestGitHub(BaseTest):
                                  'ghp_myothertoken_for_git_example_org git.example.org\n'
                                  'ghp_yetanothertoken_for_git_example_com git.example.com')
 
-        with temporary_home_directory() as home:
+        # A failing fake `gh` keeps the gh-fallback step deterministic for
+        # the final assertion (domain=git.example.net): without this, on a
+        # host with `gh` actually installed, the call would proceed to the
+        # real binary and might be slow / produce surprising output.
+        with temporary_home_directory() as home, fake_executables_on_path(gh=FAKE_GH_ALWAYS_FAILS):
             write_to_file(os.path.join(home, '.github-token'), github_token_contents)
 
             domain = GitHubClient.DEFAULT_GITHUB_DOMAIN
@@ -256,92 +268,135 @@ class TestGitHub(BaseTest):
             assert github_token.provider == f'auth token for {domain} from `~/.github-token`'
             assert github_token.value == 'ghp_yetanothertoken_for_git_example_com'
 
-            domain = 'git.example.net'
-            github_token = GitHubToken.for_domain(domain=domain)
-            assert github_token is None
+            assert GitHubToken.for_domain(domain='git.example.net') is None
 
-    def test_github_get_token_from_gh(self, mocker: MockerFixture) -> None:
-        self.patch_symbol(mocker, 'shutil.which', mock_shutil_which('/path/to/gh'))
+    def test_github_get_token_from_gh_when_version_check_fails(self) -> None:
+        fake_gh = textwrap.dedent("""\
+            import sys
+            sys.stderr.write('unknown error')
+            sys.exit(1)
+        """)
+        with temporary_home_directory(), fake_executables_on_path(gh=fake_gh):
+            assert GitHubToken.for_domain(domain='git.example.com') is None
 
-        domain = 'git.example.com'
+    def test_github_get_token_from_gh_pre_2_17_no_token(self) -> None:
+        # `gh` versions prior to 2.17.0 don't have `gh auth token`; the
+        # token (if any) has to be parsed from `gh auth status --show-token`.
+        # Output without a "Token:" line means "no token configured".
+        fake_gh = textwrap.dedent("""\
+            import sys
+            args = sys.argv[1:]
+            if args == ['--version']:
+                print('gh version 2.0.0 (2099-12-31)')
+                print('https://github.com/cli/cli/releases/tag/v2.0.0')
+                sys.exit(0)
+            if args[:2] == ['auth', 'status']:
+                sys.stderr.write(
+                    'You are not logged into any GitHub hosts. '
+                    'Run gh auth login to authenticate.')
+                sys.exit(0)
+            sys.exit(99)
+        """)
+        with temporary_home_directory(), fake_executables_on_path(gh=fake_gh):
+            assert GitHubToken.for_domain(domain='git.example.com') is None
 
-        with temporary_home_directory():
-            fixed_popen_cmd_results = [(1, "unknown error", "")]
-            self.patch_symbol(mocker, 'git_machete.utils._popen_cmd', mock__popen_cmd_with_fixed_results(*fixed_popen_cmd_results))
-            github_token = GitHubToken.for_domain(domain=domain)
-            assert github_token is None
-
-            fixed_popen_cmd_results = [(0, "gh version 2.0.0 (2099-12-31)\nhttps://github.com/cli/cli/releases/tag/v2.0.0\n", ""),
-                                       (0, "", "You are not logged into any GitHub hosts. Run gh auth login to authenticate.")]
-            self.patch_symbol(mocker, 'git_machete.utils._popen_cmd', mock__popen_cmd_with_fixed_results(*fixed_popen_cmd_results))
-            github_token = GitHubToken.for_domain(domain=domain)
-            assert github_token is None
-
-            fixed_popen_cmd_results = [(0, "gh version 2.16.0 (2099-12-31)\nhttps://github.com/cli/cli/releases/tag/v2.16.0\n", ""),
-                                       (0, "", """github.com
-                                                    ✓ Logged in to git.example.com as Foo Bar (/Users/foo_bar/.config/gh/hosts.yml)
-                                                    ✓ Git operations for git.example.com configured to use ssh protocol.
-                                                    ✓ Token: ghp_mytoken_for_github_com_from_gh_cli
-                                                    ✓ Token scopes: gist, read:discussion, read:org, repo, workflow""")]
-            self.patch_symbol(mocker, 'git_machete.utils._popen_cmd', mock__popen_cmd_with_fixed_results(*fixed_popen_cmd_results))
-            github_token = GitHubToken.for_domain(domain=domain)
+    def test_github_get_token_from_gh_pre_2_17_with_token(self) -> None:
+        fake_gh = textwrap.dedent("""\
+            import sys
+            args = sys.argv[1:]
+            if args == ['--version']:
+                print('gh version 2.16.0 (2099-12-31)')
+                print('https://github.com/cli/cli/releases/tag/v2.16.0')
+                sys.exit(0)
+            if args[:2] == ['auth', 'status']:
+                sys.stderr.write(
+                    'github.com\\n'
+                    '  \u2713 Logged in to git.example.com as Foo Bar'
+                    ' (/Users/foo_bar/.config/gh/hosts.yml)\\n'
+                    '  \u2713 Token: ghp_mytoken_for_github_com_from_gh_cli\\n'
+                    '  \u2713 Token scopes: gist, read:discussion, read:org, repo, workflow')
+                sys.exit(0)
+            sys.exit(99)
+        """)
+        with temporary_home_directory(), fake_executables_on_path(gh=fake_gh):
+            github_token = GitHubToken.for_domain(domain='git.example.com')
             assert github_token is not None
-            assert github_token.provider == f'auth token for {domain} from `gh` GitHub CLI'
+            assert github_token.provider == 'auth token for git.example.com from `gh` GitHub CLI'
             assert github_token.value == 'ghp_mytoken_for_github_com_from_gh_cli'
 
-            fixed_popen_cmd_results = [(0, "gh version 2.17.0 (2099-12-31)\nhttps://github.com/cli/cli/releases/tag/v2.17.0\n", ""),
-                                       (0, "", "You are not logged into any GitHub hosts. Run gh auth login to authenticate.")]
-            self.patch_symbol(mocker, 'git_machete.utils._popen_cmd', mock__popen_cmd_with_fixed_results(*fixed_popen_cmd_results))
-            github_token = GitHubToken.for_domain(domain=domain)
-            assert github_token is None
+    def test_github_get_token_from_gh_post_2_17_no_token(self) -> None:
+        # As of `gh` 2.17.0, `gh auth token` is the canonical way to read
+        # the token. Empty stdout means "no token configured".
+        fake_gh = textwrap.dedent("""\
+            import sys
+            args = sys.argv[1:]
+            if args == ['--version']:
+                print('gh version 2.17.0 (2099-12-31)')
+                print('https://github.com/cli/cli/releases/tag/v2.17.0')
+                sys.exit(0)
+            if args[:2] == ['auth', 'token']:
+                sys.exit(0)
+            sys.exit(99)
+        """)
+        with temporary_home_directory(), fake_executables_on_path(gh=fake_gh):
+            assert GitHubToken.for_domain(domain='git.example.com') is None
 
-            fixed_popen_cmd_results = [(0, "gh version 2.17.0 (2099-12-31)\nhttps://github.com/cli/cli/releases/tag/v2.17.0\n", ""),
-                                       (0, "ghp_mytoken_for_github_com_from_gh_cli", "")]
-            self.patch_symbol(mocker, 'git_machete.utils._popen_cmd', mock__popen_cmd_with_fixed_results(*fixed_popen_cmd_results))
-            github_token = GitHubToken.for_domain(domain=domain)
+    def test_github_get_token_from_gh_post_2_17_with_token(self) -> None:
+        fake_gh = textwrap.dedent("""\
+            import sys
+            args = sys.argv[1:]
+            if args == ['--version']:
+                print('gh version 2.17.0 (2099-12-31)')
+                print('https://github.com/cli/cli/releases/tag/v2.17.0')
+                sys.exit(0)
+            if args[:2] == ['auth', 'token']:
+                print('ghp_mytoken_for_github_com_from_gh_cli')
+                sys.exit(0)
+            sys.exit(99)
+        """)
+        with temporary_home_directory(), fake_executables_on_path(gh=fake_gh):
+            github_token = GitHubToken.for_domain(domain='git.example.com')
             assert github_token is not None
-            assert github_token.provider == f'auth token for {domain} from `gh` GitHub CLI'
+            assert github_token.provider == 'auth token for git.example.com from `gh` GitHub CLI'
             assert github_token.value == 'ghp_mytoken_for_github_com_from_gh_cli'
 
-    def test_github_get_token_from_hub(self, mocker: MockerFixture) -> None:
-        domain0 = 'git.example.net'
-        domain1 = GitHubClient.DEFAULT_GITHUB_DOMAIN
-        domain2 = 'git.example.org'
-        config_hub_contents = dedent(f'''        {domain1}:
+    # ~/.config/hub fallback - the three split tests below all rely on
+    # `__get_token_from_gh` (step 3) returning None so step 4 (hub) is reached;
+    # FAKE_GH_ALWAYS_FAILS achieves that by failing the very first `gh --version` call.
+
+    HUB_DEFAULT_DOMAIN = GitHubClient.DEFAULT_GITHUB_DOMAIN
+    HUB_CUSTOM_DOMAIN = 'git.example.org'
+    CONFIG_HUB_CONTENTS = textwrap.dedent(f'''\
+        {HUB_DEFAULT_DOMAIN}:
         - user: username1
           oauth_token: ghp_mytoken_for_github_com
           protocol: protocol
 
-        {domain2}:
+        {HUB_CUSTOM_DOMAIN}:
         - user: username2
           oauth_token: ghp_myothertoken_for_git_example_org
           protocol: protocol
         ''')
 
-        # Let's pretend that `gh` is available, but fails for whatever reason.
-        self.patch_symbol(mocker, 'shutil.which', mock_shutil_which('/path/to/gh'))
+    def test_github_get_token_from_hub_when_domain_not_in_config(self) -> None:
+        with temporary_home_directory() as home, fake_executables_on_path(gh=FAKE_GH_ALWAYS_FAILS):
+            write_to_file(os.path.join(home, '.config', 'hub'), self.CONFIG_HUB_CONTENTS)
+            assert GitHubToken.for_domain(domain='git.example.net') is None
 
-        with temporary_home_directory() as home:
-            write_to_file(os.path.join(home, '.config', 'hub'), config_hub_contents)
-
-            fixed_popen_cmd_results = [(0, "gh version 2.31.0 (2099-12-31)\nhttps://github.com/cli/cli/releases/tag/v2.31.0\n", ""),
-                                       (1, "", "unknown error")]
-            self.patch_symbol(mocker, 'git_machete.utils._popen_cmd', mock__popen_cmd_with_fixed_results(*fixed_popen_cmd_results))
-            github_token = GitHubToken.for_domain(domain=domain0)
-            assert github_token is None
-
-            self.patch_symbol(mocker, 'git_machete.utils._popen_cmd', mock__popen_cmd_with_fixed_results(*fixed_popen_cmd_results))
-            github_token = GitHubToken.for_domain(domain=domain1)
+    def test_github_get_token_from_hub_for_default_domain(self) -> None:
+        with temporary_home_directory() as home, fake_executables_on_path(gh=FAKE_GH_ALWAYS_FAILS):
+            write_to_file(os.path.join(home, '.config', 'hub'), self.CONFIG_HUB_CONTENTS)
+            github_token = GitHubToken.for_domain(domain=self.HUB_DEFAULT_DOMAIN)
             assert github_token is not None
-            assert github_token.provider == f'auth token for {domain1} from `hub` GitHub CLI'
+            assert github_token.provider == f'auth token for {self.HUB_DEFAULT_DOMAIN} from `hub` GitHub CLI'
             assert github_token.value == 'ghp_mytoken_for_github_com'
 
-            fixed_popen_cmd_results = [(0, "gh version 2.16.0 (2099-12-31)\nhttps://github.com/cli/cli/releases/tag/v2.16.0\n", ""),
-                                       (1, "", "unknown error")]
-            self.patch_symbol(mocker, 'git_machete.utils._popen_cmd', mock__popen_cmd_with_fixed_results(*fixed_popen_cmd_results))
-            github_token = GitHubToken.for_domain(domain=domain2)
+    def test_github_get_token_from_hub_for_custom_domain(self) -> None:
+        with temporary_home_directory() as home, fake_executables_on_path(gh=FAKE_GH_ALWAYS_FAILS):
+            write_to_file(os.path.join(home, '.config', 'hub'), self.CONFIG_HUB_CONTENTS)
+            github_token = GitHubToken.for_domain(domain=self.HUB_CUSTOM_DOMAIN)
             assert github_token is not None
-            assert github_token.provider == f'auth token for {domain2} from `hub` GitHub CLI'
+            assert github_token.provider == f'auth token for {self.HUB_CUSTOM_DOMAIN} from `hub` GitHub CLI'
             assert github_token.value == 'ghp_myothertoken_for_git_example_org'
 
     def test_github_invalid_flag_combinations(self) -> None:

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -311,10 +311,10 @@ class TestGitHub(BaseTest):
             if args[:2] == ['auth', 'status']:
                 sys.stderr.write(
                     'github.com\\n'
-                    '  \u2713 Logged in to git.example.com as Foo Bar'
+                    '  ✓ Logged in to git.example.com as Foo Bar'
                     ' (/Users/foo_bar/.config/gh/hosts.yml)\\n'
-                    '  \u2713 Token: ghp_mytoken_for_github_com_from_gh_cli\\n'
-                    '  \u2713 Token scopes: gist, read:discussion, read:org, repo, workflow')
+                    '  ✓ Token: ghp_mytoken_for_github_com_from_gh_cli\\n'
+                    '  ✓ Token scopes: gist, read:discussion, read:org, repo, workflow')
                 sys.exit(0)
             sys.exit(99)
         """)

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -1,5 +1,6 @@
 import itertools
 import os
+import textwrap
 from contextlib import contextmanager
 from typing import Iterator
 
@@ -14,15 +15,21 @@ from tests.git_repository import (add_remote, check_out, commit, create_repo,
                                   create_repo_with_remote, delete_branch,
                                   new_branch, push, set_git_config_key,
                                   unset_git_config_key)
-from tests.mockers import (mock__popen_cmd_with_fixed_results,
-                           mock_input_returning_y, overridden_environment,
-                           temporary_home_directory)
-from tests.mockers_code_hosting import mock_from_url, mock_shutil_which
+from tests.mockers import (fake_executables_on_path, mock_input_returning_y,
+                           overridden_environment, temporary_home_directory)
+from tests.mockers_code_hosting import mock_from_url
 from tests.mockers_gitlab import (MockGitLabAPIState,
                                   mock_gitlab_token_for_domain_fake,
                                   mock_gitlab_token_for_domain_none,
                                   mock_mr_json, mock_urlopen)
 from tests.shell import write_to_file
+
+# A `glab` fake that fails on every invocation, so callers of
+# `GitLabToken.for_domain(...)` fall through past `__get_token_from_glab`
+# to (currently nothing - glab is the last provider). Used by tests that
+# target a downstream provider (e.g. `~/.gitlab-token`) and need the glab
+# step to be deterministically out of the way.
+FAKE_GLAB_ALWAYS_FAILS = 'import sys; sys.exit(1)'
 
 
 class TestGitLab(BaseTest):
@@ -189,7 +196,6 @@ class TestGitLab(BaseTest):
 
     def test_gitlab_token_retrieval_order(self, mocker: MockerFixture) -> None:
         self.patch_symbol(mocker, 'git_machete.code_hosting.OrganizationAndRepository.from_url', mock_from_url)
-        self.patch_symbol(mocker, 'shutil.which', mock_shutil_which(None))
         self.patch_symbol(mocker, 'urllib.request.urlopen', mock_urlopen(self.gitlab_api_state_for_test_gitlab_enterprise_domain()))
 
         create_repo_with_remote()
@@ -209,7 +215,10 @@ class TestGitLab(BaseTest):
                            "__get_token_from_glab(cls=<class 'git_machete.gitlab.GitLabToken'>, domain=gitlab.com): "
                            "3. Trying to find token via glab GitLab CLI..."]
 
-        with temporary_home_directory():
+        # Empty home dir + a fake `glab` that always fails ensure every step
+        # in `GitLabToken.for_domain` falls through to the next, so the
+        # debug log records the full retrieval sequence.
+        with temporary_home_directory(), fake_executables_on_path(glab=FAKE_GLAB_ALWAYS_FAILS):
             assert list(itertools.dropwhile(
                 lambda line: '__get_token_from_env' not in line,
                 launch_command('gitlab', 'anno-mrs', '--debug').splitlines()
@@ -233,7 +242,11 @@ class TestGitLab(BaseTest):
                                  'glpat-myothertoken_for_git_example_org git.example.org\n'
                                  'glpat-yetanothertoken_for_git_example_com git.example.com')
 
-        with temporary_home_directory() as home:
+        # A failing fake `glab` keeps the glab-fallback step deterministic for
+        # the final assertion (domain=git.example.net): without this, on a host
+        # with `glab` actually installed, the call would proceed to the real
+        # binary and might be slow / produce surprising output.
+        with temporary_home_directory() as home, fake_executables_on_path(glab=FAKE_GLAB_ALWAYS_FAILS):
             write_to_file(os.path.join(home, '.gitlab-token'), gitlab_token_contents)
 
             domain = GitLabClient.DEFAULT_GITLAB_DOMAIN
@@ -256,69 +269,89 @@ class TestGitLab(BaseTest):
             assert gitlab_token.provider == f'auth token for {domain} from `~/.gitlab-token`'
             assert gitlab_token.value == 'glpat-yetanothertoken_for_git_example_com'
 
-            domain = 'git.example.net'
-            gitlab_token = GitLabToken.for_domain(domain=domain)
-            assert gitlab_token is None
+            assert GitLabToken.for_domain(domain='git.example.net') is None
 
-    def test_gitlab_get_token_from_glab(self, mocker: MockerFixture) -> None:
-        self.patch_symbol(mocker, 'shutil.which', mock_shutil_which('/path/to/glab'))
+    def test_gitlab_get_token_from_glab_when_auth_status_fails(self) -> None:
+        fake_glab = textwrap.dedent("""\
+            import sys
+            sys.stderr.write('unknown error')
+            sys.exit(1)
+        """)
+        with temporary_home_directory(), fake_executables_on_path(glab=fake_glab):
+            assert GitLabToken.for_domain(domain='git.example.com') is None
 
-        domain = 'git.example.com'
+    def test_gitlab_get_token_from_glab_when_no_token_in_status(self) -> None:
+        # `glab auth status` succeeds but doesn't print a "Token:" /
+        # "Token found:" line - i.e. the user isn't authenticated.
+        fake_glab = textwrap.dedent("""\
+            import sys
+            sys.stderr.write('''gitlab.com
+              x gitlab.com: api call failed: GET https://gitlab.com/api/v4/user: 401 {message: 401 Unauthorized}
+              \u2713 Git operations for gitlab.com configured to use ssh protocol.
+              \u2713 API calls for gitlab.com are made over https protocol
+              \u2713 REST API Endpoint: https://gitlab.com/api/v4/
+              \u2713 GraphQL Endpoint: https://gitlab.com/api/graphql/
+              x No token provided''')
+            sys.exit(0)
+        """)
+        with temporary_home_directory(), fake_executables_on_path(glab=fake_glab):
+            assert GitLabToken.for_domain(domain='git.example.com') is None
 
-        with temporary_home_directory():
-            fixed_popen_cmd_result = (1, "unknown error", "")
-            self.patch_symbol(mocker, 'git_machete.utils._popen_cmd', mock__popen_cmd_with_fixed_results(fixed_popen_cmd_result))
-            gitlab_token = GitLabToken.for_domain(domain=domain)
-            assert gitlab_token is None
-
-            fixed_popen_cmd_result = (0, "", """gitlab.com
-                                          x gitlab.com: api call failed: GET https://gitlab.com/api/v4/user: 401 {message: 401 Unauthorized}
-                                          ✓ Git operations for gitlab.com configured to use ssh protocol.
-                                          ✓ API calls for gitlab.com are made over https protocol
-                                          ✓ REST API Endpoint: https://gitlab.com/api/v4/
-                                          ✓ GraphQL Endpoint: https://gitlab.com/api/graphql/
-                                          x No token provided""")
-            self.patch_symbol(mocker, 'git_machete.utils._popen_cmd', mock__popen_cmd_with_fixed_results(fixed_popen_cmd_result))
-            gitlab_token = GitLabToken.for_domain(domain=domain)
-            assert gitlab_token is None
-
-            fixed_popen_cmd_result = (0, "", """gitlab.com
-                                          ✓ Logged in to gitlab.com as Foo Bar (/Users/foo_bar/.config/gh/hosts.yml)
-                                          ✓ Git operations for gitlab.com configured to use ssh protocol.
-                                          ✓ API calls for gitlab.com are made over https protocol
-                                          ✓ REST API Endpoint: https://gitlab.com/api/v4/
-                                          ✓ GraphQL Endpoint: https://gitlab.com/api/graphql/
-                                          ✓ Token: glpat-mytoken_for_gitlab_com_from_glab_cli_pre_1_66_0""")
-            self.patch_symbol(mocker, 'git_machete.utils._popen_cmd', mock__popen_cmd_with_fixed_results(fixed_popen_cmd_result))
-            gitlab_token = GitLabToken.for_domain(domain=domain)
+    def test_gitlab_get_token_from_glab_pre_1_66_0(self) -> None:
+        # In `glab` versions prior to 1.66.0 the line was "Token: <value>".
+        fake_glab = textwrap.dedent("""\
+            import sys
+            sys.stderr.write('''gitlab.com
+              \u2713 Logged in to gitlab.com as Foo Bar (/Users/foo_bar/.config/gh/hosts.yml)
+              \u2713 Git operations for gitlab.com configured to use ssh protocol.
+              \u2713 API calls for gitlab.com are made over https protocol
+              \u2713 REST API Endpoint: https://gitlab.com/api/v4/
+              \u2713 GraphQL Endpoint: https://gitlab.com/api/graphql/
+              \u2713 Token: glpat-mytoken_for_gitlab_com_from_glab_cli_pre_1_66_0''')
+            sys.exit(0)
+        """)
+        with temporary_home_directory(), fake_executables_on_path(glab=fake_glab):
+            gitlab_token = GitLabToken.for_domain(domain='git.example.com')
             assert gitlab_token is not None
-            assert gitlab_token.provider == f'auth token for {domain} from `glab` GitLab CLI'
+            assert gitlab_token.provider == 'auth token for git.example.com from `glab` GitLab CLI'
             assert gitlab_token.value == 'glpat-mytoken_for_gitlab_com_from_glab_cli_pre_1_66_0'
 
-            fixed_popen_cmd_result = (0, "", """gitlab.com
-                                          ✓ Logged in to gitlab.com as Foo Bar (/Users/foo_bar/.config/glab-cli/config.yml)
-                                          ✓ Git operations for gitlab.com configured to use https protocol.
-                                          ✓ API calls for gitlab.com are made over https protocol.
-                                          ✓ REST API Endpoint: https://gitlab.com/api/v4/
-                                          ✓ GraphQL Endpoint: https://gitlab.com/api/graphql/
-                                          ✓ Token found: glpat-mytoken_for_gitlab_com_from_glab_cli_post_1_66_0""")
-            self.patch_symbol(mocker, 'git_machete.utils._popen_cmd', mock__popen_cmd_with_fixed_results(fixed_popen_cmd_result))
-            gitlab_token = GitLabToken.for_domain(domain=domain)
+    def test_gitlab_get_token_from_glab_post_1_66_0(self) -> None:
+        # As of `glab` 1.66.0 the line is "Token found: <value>".
+        fake_glab = textwrap.dedent("""\
+            import sys
+            sys.stderr.write('''gitlab.com
+              \u2713 Logged in to gitlab.com as Foo Bar (/Users/foo_bar/.config/glab-cli/config.yml)
+              \u2713 Git operations for gitlab.com configured to use https protocol.
+              \u2713 API calls for gitlab.com are made over https protocol.
+              \u2713 REST API Endpoint: https://gitlab.com/api/v4/
+              \u2713 GraphQL Endpoint: https://gitlab.com/api/graphql/
+              \u2713 Token found: glpat-mytoken_for_gitlab_com_from_glab_cli_post_1_66_0''')
+            sys.exit(0)
+        """)
+        with temporary_home_directory(), fake_executables_on_path(glab=fake_glab):
+            gitlab_token = GitLabToken.for_domain(domain='git.example.com')
             assert gitlab_token is not None
-            assert gitlab_token.provider == f'auth token for {domain} from `glab` GitLab CLI'
+            assert gitlab_token.provider == 'auth token for git.example.com from `glab` GitLab CLI'
             assert gitlab_token.value == 'glpat-mytoken_for_gitlab_com_from_glab_cli_post_1_66_0'
 
-            fixed_popen_cmd_result = (0, "", """gitlab.com
-                                          ✓ Logged in to gitlab.com as Foo Bar (/Users/foo_bar/.config/glab-cli/config.yml)
-                                          ✓ Git operations for gitlab.com configured to use https protocol.
-                                          ✓ API calls for gitlab.com are made over https protocol.
-                                          ✓ REST API Endpoint: https://gitlab.com/api/v4/
-                                          ✓ GraphQL Endpoint: https://gitlab.com/api/graphql/
-                                          ✓ Token found: glpat-mytoken_for_gitlab_com.containing.dots""")
-            self.patch_symbol(mocker, 'git_machete.utils._popen_cmd', mock__popen_cmd_with_fixed_results(fixed_popen_cmd_result))
-            gitlab_token = GitLabToken.for_domain(domain=domain)
+    def test_gitlab_get_token_from_glab_with_dots_in_token(self) -> None:
+        # Newer GitLab personal access tokens can contain "."s.
+        fake_glab = textwrap.dedent("""\
+            import sys
+            sys.stderr.write('''gitlab.com
+              \u2713 Logged in to gitlab.com as Foo Bar (/Users/foo_bar/.config/glab-cli/config.yml)
+              \u2713 Git operations for gitlab.com configured to use https protocol.
+              \u2713 API calls for gitlab.com are made over https protocol.
+              \u2713 REST API Endpoint: https://gitlab.com/api/v4/
+              \u2713 GraphQL Endpoint: https://gitlab.com/api/graphql/
+              \u2713 Token found: glpat-mytoken_for_gitlab_com.containing.dots''')
+            sys.exit(0)
+        """)
+        with temporary_home_directory(), fake_executables_on_path(glab=fake_glab):
+            gitlab_token = GitLabToken.for_domain(domain='git.example.com')
             assert gitlab_token is not None
-            assert gitlab_token.provider == f'auth token for {domain} from `glab` GitLab CLI'
+            assert gitlab_token.provider == 'auth token for git.example.com from `glab` GitLab CLI'
             assert gitlab_token.value == 'glpat-mytoken_for_gitlab_com.containing.dots'
 
     def test_gitlab_invalid_flag_combinations(self) -> None:

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -287,10 +287,10 @@ class TestGitLab(BaseTest):
             import sys
             sys.stderr.write('''gitlab.com
               x gitlab.com: api call failed: GET https://gitlab.com/api/v4/user: 401 {message: 401 Unauthorized}
-              \u2713 Git operations for gitlab.com configured to use ssh protocol.
-              \u2713 API calls for gitlab.com are made over https protocol
-              \u2713 REST API Endpoint: https://gitlab.com/api/v4/
-              \u2713 GraphQL Endpoint: https://gitlab.com/api/graphql/
+              ✓ Git operations for gitlab.com configured to use ssh protocol.
+              ✓ API calls for gitlab.com are made over https protocol
+              ✓ REST API Endpoint: https://gitlab.com/api/v4/
+              ✓ GraphQL Endpoint: https://gitlab.com/api/graphql/
               x No token provided''')
             sys.exit(0)
         """)
@@ -302,12 +302,12 @@ class TestGitLab(BaseTest):
         fake_glab = textwrap.dedent("""\
             import sys
             sys.stderr.write('''gitlab.com
-              \u2713 Logged in to gitlab.com as Foo Bar (/Users/foo_bar/.config/gh/hosts.yml)
-              \u2713 Git operations for gitlab.com configured to use ssh protocol.
-              \u2713 API calls for gitlab.com are made over https protocol
-              \u2713 REST API Endpoint: https://gitlab.com/api/v4/
-              \u2713 GraphQL Endpoint: https://gitlab.com/api/graphql/
-              \u2713 Token: glpat-mytoken_for_gitlab_com_from_glab_cli_pre_1_66_0''')
+              ✓ Logged in to gitlab.com as Foo Bar (/Users/foo_bar/.config/gh/hosts.yml)
+              ✓ Git operations for gitlab.com configured to use ssh protocol.
+              ✓ API calls for gitlab.com are made over https protocol
+              ✓ REST API Endpoint: https://gitlab.com/api/v4/
+              ✓ GraphQL Endpoint: https://gitlab.com/api/graphql/
+              ✓ Token: glpat-mytoken_for_gitlab_com_from_glab_cli_pre_1_66_0''')
             sys.exit(0)
         """)
         with temporary_home_directory(), fake_executables_on_path(glab=fake_glab):
@@ -321,12 +321,12 @@ class TestGitLab(BaseTest):
         fake_glab = textwrap.dedent("""\
             import sys
             sys.stderr.write('''gitlab.com
-              \u2713 Logged in to gitlab.com as Foo Bar (/Users/foo_bar/.config/glab-cli/config.yml)
-              \u2713 Git operations for gitlab.com configured to use https protocol.
-              \u2713 API calls for gitlab.com are made over https protocol.
-              \u2713 REST API Endpoint: https://gitlab.com/api/v4/
-              \u2713 GraphQL Endpoint: https://gitlab.com/api/graphql/
-              \u2713 Token found: glpat-mytoken_for_gitlab_com_from_glab_cli_post_1_66_0''')
+              ✓ Logged in to gitlab.com as Foo Bar (/Users/foo_bar/.config/glab-cli/config.yml)
+              ✓ Git operations for gitlab.com configured to use https protocol.
+              ✓ API calls for gitlab.com are made over https protocol.
+              ✓ REST API Endpoint: https://gitlab.com/api/v4/
+              ✓ GraphQL Endpoint: https://gitlab.com/api/graphql/
+              ✓ Token found: glpat-mytoken_for_gitlab_com_from_glab_cli_post_1_66_0''')
             sys.exit(0)
         """)
         with temporary_home_directory(), fake_executables_on_path(glab=fake_glab):
@@ -340,12 +340,12 @@ class TestGitLab(BaseTest):
         fake_glab = textwrap.dedent("""\
             import sys
             sys.stderr.write('''gitlab.com
-              \u2713 Logged in to gitlab.com as Foo Bar (/Users/foo_bar/.config/glab-cli/config.yml)
-              \u2713 Git operations for gitlab.com configured to use https protocol.
-              \u2713 API calls for gitlab.com are made over https protocol.
-              \u2713 REST API Endpoint: https://gitlab.com/api/v4/
-              \u2713 GraphQL Endpoint: https://gitlab.com/api/graphql/
-              \u2713 Token found: glpat-mytoken_for_gitlab_com.containing.dots''')
+              ✓ Logged in to gitlab.com as Foo Bar (/Users/foo_bar/.config/glab-cli/config.yml)
+              ✓ Git operations for gitlab.com configured to use https protocol.
+              ✓ API calls for gitlab.com are made over https protocol.
+              ✓ REST API Endpoint: https://gitlab.com/api/v4/
+              ✓ GraphQL Endpoint: https://gitlab.com/api/graphql/
+              ✓ Token found: glpat-mytoken_for_gitlab_com.containing.dots''')
             sys.exit(0)
         """)
         with temporary_home_directory(), fake_executables_on_path(glab=fake_glab):


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1656

## Chain of upstream PRs as of 2026-05-06

* PR #1656:
  `develop` ← `ci/home-override-for-token-tests`

  * **PR #1657 (THIS ONE)**:
    `ci/home-override-for-token-tests` ← `cross-platform/fake-gh-glab-on-path`

<!-- end git-machete generated -->

For the GitHub and GitLab token-retrieval tests, drop the direct mocking of
shutil.which and git_machete.utils._popen_cmd in favour of putting real (but
tiny) Python-backed fake executables on PATH via the new fake_executables_on_path()
context manager.

Each of the former monolithic multi-scenario tests is split into focused,
single-scenario methods:
  test_github_get_token_from_gh  → 5 tests (version-check failure, pre-2.17
    with/without token, post-2.17 with/without token)
  test_github_get_token_from_hub → 3 tests (domain not in config, default
    domain, custom domain)
  test_gitlab_get_token_from_glab → 5 tests (auth-status failure, no token in
    status, pre-1.66.0 / post-1.66.0 token line, token with dots)

The tests that target a provider *after* gh/glab in the chain now use the
module-level FAKE_GH_ALWAYS_FAILS / FAKE_GLAB_ALWAYS_FAILS constants so the
intent is immediately clear.

Remove the now-unused mock_shutil_which helper from mockers_code_hosting and
drop both shutil.which and git_machete.utils._popen_cmd from the mocking
whitelist.