### PR TITLE
refactor: move fork point retrieval from cli.py to squash and reapply

### DIFF
--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -21,6 +21,7 @@ from git_machete.client.fork_point import ForkPointMacheteClient
 from git_machete.client.go_interactive import GoInteractiveMacheteClient
 from git_machete.client.go_show import GoShowMacheteClient
 from git_machete.client.log import LogMacheteClient
+from git_machete.client.reapply import ReapplyMacheteClient
 from git_machete.client.slide_out import SlideOutMacheteClient
 from git_machete.client.squash import SquashMacheteClient
 from git_machete.client.status import StatusMacheteClient
@@ -1101,18 +1102,10 @@ def launch_internal(orig_args: List[str]) -> None:
             branch = cli_opts.opt_branch or git.get_current_branch()
             log_client.display_log(branch, extra_git_log_args=pass_through_args)
         elif cmd == "reapply":
-            reapply_client = MacheteClient(git)
+            reapply_client = ReapplyMacheteClient(git)
             reapply_client.read_branch_layout_file()
-            current_branch = git.get_current_branch()
-            if cli_opts.opt_fork_point is not None:
-                reapply_client.check_that_fork_point_is_ancestor_or_equal_to_tip_of_branch(
-                    fork_point=cli_opts.opt_fork_point, branch=current_branch)
-
-            reapply_fork_point = cli_opts.opt_fork_point or reapply_client.fork_point(branch=current_branch, use_overrides=True)
-            reapply_client.rebase(
-                onto=reapply_fork_point,
-                from_exclusive=reapply_fork_point,
-                branch=current_branch,
+            reapply_client.reapply(
+                opt_fork_point=cli_opts.opt_fork_point,
                 opt_no_interactive_rebase=cli_opts.opt_no_interactive_rebase)
         elif cmd == "show":
             direction = parsed_cli.direction
@@ -1164,20 +1157,9 @@ def launch_internal(orig_args: List[str]) -> None:
         elif cmd == "squash":
             squash_client = SquashMacheteClient(git)
             squash_client.read_branch_layout_file()
-            current_branch = git.get_current_branch()
-            if cli_opts.opt_fork_point is not None:
-                squash_client.check_that_fork_point_is_ancestor_or_equal_to_tip_of_branch(
-                    fork_point=cli_opts.opt_fork_point, branch=current_branch)
-
-            squash_fork_point = cli_opts.opt_fork_point or squash_client.fork_point_or_none(branch=current_branch, use_overrides=True)
-            if squash_fork_point is None:
-                raise MacheteException(
-                    f"git-machete cannot determine the range of commits unique to branch <b>{current_branch}</b>.\n"
-                    f"Use `git machete squash --fork-point=...` to select the commit "
-                    f"after which the commits of <b>{current_branch}</b> start.\n"
-                    "For example, if you want to squash 3 latest commits, use `git machete squash --fork-point=HEAD~3`."
-                )
-            squash_client.squash(current_branch=current_branch, opt_fork_point=squash_fork_point)
+            squash_client.squash(
+                current_branch=git.get_current_branch(),
+                opt_fork_point=cli_opts.opt_fork_point)
         elif cmd in {"status", alias_by_command["status"]}:
             opt_squash_merge_detection = squash_merge_detection()
             status_client = StatusMacheteClient(git)
@@ -1214,9 +1196,6 @@ def launch_internal(orig_args: List[str]) -> None:
         elif cmd == "update":
             update_client = UpdateMacheteClient(git)
             update_client.read_branch_layout_file()
-            if cli_opts.opt_fork_point is not None:
-                update_client.check_that_fork_point_is_ancestor_or_equal_to_tip_of_branch(
-                    fork_point=cli_opts.opt_fork_point, branch=git.get_current_branch())
             update_client.update(
                 opt_merge=cli_opts.opt_merge,
                 opt_no_edit_merge=cli_opts.opt_no_edit_merge,

--- a/git_machete/client/reapply.py
+++ b/git_machete/client/reapply.py
@@ -1,0 +1,18 @@
+from typing import Optional
+
+from git_machete.client.base import MacheteClient
+from git_machete.git_operations import AnyRevision
+
+
+class ReapplyMacheteClient(MacheteClient):
+    def reapply(self, *, opt_fork_point: Optional[AnyRevision], opt_no_interactive_rebase: bool) -> None:
+        current_branch = self._git.get_current_branch()
+        if opt_fork_point is not None:
+            self.check_that_fork_point_is_ancestor_or_equal_to_tip_of_branch(
+                fork_point=opt_fork_point, branch=current_branch)
+        reapply_fork_point = opt_fork_point or self.fork_point(branch=current_branch, use_overrides=True)
+        self.rebase(
+            onto=reapply_fork_point,
+            from_exclusive=reapply_fork_point,
+            branch=current_branch,
+            opt_no_interactive_rebase=opt_no_interactive_rebase)

--- a/git_machete/client/squash.py
+++ b/git_machete/client/squash.py
@@ -1,5 +1,5 @@
 import os
-from typing import List
+from typing import List, Optional
 
 from git_machete.client.base import MacheteClient
 from git_machete.git_operations import (AnyRevision, FullCommitHash,
@@ -9,10 +9,21 @@ from git_machete.utils import MacheteException, print_fmt
 
 
 class SquashMacheteClient(MacheteClient):
-    def squash(self, *, current_branch: LocalBranchShortName, opt_fork_point: AnyRevision) -> None:
+    def squash(self, *, current_branch: LocalBranchShortName, opt_fork_point: Optional[AnyRevision]) -> None:
         self._git.expect_no_operation_in_progress()
+        if opt_fork_point is not None:
+            self.check_that_fork_point_is_ancestor_or_equal_to_tip_of_branch(
+                fork_point=opt_fork_point, branch=current_branch)
+        fork_point = opt_fork_point or self.fork_point_or_none(branch=current_branch, use_overrides=True)
+        if fork_point is None:
+            raise MacheteException(
+                f"git-machete cannot determine the range of commits unique to branch <b>{current_branch}</b>.\n"
+                f"Use `git machete squash --fork-point=...` to select the commit "
+                f"after which the commits of <b>{current_branch}</b> start.\n"
+                "For example, if you want to squash 3 latest commits, use `git machete squash --fork-point=HEAD~3`."
+            )
 
-        commits: List[GitLogEntry] = self._git.get_commits_between(earliest_exclusive=opt_fork_point, latest_inclusive=current_branch)
+        commits: List[GitLogEntry] = self._git.get_commits_between(earliest_exclusive=fork_point, latest_inclusive=current_branch)
         if not commits:
             raise MacheteException(
                 "No commits to squash. Use `-f` or `--fork-point` to specify the "
@@ -43,7 +54,7 @@ class SquashMacheteClient(MacheteClient):
         # otherwise the entire `commit-tree` will fail on some ancient supported
         # versions of git (at least on v1.7.10).
         squashed_hash = FullCommitHash.of(self._git.commit_tree_with_given_parent_and_message_and_env(
-            opt_fork_point, earliest_full_message, author_env).strip())
+            fork_point, earliest_full_message, author_env).strip())
 
         # This can't be done with `git reset` since it doesn't allow for a custom reflog message.
         # Even worse, reset's reflog message would be filtered out in our fork point algorithm,

--- a/git_machete/client/update.py
+++ b/git_machete/client/update.py
@@ -11,6 +11,9 @@ class UpdateMacheteClient(MacheteClient):
             opt_no_interactive_rebase: bool, opt_fork_point: Optional[AnyRevision]) -> None:
         self._git.expect_no_operation_in_progress()
         current_branch = self._git.get_current_branch()
+        if opt_fork_point is not None:
+            self.check_that_fork_point_is_ancestor_or_equal_to_tip_of_branch(
+                fork_point=opt_fork_point, branch=current_branch)
         use_merge = opt_merge or (current_branch in self.annotations and self.annotations[current_branch].qualifiers.update_with_merge)
         if use_merge:
             with_branch = self.get_or_infer_up_branch_for(


### PR DESCRIPTION
## Summary

Closes #840.

Mirrors the existing pattern in `UpdateMacheteClient.update()` — fork point retrieval/validation now lives in the client methods rather than in `cli.py`.

- New `git_machete/client/reapply.py` with `ReapplyMacheteClient.reapply()` that handles fork point validation and retrieval internally
- `SquashMacheteClient.squash()` now accepts `Optional[AnyRevision]` and moves the `fork_point_or_none()` call + `None` error message inside
- `cli.py` for both commands is now a thin three-liner (instantiate, read layout, delegate), consistent with `update`
