### PR TITLE
cli: improve 'Unrecognized arguments' error messages

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -3,6 +3,7 @@ extend-exclude = [
   "ci/checks/*",
   "graphics/*.cast",
   "graphics/generate-asciinema-gif",
+  "tests/test_cli.py"  # to allow for testing typos in commands/flags
 ]
 
 [default.extend-words]

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -352,13 +352,15 @@ class CustomArgumentParser(argparse.ArgumentParser):
             leftovers: List[str],
             parsed: argparse.Namespace,
     ) -> NoReturn:
-        active_parser = self._active_parser_chain(parsed)[-1]
+        chain = self._active_parser_chain(parsed)
+        active_parser = chain[-1]
         known_options = [
             opt for action in active_parser._actions
             for opt in action.option_strings
         ]
 
-        suggestion_lines: List[str] = []
+        # Collect (flag, close_matches) for every unrecognized option-like arg.
+        flag_suggestions: List[Tuple[str, List[str]]] = []
         for arg in leftovers:
             if not arg.startswith("-"):
                 continue
@@ -366,11 +368,25 @@ class CustomArgumentParser(argparse.ArgumentParser):
             flag = arg.split("=", 1)[0]
             close = _close_matches(flag, known_options)
             if close:
-                suggestion_lines.append(f"For `{flag}`: {_format_suggestions(close, capitalize=False)}")
+                flag_suggestions.append((flag, close))
 
         message = "Unrecognized arguments: " + " ".join(leftovers)
-        if suggestion_lines:
-            message += "\n" + "\n".join(suggestion_lines)
+        if len(flag_suggestions) == 1:
+            # Single suggestion: the flag already appears on the "Unrecognized
+            # arguments" line so the "For `flag`:" prefix would be redundant.
+            _, close = flag_suggestions[0]
+            message += "\n" + _format_suggestions(close)
+        elif flag_suggestions:
+            # Multiple flags with suggestions: prefix each line so the user can
+            # tell which suggestion belongs to which argument.
+            lines = [f"For `{flag}`: {_format_suggestions(close, capitalize=False)}"
+                     for flag, close in flag_suggestions]
+            message += "\n" + "\n".join(lines)
+        elif len(chain) > 1:
+            # No spelling-correction hint available: point to the subcommand's
+            # help page.  chain[1] is always the top-level subcommand parser.
+            top_cmd = chain[1].prog.split()[-1]
+            message += f"\nSee `git machete help {top_cmd}` for usage."
         self.error(message)
 
     def _fail_for_missing_required(self, actions: List[argparse.Action]) -> NoReturn:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -146,6 +146,16 @@ class TestCLI(BaseTest):
             "Unrecognized arguments: --checked-out-snc foo\n"
             "Did you mean: `--checked-out-since`?")
 
+    def test_two_unknown_flags_each_with_suggestion(self) -> None:
+        """When multiple unrecognized flags each have a close match, every
+        suggestion line is prefixed with the originating flag name so the
+        user can tell them apart."""
+        assert_argparse_failure(
+            ["traverse", "--srart-from", "foo", "--debugg"],
+            "Unrecognized arguments: --srart-from foo --debugg\n"
+            "For `--srart-from`: did you mean: `--start-from`?\n"
+            "For `--debugg`: did you mean: `--debug`?")
+
     def test_unknown_short_flag_points_to_help(self) -> None:
         """Short flags like `-q` or `-gs` have no long-option close match,
         so the message falls back to the subcommand help page."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -95,21 +95,21 @@ class TestCLI(BaseTest):
         assert_argparse_failure(
             ["--debg"],
             "Unrecognized arguments: --debg\n"
-            "For `--debg`: did you mean: `--debug`?")
+            "Did you mean: `--debug`?")
 
     def test_unknown_flag_suggests_close_match(self) -> None:
         """`git machete traverse --srart-from foo` should suggest `--start-from`."""
         assert_argparse_failure(
             ["traverse", "--srart-from", "foo"],
             "Unrecognized arguments: --srart-from foo\n"
-            "For `--srart-from`: did you mean: `--start-from`?")
+            "Did you mean: `--start-from`?")
 
     def test_unknown_flag_with_equals_suggests_close_match(self) -> None:
         """`--srart-from=foo` is split on `=` before fuzzy-matching."""
         assert_argparse_failure(
             ["traverse", "--srart-from=foo"],
             "Unrecognized arguments: --srart-from=foo\n"
-            "For `--srart-from`: did you mean: `--start-from`?")
+            "Did you mean: `--start-from`?")
 
     def test_unknown_flag_with_uppercase_letter_suggests_close_match(self) -> None:
         """A wrong-case typo (`--list-commitS` vs `--list-commits`) is still
@@ -121,7 +121,7 @@ class TestCLI(BaseTest):
         assert_argparse_failure(
             ["status", "--list-commitS"],
             "Unrecognized arguments: --list-commitS\n"
-            "For `--list-commitS`: did you mean: `--list-commits`, `--list-commits-with-hashes`?")
+            "Did you mean: `--list-commits`, `--list-commits-with-hashes`?")
 
     def test_unknown_flag_scoped_to_subparser(self) -> None:
         """Suggestions only consider options of the active subcommand.
@@ -130,17 +130,45 @@ class TestCLI(BaseTest):
         of it under `traverse` must NOT trigger a suggestion based on `discover`'s
         vocabulary - otherwise we'd be telling the user to use a flag that the
         active subcommand rejects.
+
+        Since there is no spelling-correction hint, the message falls back to
+        pointing the user at the subcommand's help page.
         """
         assert_argparse_failure(
             ["traverse", "--checked-out-snc", "foo"],
-            "Unrecognized arguments: --checked-out-snc foo")
+            "Unrecognized arguments: --checked-out-snc foo\n"
+            "See `git machete help traverse` for usage.")
 
     def test_unknown_flag_scoped_to_subparser_positive(self) -> None:
         """Conversely, when the typo is under the right subparser, suggest."""
         assert_argparse_failure(
             ["discover", "--checked-out-snc", "foo"],
             "Unrecognized arguments: --checked-out-snc foo\n"
-            "For `--checked-out-snc`: did you mean: `--checked-out-since`?")
+            "Did you mean: `--checked-out-since`?")
+
+    def test_unknown_short_flag_points_to_help(self) -> None:
+        """Short flags like `-q` or `-gs` have no long-option close match,
+        so the message falls back to the subcommand help page."""
+        assert_argparse_failure(
+            ["status", "-q"],
+            "Unrecognized arguments: -q\n"
+            "See `git machete help status` for usage.")
+
+    def test_unknown_short_flags_nested_subcommand_points_to_help(self) -> None:
+        """For a two-level subcommand (`github create-pr`), the hint points
+        at the top-level subcommand (`github`) since that is what
+        `git machete help` accepts as its argument."""
+        assert_argparse_failure(
+            ["github", "create-pr", "-gs"],
+            "Unrecognized arguments: -gs\n"
+            "See `git machete help github` for usage.")
+
+    def test_unknown_flag_no_subcommand_no_hint(self) -> None:
+        """At the top level (no subcommand selected), there is no help page
+        to point at, so no hint is appended when there is also no suggestion."""
+        assert_argparse_failure(
+            ["-q"],
+            "Unrecognized arguments: -q")
 
     # ─── Invalid choice for positional ───────────────────────────────────────
 


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1657

## Chain of upstream PRs as of 2026-05-06

* PR #1656:
  `develop` ← `ci/home-override-for-token-tests`

  * PR #1657:
    `ci/home-override-for-token-tests` ← `cross-platform/fake-gh-glab-on-path`

    * **PR #1658 (THIS ONE)**:
      `cross-platform/fake-gh-glab-on-path` ← `cli/better-unrecognized-arg-messages`

<!-- end git-machete generated -->

Two UX improvements to the argparse error for unrecognized flags:

1. Drop the redundant "For `<flag>`:" prefix in the single-suggestion case.
   The flag already appears on the "Unrecognized arguments:" line above, so
   repeating it is noise.  Before:
     Unrecognized arguments: --list-commitZ
     For `--list-commitZ`: did you mean: `--list-commits`, `--list-commits-with-hashes`?
   After:
     Unrecognized arguments: --list-commitZ
     Did you mean: `--list-commits`, `--list-commits-with-hashes`?
   When multiple flags each have a close match the "For `<flag>`:" prefix is
   kept on every line so the user can tell suggestions apart.

2. When there is no spelling-correction hint (e.g. unrecognized short flags
   like `-q`, `-gs`) and a subcommand is active, append a help pointer:
     Unrecognized arguments: -q
     See `git machete help status` for usage.
   For nested subcommands (`github create-pr`) the hint targets the top-level
   subcommand name (`github`) since that is what `git machete help` accepts.
   At the top level (no subcommand selected) no pointer is added.