### PR TITLE
refactor: encapsulate MacheteState in state.py with private internals

### DIFF
--- a/docs/generate-sphinx-man.sh
+++ b/docs/generate-sphinx-man.sh
@@ -6,3 +6,8 @@ target_dir=$1
 
 # `-t man` is needed for the conditionally rendered sections
 sphinx-build -W --keep-going -b man -t man docs/source "$target_dir"
+
+# Strip the date from the .TH header so the generated file is deterministic
+# (the date is irrelevant for `man` display and changes on every regeneration).
+sed -i.bak 's/^\(\.TH "GIT-MACHETE" "1"\) "[^"]*"/\1 ""/' "$target_dir/git-machete.1"
+rm -f "$target_dir/git-machete.1.bak"

--- a/docs/man/git-machete.1
+++ b/docs/man/git-machete.1
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GIT-MACHETE" "1" "May 06, 2026" "" "git-machete"
+.TH "GIT-MACHETE" "1" "" "" "git-machete"
 .SH NAME
 git-machete \- git-machete 3.41.0
 .sp

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -817,15 +817,15 @@ def launch_internal(orig_args: List[str]) -> None:
             fork_point_client = ForkPointMacheteClient(git)
             fork_point_client.read_branch_layout_file()
             branch = cli_opts.opt_branch or git.get_current_branch()
-            upstream = fork_point_client.up_branch_for(branch)
+            parent = fork_point_client.parent_of(branch)
             fork_point_client.expect_in_local_branches(branch)
 
             def warn_on_deprecation(*, flag: str, revision: AnyRevision, revision_str: str) -> None:
-                if upstream:
+                if parent:
                     print()
                     warn(
                         f"`git machete fork-point {flag}` may lead to a confusing user experience and is deprecated.\n\n"
-                        f"If the commits between <b>{upstream}</b> (parent of <b>{branch}</b>) "
+                        f"If the commits between <b>{parent}</b> (parent of <b>{branch}</b>) "
                         f"and {revision_str} <b>{git.get_short_commit_hash_by_revision_or_none(revision) or ''}</b> "
                         f"do NOT belong to <b>{branch}</b>, consider using:\n"
                         f"    `git checkout {branch}`\n"
@@ -855,8 +855,8 @@ def launch_internal(orig_args: List[str]) -> None:
                     revision=fork_point,
                     revision_str="inferred commit")
             elif cli_opts.opt_override_to_parent:
-                if upstream:
-                    fork_point_client.set_fork_point_override(branch, upstream)
+                if parent:
+                    fork_point_client.set_fork_point_override(branch, parent)
                 else:
                     raise MacheteException(
                         f"Branch <b>{branch}</b> does not have upstream (parent) branch")

--- a/git_machete/client/advance.py
+++ b/git_machete/client/advance.py
@@ -2,7 +2,7 @@ from git_machete.client.base import MacheteClient
 from git_machete.config import SquashMergeDetection
 from git_machete.git_operations import (GitContext, LocalBranchShortName,
                                         SyncToRemoteStatus)
-from git_machete.utils import MacheteException, flat_map, pretty_choices, warn
+from git_machete.utils import MacheteException, pretty_choices, warn
 
 
 class AdvanceMacheteClient(MacheteClient):
@@ -15,52 +15,52 @@ class AdvanceMacheteClient(MacheteClient):
         branch = self._git.get_current_branch()
         self.expect_in_managed_branches(branch)
 
-        down_branches = self.down_branches_for(branch)
-        if not down_branches:
+        children = self.children_of(branch)
+        if not children:
             raise MacheteException(
                 f"<b>{branch}</b> does not have any downstream (child) branches to advance towards")
 
-        def connected_with_green_edge(bd: LocalBranchShortName) -> bool:
+        def connected_with_green_edge(child: LocalBranchShortName) -> bool:
             return bool(
-                not self._is_merged_to_upstream(bd, opt_squash_merge_detection=SquashMergeDetection.NONE) and
-                self._git.is_ancestor_or_equal(branch.full_name(), bd.full_name()) and
-                (self._get_overridden_fork_point(bd) or
-                 self._git.get_commit_hash_by_revision(branch) == self.fork_point(bd, use_overrides=False)))
+                not self._is_merged_to_parent(child, opt_squash_merge_detection=SquashMergeDetection.NONE) and
+                self._git.is_ancestor_or_equal(branch.full_name(), child.full_name()) and
+                (self._get_overridden_fork_point(child) or
+                 self._git.get_commit_hash_by_revision(branch) == self.fork_point(child, use_overrides=False)))
 
-        candidate_downstreams = list(filter(connected_with_green_edge, down_branches))
-        if not candidate_downstreams:
+        candidate_children = list(filter(connected_with_green_edge, children))
+        if not candidate_children:
             raise MacheteException(
                 f"No downstream (child) branch of <b>{branch}</b> is connected to "
                 f"<b>{branch}</b> with a green edge")
-        if len(candidate_downstreams) > 1:
+        if len(candidate_children) > 1:
             if opt_yes:
                 raise MacheteException(
                     f"More than one downstream (child) branch of <b>{branch}</b> is "
                     f"connected to <b>{branch}</b> with a green edge and `-y/--yes` option is specified")
             else:
-                down_branch = self.pick(
-                    candidate_downstreams,
+                child_branch = self.pick(
+                    candidate_children,
                     f"downstream branch towards which <b>{branch}</b> is to be fast-forwarded")
-                self._git.merge_fast_forward_only(down_branch)
+                self._git.merge_fast_forward_only(child_branch)
         else:
-            down_branch = candidate_downstreams[0]
+            child_branch = candidate_children[0]
             ans = self.ask_if(
-                f"Fast-forward <b>{branch}</b> to match <b>{down_branch}</b>?" + pretty_choices('y', 'N'),
-                f"Fast-forwarding <b>{branch}</b> to match <b>{down_branch}</b>...", opt_yes=opt_yes)
+                f"Fast-forward <b>{branch}</b> to match <b>{child_branch}</b>?" + pretty_choices('y', 'N'),
+                f"Fast-forwarding <b>{branch}</b> to match <b>{child_branch}</b>...", opt_yes=opt_yes)
             if ans in ('y', 'yes'):
-                self._git.merge_fast_forward_only(down_branch)
+                self._git.merge_fast_forward_only(child_branch)
             else:
                 return
 
         s, remote = self._git.get_combined_remote_sync_status(branch)
-        anno = self.annotations.get(branch)
+        anno = self._state.get_annotation(branch)
 
         if remote and (not anno or anno.qualifiers.push) and s == SyncToRemoteStatus.AHEAD_OF_REMOTE:
             push_msg = (
-                f"\nBranch <b>{branch}</b> is now fast-forwarded to match <b>{down_branch}</b>. "
+                f"\nBranch <b>{branch}</b> is now fast-forwarded to match <b>{child_branch}</b>. "
                 f"Push <b>{branch}</b> to <b>{remote}</b>?" + pretty_choices('y', 'N'))
             opt_yes_push_msg = (
-                f"\nBranch <b>{branch}</b> is now fast-forwarded to match <b>{down_branch}</b>. "
+                f"\nBranch <b>{branch}</b> is now fast-forwarded to match <b>{child_branch}</b>. "
                 f"Pushing <b>{branch}</b> to <b>{remote}</b>...")
             ans = self.ask_if(push_msg, opt_yes_push_msg, opt_yes=opt_yes)
             if ans in ('y', 'yes'):
@@ -68,7 +68,7 @@ class AdvanceMacheteClient(MacheteClient):
                 branch_pushed_or_fast_forwarded_msg = f"\nBranch <b>{branch}</b> is now pushed to <b>{remote}</b>."
             else:
                 branch_pushed_or_fast_forwarded_msg = (
-                    f"\nBranch <b>{branch}</b> is now fast-forwarded to match <b>{down_branch}</b>.")
+                    f"\nBranch <b>{branch}</b> is now fast-forwarded to match <b>{child_branch}</b>.")
         else:
             if remote:
                 sync_status_warnings = {
@@ -85,23 +85,19 @@ class AdvanceMacheteClient(MacheteClient):
                 if s in sync_status_warnings:
                     warn(sync_status_warnings[s])
             branch_pushed_or_fast_forwarded_msg = (
-                f"\nBranch <b>{branch}</b> is now fast-forwarded to match <b>{down_branch}</b>.")
+                f"\nBranch <b>{branch}</b> is now fast-forwarded to match <b>{child_branch}</b>.")
 
-        down_anno = self.annotations.get(down_branch)
-        if not down_anno or down_anno.qualifiers.slide_out:
+        child_anno = self._state.get_annotation(child_branch)
+        if not child_anno or child_anno.qualifiers.slide_out:
             slide_out_msg = (
-                f"{branch_pushed_or_fast_forwarded_msg} Slide <b>{down_branch}</b> out "
+                f"{branch_pushed_or_fast_forwarded_msg} Slide <b>{child_branch}</b> out "
                 f"of the tree of branch dependencies?{pretty_choices('y', 'N')}")
             slide_out_opt_yes_msg = (
-                f"{branch_pushed_or_fast_forwarded_msg} Sliding <b>{down_branch}</b> out "
+                f"{branch_pushed_or_fast_forwarded_msg} Sliding <b>{child_branch}</b> out "
                 "of the tree of branch dependencies...")
             ans = self.ask_if(slide_out_msg, slide_out_opt_yes_msg, opt_yes=opt_yes)
             if ans in ('y', 'yes'):
-                dds = self.down_branches_for(LocalBranchShortName.of(down_branch)) or []
-                for dd in dds:
-                    self._state.up_branch_for[dd] = branch
-                self._state.down_branches_for[branch] = flat_map(
-                    lambda bd: dds if bd == down_branch else [bd],
-                    self.down_branches_for(branch) or [])
+                grandchildren = self._state.get_children(LocalBranchShortName.of(child_branch)) or []
+                self._state.splice_out(child_branch)
                 self.save_branch_layout_file()
-                self._run_post_slide_out_hook(new_upstream=branch, slid_out_branch=down_branch, new_downstreams=dds)
+                self._run_post_slide_out_hook(new_upstream=branch, slid_out_branch=child_branch, new_downstreams=grandchildren)

--- a/git_machete/client/anno.py
+++ b/git_machete/client/anno.py
@@ -7,12 +7,13 @@ from git_machete.git_operations import LocalBranchShortName
 
 class AnnoMacheteClient(MacheteClientWithCodeHosting):
     def annotate(self, branch: LocalBranchShortName, words: List[str]) -> None:
-        if branch in self._state.annotations and words == ['']:
-            del self._state.annotations[branch]
+        if self._state.has_annotation(branch) and words == ['']:
+            self._state.delete_annotation(branch)
         else:
-            self._state.annotations[branch] = Annotation.parse(" ".join(words))
+            self._state.set_annotation(branch, Annotation.parse(" ".join(words)))
         self.save_branch_layout_file()
 
     def print_annotation(self, branch: LocalBranchShortName) -> None:
-        if branch in self._state.annotations:
-            print(self._state.annotations[branch].text_without_qualifiers)
+        anno = self._state.get_annotation(branch)
+        if anno is not None:
+            print(anno.text_without_qualifiers)

--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -10,6 +10,7 @@ from typing import Callable, Dict, Iterator, List, NoReturn, Optional, Tuple
 
 from git_machete import utils
 from git_machete.annotation import Annotation
+from git_machete.client.state import MacheteState
 from git_machete.config import MacheteConfig, SquashMergeDetection
 from git_machete.constants import (INITIAL_COMMIT_COUNT_FOR_LOG,
                                    TOTAL_COMMIT_COUNT_FOR_LOG)
@@ -21,23 +22,14 @@ from git_machete.git_operations import (HEAD, AnyBranchName, AnyRevision,
                                         SyncToRemoteStatus)
 from git_machete.utils import (InteractionStopped, MacheteException,
                                UnexpectedMacheteException, debug, excluding,
-                               flat_map, get_second, input_fmt,
-                               join_paths_posix, pretty_choices, print_fmt,
-                               relpath_posix, tupled, warn)
+                               get_second, input_fmt, join_paths_posix,
+                               pretty_choices, print_fmt, relpath_posix,
+                               tupled, warn)
 
 
 class PickRoot(Enum):
     FIRST = auto()
     LAST = auto()
-
-
-class MacheteState:
-    def __init__(self) -> None:
-        self.managed_branches: List[LocalBranchShortName] = []
-        self.roots: List[LocalBranchShortName] = []
-        self.up_branch_for: Dict[LocalBranchShortName, LocalBranchShortName] = {}
-        self.down_branches_for: Dict[LocalBranchShortName, List[LocalBranchShortName]] = {}
-        self.annotations: Dict[LocalBranchShortName, Annotation] = {}
 
 
 class MacheteClient:
@@ -92,7 +84,7 @@ class MacheteClient:
 
     @property
     def managed_branches(self) -> List[LocalBranchShortName]:
-        return self._state.managed_branches
+        return self._state.managed_branches  # returns a copy
 
     @property
     def addable_branches(self) -> List[LocalBranchShortName]:
@@ -113,22 +105,17 @@ class MacheteClient:
 
     @property
     def childless_managed_branches(self) -> List[LocalBranchShortName]:
-        parent_branches = [parent_branch for parent_branch, child_branches in self._state.down_branches_for.items() if child_branches]
-        return excluding(self.managed_branches, parent_branches)
+        return [b for b in self._state.managed_branches if not self._state.get_children(b)]
 
     @property
     def branches_with_overridden_fork_point(self) -> List[LocalBranchShortName]:
         return [branch for branch in self._git.get_local_branches() if self.has_any_fork_point_override_config(branch)]
 
-    @property
-    def annotations(self) -> Dict[LocalBranchShortName, Annotation]:
-        return self._state.annotations
+    def parent_of(self, branch: LocalBranchShortName) -> Optional[LocalBranchShortName]:
+        return self._state.get_parent(branch)
 
-    def up_branch_for(self, branch: LocalBranchShortName) -> Optional[LocalBranchShortName]:
-        return self._state.up_branch_for.get(branch)
-
-    def down_branches_for(self, branch: LocalBranchShortName) -> Optional[List[LocalBranchShortName]]:
-        return self._state.down_branches_for.get(branch)
+    def children_of(self, branch: LocalBranchShortName) -> Optional[List[LocalBranchShortName]]:
+        return self._state.get_children(branch)
 
     def expect_in_managed_branches(self, branch: LocalBranchShortName) -> None:
         if branch not in self.managed_branches:
@@ -141,7 +128,7 @@ class MacheteClient:
             raise MacheteException(f"<b>{branch}</b> is not a local branch")
 
     def expect_at_least_one_managed_branch(self) -> None:
-        if not self._state.roots:
+        if not self._state.roots:  # property returns a copy; falsy check works fine
             self.__raise_no_branches_error()
 
     def __raise_no_branches_error(self) -> NoReturn:
@@ -177,15 +164,13 @@ class MacheteClient:
             branch_and_maybe_annotation: List[LocalBranchShortName] = [LocalBranchShortName.of(entry) for entry in
                                                                        line.strip().split(" ", 1)]
             branch = branch_and_maybe_annotation[0]
-            if len(branch_and_maybe_annotation) > 1:
-                self._state.annotations[branch] = Annotation.parse(branch_and_maybe_annotation[1])
-            if branch in self.managed_branches:
+            annotation = Annotation.parse(branch_and_maybe_annotation[1]) if len(branch_and_maybe_annotation) > 1 else None
+            if self._state.is_managed(branch):
                 raise MacheteException(
                     f"{self._branch_layout_file_path}, line {index + 1}: branch "
                     f"<b>{branch}</b> re-appears in the branch layout. {hint}")
             if verify_branches and branch not in self._git.get_local_branches():
                 invalid_branches += [branch]
-            self._state.managed_branches += [branch]
 
             if prefix:
                 assert self.__indent is not None
@@ -209,15 +194,8 @@ class MacheteClient:
             last_depth = depth
 
             at_depth[depth] = branch
-            if depth:
-                p = at_depth[depth - 1]
-                self._state.up_branch_for[branch] = p
-                if p in self._state.down_branches_for:
-                    self._state.down_branches_for[p] += [branch]
-                else:
-                    self._state.down_branches_for[p] = [branch]
-            else:
-                self._state.roots += [branch]
+            parent = at_depth[depth - 1] if depth else None
+            self._state.add_branch(branch, parent=parent, annotation=annotation)
 
         if not invalid_branches:
             return
@@ -243,28 +221,8 @@ class MacheteClient:
             print_fmt(f"Warning: sliding {what} out of the branch layout file", file=sys.stderr)
             ans = 'y'
 
-        def recursive_slide_out_invalid_branches(branch: LocalBranchShortName) -> List[LocalBranchShortName]:
-            new_down_branches = flat_map(
-                recursive_slide_out_invalid_branches, self.down_branches_for(branch) or [])
-            if branch in invalid_branches:
-                if branch in self._state.down_branches_for:
-                    del self._state.down_branches_for[branch]
-                if branch in self._state.annotations:
-                    del self._state.annotations[branch]
-                if branch in self._state.up_branch_for:
-                    for down_branch in new_down_branches:
-                        self._state.up_branch_for[down_branch] = self._state.up_branch_for[branch]
-                    del self._state.up_branch_for[branch]
-                else:
-                    for down_branch in new_down_branches:
-                        del self._state.up_branch_for[down_branch]
-                return new_down_branches
-            else:
-                self._state.down_branches_for[branch] = new_down_branches
-                return [branch]
-
-        self._state.roots = flat_map(recursive_slide_out_invalid_branches, self._state.roots)
-        self._state.managed_branches = excluding(self.managed_branches, invalid_branches)
+        for branch in invalid_branches:
+            self._state.splice_out(branch)
         if ans in ('y', 'yes'):
             self.save_branch_layout_file()
         elif ans in ('e', 'edit'):
@@ -274,14 +232,15 @@ class MacheteClient:
 
     def render_branch_layout_file(self, indent: str) -> List[str]:
         def render_dfs(branch: LocalBranchShortName, depth: int) -> List[str]:
-            annotation = (" " + self.annotations[branch].unformatted_full_text) if branch in self.annotations else ""
+            anno = self._state.get_annotation(branch)
+            annotation = (" " + anno.unformatted_full_text) if anno is not None else ""
             res: List[str] = [depth * indent + branch + annotation]
-            for down_branch in self.down_branches_for(branch) or []:
-                res += render_dfs(down_branch, depth + 1)
+            for child in self.children_of(branch) or []:
+                res += render_dfs(child, depth + 1)
             return res
 
         result: List[str] = []
-        for root in self._state.roots:
+        for root in self._state.roots:  # property returns a copy
             result += render_dfs(root, depth=0)
         return result
 
@@ -342,8 +301,7 @@ class MacheteClient:
                                 # In this case (empty .git/machete, creating a new branch with `git machete add`)
                                 # it's usually pretty obvious that the current branch needs to be added as root first.
                                 # Let's skip interactive questions so as not to confuse new users.
-                                self._state.roots = [current_branch]
-                                self._state.managed_branches = [current_branch]
+                                self._state.bootstrap_as_single_managed(current_branch)
                                 # This section of code is only ever executed in verbose mode, but let's leave the `if` for consistency
                                 if verbose:  # pragma: no branch
                                     print_fmt(f"Added branch <b>{current_branch}</b> as a new root")
@@ -353,16 +311,16 @@ class MacheteClient:
                     return
 
         if opt_as_root or not self._state.roots:
-            self._state.roots += [branch]
+            self._state.add_as_root(branch)
             if verbose:
                 print_fmt(f"Added branch <b>{branch}</b> as a new root")
         else:
             if not opt_onto:
-                upstream = self._infer_upstream(
+                parent = self._infer_upstream(
                     branch,
                     condition=lambda x: x in self.managed_branches,
                     reject_reason_message="this candidate is not a managed branch")
-                if not upstream:
+                if not parent:
                     raise MacheteException(
                         f"Could not automatically infer upstream (parent) branch for <b>{branch}</b>.\n"
                         "You can either:\n"
@@ -371,26 +329,18 @@ class MacheteClient:
                         "3) edit the branch layout file manually with `git machete edit`")
                 else:
                     msg = (f"Add <b>{branch}</b> onto the inferred upstream (parent) "
-                           f"branch <b>{upstream}</b>?" + pretty_choices('y', 'N'))
+                           f"branch <b>{parent}</b>?" + pretty_choices('y', 'N'))
                     opt_yes_msg = (f"Adding <b>{branch}</b> onto the inferred upstream"
-                                   f" (parent) branch <b>{upstream}</b>")
+                                   f" (parent) branch <b>{parent}</b>")
                     if self.ask_if(msg, opt_yes_msg, opt_yes=opt_yes, verbose=verbose) in ('y', 'yes'):
-                        opt_onto = upstream
+                        opt_onto = parent
                     else:
                         return
 
-            self._state.up_branch_for[branch] = opt_onto
-
-            existing_down_branches = self._state.down_branches_for[opt_onto] if opt_onto in self._state.down_branches_for else []
-            if opt_as_first_child:
-                down_branches = [branch] + existing_down_branches
-            else:
-                down_branches = existing_down_branches + [branch]
-            self._state.down_branches_for[opt_onto] = down_branches
+            self._state.add_as_child(branch=branch, parent=opt_onto, as_first_child=opt_as_first_child)
             if verbose:
                 print_fmt(f"Added branch <b>{branch}</b> onto <b>{opt_onto}</b>")
 
-        self._state.managed_branches += [branch]
         self.save_branch_layout_file()
 
     def _mark_trailing_blank_line(self) -> None:
@@ -417,7 +367,7 @@ class MacheteClient:
     ) -> None:
         self._git.expect_no_operation_in_progress()
 
-        anno = self.annotations.get(branch)
+        anno = self._state.get_annotation(branch)
         if anno and not anno.qualifiers.rebase:
             raise MacheteException(f"Branch <b>{branch}</b> is annotated with `rebase=no` qualifier, aborting.\n"
                                    f"Remove the qualifier using `git machete anno` or edit branch layout file directly.")
@@ -469,12 +419,12 @@ class MacheteClient:
                 self._git.delete_branch(branch, force=True)
         else:
             for branch in branches_to_delete:
-                if self.is_merged_to(branch=branch, upstream=AnyBranchName('HEAD'), opt_squash_merge_detection=opt_squash_merge_detection):
+                if self.is_merged_to(branch=branch, parent=AnyBranchName('HEAD'), opt_squash_merge_detection=opt_squash_merge_detection):
                     remote_branch = self._git.get_strict_counterpart_for_fetching_of_branch(branch)
                     if remote_branch:
                         is_merged_to_remote = self.is_merged_to(
                             branch=branch,
-                            upstream=remote_branch,
+                            parent=remote_branch,
                             opt_squash_merge_detection=opt_squash_merge_detection)
                     else:
                         is_merged_to_remote = True
@@ -557,26 +507,26 @@ class MacheteClient:
         *,
         use_overrides: bool
     ) -> Tuple[FullCommitHash, List[BranchPair]]:
-        upstream = self.up_branch_for(branch)
-        upstream_hash = self._git.get_commit_hash_by_revision(upstream) if upstream else None
+        parent = self.parent_of(branch)
+        upstream_hash = self._git.get_commit_hash_by_revision(parent) if parent else None
 
         if use_overrides:
             overridden_fork_point = self._get_overridden_fork_point(branch)
             if overridden_fork_point:
-                if upstream and upstream_hash and \
-                        self._git.is_ancestor_or_equal(upstream.full_name(), branch.full_name()) and \
-                        not self._git.is_ancestor_or_equal(upstream.full_name(), overridden_fork_point):
-                    # We need to handle the case when branch is a descendant of upstream,
-                    # but the fork point of branch is overridden to a commit that is NOT a descendant of upstream.
-                    # In this case it's more reasonable to assume that upstream (and not overridden_fork_point) is the fork point.
+                if parent and upstream_hash and \
+                        self._git.is_ancestor_or_equal(parent.full_name(), branch.full_name()) and \
+                        not self._git.is_ancestor_or_equal(parent.full_name(), overridden_fork_point):
+                    # We need to handle the case when branch is a descendant of parent,
+                    # but the fork point of branch is overridden to a commit that is NOT a descendant of parent.
+                    # In this case it's more reasonable to assume that parent (and not overridden_fork_point) is the fork point.
                     debug(
-                        f"{branch} is descendant of its upstream {upstream}, but overridden fork point commit {overridden_fork_point} "
-                        f"is NOT a descendant of {upstream}; falling back to {upstream} as fork point")
+                        f"{branch} is descendant of its parent {parent}, but overridden fork point commit {overridden_fork_point} "
+                        f"is NOT a descendant of {parent}; falling back to {parent} as fork point")
                     return upstream_hash, []
-                elif upstream and \
-                        self._git.is_ancestor_or_equal(overridden_fork_point, upstream.full_name()):
-                    common_ancestor = self._git.get_merge_base(upstream.full_name(), branch.full_name())
-                    # We are sure that a common ancestor exists - `overridden_fork_point` is an ancestor of both `branch` and `upstream`.
+                elif parent and \
+                        self._git.is_ancestor_or_equal(overridden_fork_point, parent.full_name()):
+                    common_ancestor = self._git.get_merge_base(parent.full_name(), branch.full_name())
+                    # We are sure that a common ancestor exists - `overridden_fork_point` is an ancestor of both `branch` and `parent`.
                     assert common_ancestor is not None
                     return common_ancestor, []
                 else:
@@ -586,18 +536,18 @@ class MacheteClient:
         try:
             computed_fork_point, containing_branch_pairs = next(self.__match_log_to_filtered_reflogs(branch))
         except StopIteration:
-            if upstream and upstream_hash:
-                if self._git.is_ancestor_or_equal(upstream.full_name(), branch.full_name()):
+            if parent and upstream_hash:
+                if self._git.is_ancestor_or_equal(parent.full_name(), branch.full_name()):
                     debug(
-                        f"cannot find fork point, but {branch} is a descendant of its upstream {upstream}; "
-                        f"falling back to {upstream} as fork point")
+                        f"cannot find fork point, but {branch} is a descendant of its parent {parent}; "
+                        f"falling back to {parent} as fork point")
                     return upstream_hash, []
                 else:
-                    common_ancestor_hash = self._git.get_merge_base(upstream.full_name(), branch.full_name())
+                    common_ancestor_hash = self._git.get_merge_base(parent.full_name(), branch.full_name())
                     if common_ancestor_hash:
                         debug(
-                            f"cannot find fork point, and {branch} is NOT a descendant of its upstream {upstream}; "
-                            f"falling back to common ancestor of {branch} and {upstream} (commit {common_ancestor_hash}) as fork point")
+                            f"cannot find fork point, and {branch} is NOT a descendant of its parent {parent}; "
+                            f"falling back to common ancestor of {branch} and {parent} (commit {common_ancestor_hash}) as fork point")
                         return common_ancestor_hash, []
             raise MacheteException(f"Fork point not found for branch <b>{branch}</b>; "
                                    f"use `git machete fork-point {branch} --override-to...`")
@@ -606,30 +556,30 @@ class MacheteClient:
                   "filtered reflog of any other branch or its remote counterpart "
                   f"(specifically: {' and '.join(map(utils.get_second, containing_branch_pairs))})")
 
-            if upstream and upstream_hash and \
-                    self._git.is_ancestor_or_equal(upstream.full_name(), branch.full_name()) and \
-                    not self._git.is_ancestor_or_equal(upstream.full_name(), computed_fork_point):
+            if parent and upstream_hash and \
+                    self._git.is_ancestor_or_equal(parent.full_name(), branch.full_name()) and \
+                    not self._git.is_ancestor_or_equal(parent.full_name(), computed_fork_point):
                 # That happens very rarely in practice (typically current head
-                # of any branch, including upstream, should occur on the reflog
-                # of this branch, thus is_ancestor(upstream, branch) should imply
-                # is_ancestor(upstream, FP(branch)), but it's still possible in
-                # case reflog of upstream is incomplete for whatever reason.
+                # of any branch, including parent, should occur on the reflog
+                # of this branch, thus is_ancestor(parent, branch) should imply
+                # is_ancestor(parent, FP(branch)), but it's still possible in
+                # case reflog of parent is incomplete for whatever reason.
                 debug(
-                    f"{upstream} is an ancestor of {branch}, "
-                    f"but the inferred fork point commit {computed_fork_point} is NOT a descendant of {upstream}; "
-                    f"falling back to {upstream} as fork point")
+                    f"{parent} is an ancestor of {branch}, "
+                    f"but the inferred fork point commit {computed_fork_point} is NOT a descendant of {parent}; "
+                    f"falling back to {parent} as fork point")
                 return upstream_hash, []
-            elif upstream and \
-                    not self._git.is_ancestor_or_equal(upstream.full_name(), branch.full_name()) and \
-                    self._git.is_ancestor_or_equal(computed_fork_point, upstream.full_name()):
+            elif parent and \
+                    not self._git.is_ancestor_or_equal(parent.full_name(), branch.full_name()) and \
+                    self._git.is_ancestor_or_equal(computed_fork_point, parent.full_name()):
 
-                # We are sure that a common ancestor exists - `computed_fork_point` is an ancestor of both `branch` and `upstream`.
-                common_ancestor_hash = self._git.get_merge_base(upstream.full_name(), branch.full_name())
+                # We are sure that a common ancestor exists - `computed_fork_point` is an ancestor of both `branch` and `parent`.
+                common_ancestor_hash = self._git.get_merge_base(parent.full_name(), branch.full_name())
                 assert common_ancestor_hash is not None
                 debug(
-                    f"{upstream} is NOT an ancestor of {branch}, "
-                    f"but the inferred fork point commit {computed_fork_point} is an ancestor of {upstream}; "
-                    f"falling back to the common ancestor of {branch} and {upstream} (commit {common_ancestor_hash}) as fork point")
+                    f"{parent} is NOT an ancestor of {branch}, "
+                    f"but the inferred fork point commit {computed_fork_point} is an ancestor of {parent}; "
+                    f"falling back to the common ancestor of {branch} and {parent} (commit {common_ancestor_hash}) as fork point")
                 return common_ancestor_hash, []
             else:
                 improved_fork_point = computed_fork_point
@@ -656,27 +606,30 @@ class MacheteClient:
         except MacheteException:
             return None
 
-    def get_or_pick_down_branch_for(self, branch: LocalBranchShortName, *, pick_if_multiple: bool) -> List[LocalBranchShortName]:
+    def get_or_pick_child_of(self, branch: LocalBranchShortName, *, pick_if_multiple: bool) -> List[LocalBranchShortName]:
         self.expect_in_managed_branches(branch)
-        dbs = self.down_branches_for(branch)
-        if not dbs:
+        children = self.children_of(branch)
+        if not children:
             raise MacheteException(f"Branch <b>{branch}</b> has no downstream branch")
-        elif len(dbs) == 1:
-            return [dbs[0]]
+        elif len(children) == 1:
+            return [children[0]]
         elif pick_if_multiple:
-            return [self.pick(dbs, "downstream branch")]
+            return [self.pick(children, "downstream branch")]
         else:
-            return dbs
+            return children
 
     def first_branch_for(self, branch: LocalBranchShortName) -> LocalBranchShortName:
         root = self.root_branch_for(branch, if_unmanaged=PickRoot.FIRST)
-        root_dbs = self.down_branches_for(root)
-        return root_dbs[0] if root_dbs else root
+        root_children = self.children_of(root)
+        return root_children[0] if root_children else root
 
     def last_branch_for(self, branch: LocalBranchShortName) -> LocalBranchShortName:
         destination = self.root_branch_for(branch, if_unmanaged=PickRoot.LAST)
-        while self.down_branches_for(destination):
-            destination = self._state.down_branches_for[destination][-1]
+        while True:
+            children = self._state.get_children(destination)
+            if not children:
+                break
+            destination = children[-1]
         return destination
 
     def next_branch_for(self, branch: LocalBranchShortName) -> LocalBranchShortName:
@@ -694,64 +647,67 @@ class MacheteClient:
         return self.managed_branches[index]
 
     def first_root_branch(self) -> LocalBranchShortName:
-        if self._state.roots:
-            return self._state.roots[0]
+        roots = self._state.roots
+        if roots:
+            return roots[0]
         else:
             self.__raise_no_branches_error()  # pragma: no cover; this case should never happen
 
     def last_root_branch(self) -> LocalBranchShortName:
-        if self._state.roots:
-            return self._state.roots[-1]
+        roots = self._state.roots
+        if roots:
+            return roots[-1]
         else:
             self.__raise_no_branches_error()  # pragma: no cover; this case should never happen
 
     def root_branch_for(self, branch: LocalBranchShortName, if_unmanaged: PickRoot) -> LocalBranchShortName:
         if branch not in self.managed_branches:
-            if self._state.roots:
+            roots = self._state.roots
+            if roots:
                 if if_unmanaged == PickRoot.FIRST:
                     warn(
                         f"<b>{branch}</b> is not a managed branch, assuming "
-                        f"{self._state.roots[0]}{' (the first root)' if len(self._state.roots) > 1 else ''} instead as root")
-                    return self._state.roots[0]
+                        f"{roots[0]}{' (the first root)' if len(roots) > 1 else ''} instead as root")
+                    return roots[0]
                 else:  # if_unmanaged == PickRoot.LAST
                     warn(
                         f"<b>{branch}</b> is not a managed branch, assuming "
-                        f"{self._state.roots[-1]}{' (the last root)' if len(self._state.roots) > 1 else ''} instead as root")
-                    return self._state.roots[-1]
+                        f"{roots[-1]}{' (the last root)' if len(roots) > 1 else ''} instead as root")
+                    return roots[-1]
             else:
                 self.__raise_no_branches_error()
-        upstream = self.up_branch_for(branch)
-        while upstream:
-            branch = upstream
-            upstream = self.up_branch_for(branch)
+        parent = self.parent_of(branch)
+        while parent:
+            branch = parent
+            parent = self.parent_of(branch)
         return branch
 
-    def get_or_infer_up_branch_for(self,
-                                   branch: LocalBranchShortName,
-                                   prompt_if_inferred_msg: Optional[str],
-                                   prompt_if_inferred_yes_opt_msg: Optional[str]) -> LocalBranchShortName:
+    def get_or_infer_parent_of(self,
+                               branch: LocalBranchShortName,
+                               prompt_if_inferred_msg: Optional[str],
+                               prompt_if_inferred_yes_opt_msg: Optional[str]) -> LocalBranchShortName:
         if branch in self.managed_branches:
-            upstream = self.up_branch_for(branch)
-            if upstream:
-                return upstream
+            parent = self.parent_of(branch)
+            if parent:
+                return parent
             else:
                 raise MacheteException(f"Branch <b>{branch}</b> has no upstream branch")
         else:
-            upstream = self._infer_upstream(branch)
-            if upstream:
+            parent = self._infer_upstream(branch)
+            if parent:
                 if prompt_if_inferred_msg and prompt_if_inferred_yes_opt_msg:
                     if self.ask_if(
-                            prompt_if_inferred_msg % (branch, upstream),
-                            prompt_if_inferred_yes_opt_msg % (branch, upstream),
+                            prompt_if_inferred_msg % (branch, parent),
+                            prompt_if_inferred_yes_opt_msg % (branch, parent),
                             opt_yes=False
                     ) in ('y', 'yes'):
-                        return upstream
+                        return parent
                     raise MacheteException("Aborting.")
                 else:
                     warn(
                         f"branch <b>{branch}</b> not found in the tree of branch "
-                        f"dependencies; the upstream has been inferred to <b>{upstream}</b>")
-                    return upstream
+                        f"dependencies; the upstream has been inferred to <b>{parent}</b>")
+                    return parent
             else:
                 raise MacheteException(
                     f"Branch <b>{branch}</b> not found in the tree of branch "
@@ -763,18 +719,18 @@ class MacheteClient:
         return self.managed_branches
 
     def get_slidable_after(self, branch: LocalBranchShortName) -> List[LocalBranchShortName]:
-        if branch in self._state.up_branch_for:
-            dbs = self.down_branches_for(branch)
-            if dbs and len(dbs) == 1:
-                return dbs
+        if self._state.has_parent(branch):
+            children = self.children_of(branch)
+            if children and len(children) == 1:
+                return children
         return []
 
-    def _is_merged_to_upstream(
+    def _is_merged_to_parent(
             self, branch: LocalBranchShortName, *, opt_squash_merge_detection: SquashMergeDetection) -> bool:
-        upstream = self.up_branch_for(branch)
-        if not upstream:
+        parent = self.parent_of(branch)
+        if not parent:
             return False
-        return self.is_merged_to(branch=branch, upstream=upstream, opt_squash_merge_detection=opt_squash_merge_detection)
+        return self.is_merged_to(branch=branch, parent=parent, opt_squash_merge_detection=opt_squash_merge_detection)
 
     def _run_post_slide_out_hook(
         self,
@@ -827,7 +783,7 @@ class MacheteClient:
                   entry_hash not in hashes_to_exclude and not is_excluded_reflog_subject(entry_hash, reflog_subject)]
         reflog = (", ".join(result) or "<empty>")
         debug("computed filtered reflog (= reflog without branch creation "
-              f"and branch reset events irrelevant for fork point/upstream inference): {reflog}")
+              f"and branch reset events irrelevant for fork point/parent inference): {reflog}")
         return result
 
     def __match_log_to_filtered_reflogs(self, branch: LocalBranchShortName) -> Iterator[Tuple[FullCommitHash, List[BranchPair]]]:
@@ -879,7 +835,7 @@ class MacheteClient:
                                                    total_count=TOTAL_COMMIT_COUNT_FOR_LOG):
             if hash in self.__branch_pairs_by_hash_in_reflog:
                 # The entries must be sorted by lb_or_rb to make sure the
-                # upstream inference is deterministic (and does not depend on the
+                # parent inference is deterministic (and does not depend on the
                 # order in which `generate_entries` iterated through the local branches).
                 branch_pairs: List[BranchPair] = self.__branch_pairs_by_hash_in_reflog[hash]
 
@@ -897,7 +853,7 @@ class MacheteClient:
 
     def _infer_upstream(self,
                         branch: LocalBranchShortName,
-                        condition: Callable[[LocalBranchShortName], bool] = lambda upstream: True,
+                        condition: Callable[[LocalBranchShortName], bool] = lambda parent: True,
                         *,
                         reject_reason_message: str = ""
                         ) -> Optional[LocalBranchShortName]:
@@ -1111,13 +1067,13 @@ class MacheteClient:
             self,
             *,
             branch: AnyBranchName,
-            upstream: AnyBranchName,
+            parent: AnyBranchName,
             opt_squash_merge_detection: SquashMergeDetection
     ) -> bool:
-        if self._git.is_ancestor_or_equal(branch.full_name(), upstream.full_name()):
-            # If branch is ancestor of or equal to the upstream, we need to distinguish between the
-            # case of branch being "recently" created from the upstream and the case of
-            # branch being fast-forward-merged to the upstream.
+        if self._git.is_ancestor_or_equal(branch.full_name(), parent.full_name()):
+            # If branch is ancestor of or equal to the parent, we need to distinguish between the
+            # case of branch being "recently" created from the parent and the case of
+            # branch being fast-forward-merged to the parent.
             # The applied heuristics is to check if the filtered reflog of the branch
             # (reflog stripped of trivial events like branch creation, reset etc.)
             # is non-empty.
@@ -1126,14 +1082,14 @@ class MacheteClient:
             return False
         elif opt_squash_merge_detection == SquashMergeDetection.SIMPLE:
             # In the default mode.
-            # If a commit with an identical tree state to branch is reachable from upstream,
-            # then branch may have been squashed or rebase-merged into upstream.
-            return self._git.is_equivalent_tree_reachable(equivalent_to=branch, reachable_from=upstream)
+            # If a commit with an identical tree state to branch is reachable from parent,
+            # then branch may have been squashed or rebase-merged into parent.
+            return self._git.is_equivalent_tree_reachable(equivalent_to=branch, reachable_from=parent)
         elif opt_squash_merge_detection == SquashMergeDetection.EXACT:
             # Let's try another way, a little more complex but takes into account the possibility
             # that there were other commits between the common ancestor of the two branches and the squashed merge.
-            return self._git.is_equivalent_tree_reachable(equivalent_to=branch, reachable_from=upstream) or \
-                self._git.is_equivalent_patch_reachable(equivalent_to=branch, reachable_from=upstream)
+            return self._git.is_equivalent_tree_reachable(equivalent_to=branch, reachable_from=parent) or \
+                self._git.is_equivalent_patch_reachable(equivalent_to=branch, reachable_from=parent)
         else:  # pragma: no cover
             raise UnexpectedMacheteException(f"Invalid squash merged detection mode: {opt_squash_merge_detection}.")
 
@@ -1315,7 +1271,7 @@ class MacheteClient:
         branches_to_delete: List[LocalBranchShortName] = []
         for branch in self.managed_branches.copy():
             status, _ = self._git.get_combined_remote_sync_status(branch)
-            if status == SyncToRemoteStatus.UNTRACKED and not self.down_branches_for(branch):
+            if status == SyncToRemoteStatus.UNTRACKED and not self.children_of(branch):
                 branches_to_delete.append(branch)
 
         self._remove_branches_from_layout(branches_to_delete)
@@ -1323,16 +1279,5 @@ class MacheteClient:
 
     def _remove_branches_from_layout(self, branches_to_delete: List[LocalBranchShortName]) -> None:
         for branch in branches_to_delete:
-            self.managed_branches.remove(branch)
-            if branch in self._state.annotations:
-                del self._state.annotations[branch]
-            if branch in self._state.up_branch_for:
-                upstream = self._state.up_branch_for[branch]
-                del self._state.up_branch_for[branch]
-                self._state.down_branches_for[upstream] = [
-                    b for b in (self.down_branches_for(upstream) or []) if b != branch
-                ]
-            else:
-                self._state.roots.remove(branch)
-
+            self._state.remove_leaf(branch)
         self.save_branch_layout_file()

--- a/git_machete/client/discover.py
+++ b/git_machete/client/discover.py
@@ -26,22 +26,22 @@ class DiscoverMacheteClient(StatusMacheteClient):
             raise MacheteException("No local branches found")
         for root in opt_roots:
             self.expect_in_local_branches(root)
+        initial_roots: List[LocalBranchShortName] = []
         if opt_roots:
-            self._state.roots = [LocalBranchShortName.of(opt_root) for opt_root in opt_roots]
+            initial_roots = [LocalBranchShortName.of(opt_root) for opt_root in opt_roots]
         else:
-            self._state.roots = []
             if "master" in self._git.get_local_branches():
-                self._state.roots += [LocalBranchShortName.of("master")]
+                initial_roots.append(LocalBranchShortName.of("master"))
             elif "main" in self._git.get_local_branches():
                 # See https://github.com/github/renaming
-                self._state.roots += [LocalBranchShortName.of("main")]
+                initial_roots.append(LocalBranchShortName.of("main"))
             if "develop" in self._git.get_local_branches():
-                self._state.roots += [LocalBranchShortName.of("develop")]
-        self._state.down_branches_for = {}
-        self._state.up_branch_for = {}
-        self.__indent = "  "
-        for branch in self.annotations.keys():
-            self.annotations[branch] = self.annotations[branch]._replace(text_without_qualifiers='')
+                initial_roots.append(LocalBranchShortName.of("develop"))
+        for branch in self._state.managed_branches:
+            anno = self._state.get_annotation(branch)
+            if anno is not None:
+                self._state.set_annotation(branch, anno._replace(text_without_qualifiers=''))
+        self._state.reset_tree(initial_roots)
 
         root_of = dict((branch, branch) for branch in all_local_branches)
 
@@ -50,7 +50,7 @@ class DiscoverMacheteClient(StatusMacheteClient):
                 root_of[branch] = get_root_of(root_of[branch])
             return root_of[branch]
 
-        non_root_fixed_branches = excluding(all_local_branches, self._state.roots)
+        non_root_fixed_branches = excluding(all_local_branches, self._state.roots)  # property returns a copy
         last_checkout_timestamps = self._git.get_latest_checkout_timestamps()
         non_root_fixed_branches_by_last_checkout_timestamps: List[Tuple[int, LocalBranchShortName]] = sorted(
             (last_checkout_timestamps.get(branch, 0), branch) for branch in non_root_fixed_branches)
@@ -80,35 +80,31 @@ class DiscoverMacheteClient(StatusMacheteClient):
             return
 
         for branch in excluding(non_root_fixed_branches, stale_non_root_fixed_branches):
-            upstream = self._infer_upstream(
+            parent = self._infer_upstream(
                 branch,
                 condition=lambda candidate: (get_root_of(candidate) != branch and candidate not in stale_non_root_fixed_branches),
                 reject_reason_message=("choosing this candidate would form a "
                                        "cycle in the resulting graph or the candidate is a stale branch"))
-            if upstream:
-                debug(f"inferred upstream of {branch} is {upstream}, attaching {branch} as a child of {upstream}")
-                self._state.up_branch_for[branch] = upstream
-                root_of[branch] = upstream
-                if upstream in self._state.down_branches_for:
-                    self._state.down_branches_for[upstream] += [branch]
-                else:
-                    self._state.down_branches_for[upstream] = [branch]
+            if parent:
+                debug(f"inferred parent of {branch} is {parent}, attaching {branch} as a child of {parent}")
+                self._state.wire_as_child(parent=parent, child=branch)
+                root_of[branch] = parent
             else:
-                debug(f"inferred no upstream for {branch}, attaching {branch} as a new root")
-                self._state.roots += [branch]
+                debug(f"inferred no parent for {branch}, attaching {branch} as a new root")
+                self._state.wire_as_root(branch)
 
         # Let's remove merged branches for which no downstream branch have been found.
         merged_branches_to_skip = []
         for branch in fresh_branches:
-            upstream = self.up_branch_for(branch)
-            if upstream and not self.down_branches_for(branch):
+            parent = self.parent_of(branch)
+            if parent and not self.children_of(branch):
                 if self.is_merged_to(
                         branch=branch,
-                        upstream=upstream,
+                        parent=parent,
                         opt_squash_merge_detection=SquashMergeDetection.SIMPLE
                 ):
-                    debug(f"inferred upstream of {branch} is {upstream}, but "
-                          f"{branch} is merged to {upstream}; skipping {branch} from discovered tree")
+                    debug(f"inferred parent of {branch} is {parent}, but "
+                          f"{branch} is merged to {parent}; skipping {branch} from discovered tree")
                     merged_branches_to_skip += [branch]
         if merged_branches_to_skip:
             warn(
@@ -117,24 +113,23 @@ class DiscoverMacheteClient(StatusMacheteClient):
                 % (", ".join(f"<b>{branch}</b>" for branch in merged_branches_to_skip),
                    "it's" if len(merged_branches_to_skip) == 1 else "they're"))
             for branch in merged_branches_to_skip:
-                upstream = self._state.up_branch_for[branch]
-                self._state.down_branches_for[upstream] = excluding(self._state.down_branches_for[upstream], [branch])
-                del self._state.up_branch_for[branch]
+                self._state.detach_leaf(branch)
             # We're NOT applying the removal process recursively,
             # so it's theoretically possible that some merged branches became childless
             # after removing the outer layer of childless merged branches.
             # This is rare enough, however, that we can pretty much ignore this corner case.
 
         # Order managed_branches by DFS from roots (same order as in .git/machete file)
-        self._state.managed_branches = []
+        dfs_branches: List[LocalBranchShortName] = []
 
         def collect_branches_dfs(parent: LocalBranchShortName) -> None:
-            self._state.managed_branches.append(parent)
-            for child in self.down_branches_for(parent) or []:
+            dfs_branches.append(parent)
+            for child in self._state.get_children(parent) or []:
                 collect_branches_dfs(child)
 
         for root in self._state.roots:
             collect_branches_dfs(root)
+        self._state.set_managed(dfs_branches)
 
         print_fmt("<b>Discovered tree of branch dependencies:</b>\n")
         self.status(

--- a/git_machete/client/go_interactive.py
+++ b/git_machete/client/go_interactive.py
@@ -180,12 +180,12 @@ class GoInteractiveMacheteClient(StatusMacheteClient):
                     selected_idx = len(branches) - 1
                 elif key == AI.KEY_LEFT:
                     selected_branch = branches[selected_idx]
-                    parent_branch = self.up_branch_for(selected_branch)
+                    parent_branch = self.parent_of(selected_branch)
                     if parent_branch is not None:
                         selected_idx = branches.index(parent_branch)
                 elif key == AI.KEY_RIGHT:
                     selected_branch = branches[selected_idx]
-                    child_branches = self.down_branches_for(selected_branch)
+                    child_branches = self.children_of(selected_branch)
                     if child_branches:
                         selected_idx = branches.index(child_branches[0])
                 elif key in AI.KEYS_ENTER or key == AI.KEY_SPACE:

--- a/git_machete/client/go_show.py
+++ b/git_machete/client/go_show.py
@@ -19,7 +19,7 @@ class GoShowMacheteClient(MacheteClient):
         elif param in ("d", "down"):
             if branch is None:
                 raise MacheteException("Not currently on any branch")
-            return self.get_or_pick_down_branch_for(branch, pick_if_multiple=pick_if_multiple)
+            return self.get_or_pick_child_of(branch, pick_if_multiple=pick_if_multiple)
         elif param in ("f", "first"):
             # If branch is None (detached HEAD), use first root then get first branch
             if branch is None:
@@ -49,6 +49,6 @@ class GoShowMacheteClient(MacheteClient):
         elif param in ("u", "up"):
             if branch is None:
                 raise MacheteException("Not currently on any branch")
-            return [self.get_or_infer_up_branch_for(branch, prompt_if_inferred_msg=None, prompt_if_inferred_yes_opt_msg=None)]
+            return [self.get_or_infer_parent_of(branch, prompt_if_inferred_msg=None, prompt_if_inferred_yes_opt_msg=None)]
         else:  # an unknown direction is handled by argparse
             raise UnexpectedMacheteException(f"Invalid direction: `{param}`.")

--- a/git_machete/client/rename.py
+++ b/git_machete/client/rename.py
@@ -21,7 +21,7 @@ class RenameMacheteClient(MacheteClient):
         # so after rename the new branch keeps tracking the same remote branch as before.
         self._git.rename_local_branch(old_name=branch, new_name=new_name)
 
-        self._rename_branch_in_state(old_name=branch, new_name=new_name)
+        self._state.rename_branch(old_name=branch, new_name=new_name)
         self.save_branch_layout_file()
 
         if opt_repoint_tracking:
@@ -38,30 +38,3 @@ class RenameMacheteClient(MacheteClient):
                     print_fmt(f"Unset tracking (remote branch <b>{new_remote_branch}</b> does not exist)")
 
         print_fmt(f"Renamed branch <b>{branch}</b> to <b>{new_name}</b>")
-
-    def _rename_branch_in_state(self, *, old_name: LocalBranchShortName, new_name: LocalBranchShortName) -> None:
-        idx = self._state.managed_branches.index(old_name)
-        self._state.managed_branches[idx] = new_name
-
-        if old_name in self._state.roots:
-            ridx = self._state.roots.index(old_name)
-            self._state.roots[ridx] = new_name
-
-        if old_name in self._state.up_branch_for:
-            parent = self._state.up_branch_for.pop(old_name)
-            self._state.up_branch_for[new_name] = parent
-
-        for k in list(self._state.up_branch_for):
-            if self._state.up_branch_for[k] == old_name:
-                self._state.up_branch_for[k] = new_name
-
-        if old_name in self._state.down_branches_for:
-            children = self._state.down_branches_for.pop(old_name)
-            self._state.down_branches_for[new_name] = children
-
-        for children_list in self._state.down_branches_for.values():
-            if old_name in children_list:
-                children_list[children_list.index(old_name)] = new_name
-
-        if old_name in self._state.annotations:
-            self._state.annotations[new_name] = self._state.annotations.pop(old_name)

--- a/git_machete/client/slide_out.py
+++ b/git_machete/client/slide_out.py
@@ -22,14 +22,14 @@ class SlideOutMacheteClient(MacheteClient):
         # Verify that all branches exist, are managed and are NOT annotated with slide-out=no qualifier.
         for branch in branches_to_slide_out:
             self.expect_in_managed_branches(branch)
-            anno = self.annotations.get(branch)
+            anno = self._state.get_annotation(branch)
             if anno and not anno.qualifiers.slide_out:
                 raise MacheteException(f"Branch <b>{branch}</b> is annotated with `slide-out=no` qualifier, aborting.\n"
                                        f"Remove the qualifier using `git machete anno` or edit branch layout file directly.")
 
         if opt_down_fork_point:
             last_branch_to_slide_out = branches_to_slide_out[-1]
-            children_of_the_last_branch_to_slide_out = self.down_branches_for(last_branch_to_slide_out)
+            children_of_the_last_branch_to_slide_out = self.children_of(last_branch_to_slide_out)
 
             if children_of_the_last_branch_to_slide_out and len(children_of_the_last_branch_to_slide_out) > 1:
                 raise MacheteException("Last branch to slide out can't have more than one child branch "
@@ -43,95 +43,68 @@ class SlideOutMacheteClient(MacheteClient):
                 raise MacheteException("Last branch to slide out must have a child branch "
                                        "if option `--down-fork-point` is passed")
 
-        # Verify that all "interior" slide-out branches have a single downstream pointing to the next slide-out
+        # Verify that all "interior" slide-out branches have a single child pointing to the next slide-out
         for bu, bd in zip(branches_to_slide_out[:-1], branches_to_slide_out[1:]):
-            dbs = self.down_branches_for(bu)
-            if not dbs or len(dbs) == 0:
+            children = self.children_of(bu)
+            if not children or len(children) == 0:
                 raise MacheteException(f"No downstream branch defined for <b>{bu}</b>, cannot slide out")
-            elif len(dbs) > 1:
-                flat_dbs = ", ".join(f"<b>{x}</b>" for x in dbs)
+            elif len(children) > 1:
+                flat_children = ", ".join(f"<b>{x}</b>" for x in children)
                 raise MacheteException(
-                    f"Multiple downstream branches defined for <b>{bu}</b>: {flat_dbs}; cannot slide out")
-            elif dbs != [bd]:
+                    f"Multiple downstream branches defined for <b>{bu}</b>: {flat_children}; cannot slide out")
+            elif children != [bd]:
                 raise MacheteException(f"<b>{bd}</b> is not downstream of <b>{bu}</b>, cannot slide out")
 
-        # Get new branches
-        new_upstream = self._state.up_branch_for.get(branches_to_slide_out[0])
-        new_downstreams = self.down_branches_for(branches_to_slide_out[-1]) or []
+        # Read the connections we need for post-hook and checkout logic before mutating state
+        new_parent = self._state.get_parent(branches_to_slide_out[0])
+        new_children = self._state.get_children(branches_to_slide_out[-1]) or []
 
-        # Remove the slid-out branches from the tree
         for branch in branches_to_slide_out:
-            if branch in self._state.up_branch_for:
-                del self._state.up_branch_for[branch]
-            if branch in self._state.down_branches_for:
-                del self._state.down_branches_for[branch]
-            self.managed_branches.remove(branch)
-
-        # Update the upstream's children list if the slid-out branch had an upstream
-        if new_upstream is not None:
-            self._state.down_branches_for[new_upstream] = [
-                branch for branch in (self.down_branches_for(new_upstream) or [])
-                if branch != branches_to_slide_out[0]]
-        else:
-            # If the slid-out branch was a root, remove it from roots and add its children as new roots
-            root_index = self._state.roots.index(branches_to_slide_out[0])
-            # Replace the slid-out root with its children in the same position
-            self._state.roots = (self._state.roots[:root_index] +
-                                 new_downstreams +
-                                 self._state.roots[root_index + 1:])
-
-        # Reconnect the downstreams to the new upstream in the tree
-        for new_downstream in new_downstreams:
-            if new_upstream is not None:
-                self._state.up_branch_for[new_downstream] = new_upstream
-                self._state.down_branches_for[new_upstream] += [new_downstream]
-            else:
-                # If there's no new upstream, the downstream becomes a root branch
-                del self._state.up_branch_for[new_downstream]
+            self._state.splice_out(branch)
 
         # Update definition, fire post-hook, and perform the branch update
         self.save_branch_layout_file()
         self._run_post_slide_out_hook(
-            new_upstream=new_upstream,
+            new_upstream=new_parent,
             slid_out_branch=branches_to_slide_out[-1],
-            new_downstreams=new_downstreams)
+            new_downstreams=new_children)
 
-        # Check out new upstream if we were on a slid-out branch, but only if there is an upstream
+        # Check out new parent if we were on a slid-out branch, but only if there is a parent
         if self._git.get_current_branch_or_none() in branches_to_slide_out:
-            if new_upstream is not None:
-                print_fmt(f"Checking out <b>{new_upstream}</b>... ", newline=False)
-                self._git.checkout(new_upstream)
+            if new_parent is not None:
+                print_fmt(f"Checking out <b>{new_parent}</b>... ", newline=False)
+                self._git.checkout(new_parent)
                 print_fmt(green_ok())
-            elif new_downstreams:
-                # If no upstream and there are downstreams, check out the first downstream
-                print_fmt(f"Checking out <b>{new_downstreams[0]}</b>... ", newline=False)
-                self._git.checkout(new_downstreams[0])
+            elif new_children:
+                # If no parent and there are children, check out the first child
+                print_fmt(f"Checking out <b>{new_children[0]}</b>... ", newline=False)
+                self._git.checkout(new_children[0])
                 print_fmt(green_ok())
             # Otherwise, stay on the current (slid-out) branch
 
-        # Only perform rebase/merge if there is a new upstream
-        if not opt_no_rebase and new_upstream is not None:
-            for new_downstream in new_downstreams:
-                anno = self.annotations.get(new_downstream)
+        # Only perform rebase/merge if there is a new parent
+        if not opt_no_rebase and new_parent is not None:
+            for child in new_children:
+                anno = self._state.get_annotation(child)
                 use_merge = opt_merge or (anno and anno.qualifiers.update_with_merge)
                 use_rebase = not use_merge and (not anno or anno.qualifiers.rebase)
                 if use_merge or use_rebase:
-                    print_fmt(f"Checking out <b>{new_downstream}</b>... ", newline=False)
-                    self._git.checkout(new_downstream)
+                    print_fmt(f"Checking out <b>{child}</b>... ", newline=False)
+                    self._git.checkout(child)
                     print_fmt(green_ok())
                 if use_merge:
-                    print_fmt(f"Merging <b>{new_upstream}</b> into <b>{new_downstream}</b>...")
+                    print_fmt(f"Merging <b>{new_parent}</b> into <b>{child}</b>...")
                     self._git.merge(
-                        branch=new_upstream,
-                        into=new_downstream,
+                        branch=new_parent,
+                        into=child,
                         opt_no_edit_merge=opt_no_edit_merge)
                 elif use_rebase:
-                    print_fmt(f"Rebasing <b>{new_downstream}</b> onto <b>{new_upstream}</b>...")
-                    down_fork_point = opt_down_fork_point or self.fork_point(new_downstream, use_overrides=True)
+                    print_fmt(f"Rebasing <b>{child}</b> onto <b>{new_parent}</b>...")
+                    child_fork_point = opt_down_fork_point or self.fork_point(child, use_overrides=True)
                     self.rebase(
-                        onto=new_upstream.full_name(),
-                        from_exclusive=down_fork_point,
-                        branch=new_downstream,
+                        onto=new_parent.full_name(),
+                        from_exclusive=child_fork_point,
+                        branch=child,
                         opt_no_interactive_rebase=opt_no_interactive_rebase)
 
         if opt_delete:
@@ -143,8 +116,8 @@ class SlideOutMacheteClient(MacheteClient):
 
         slid_out_branches: List[LocalBranchShortName] = []
         for branch in self.managed_branches.copy():
-            if self._git.is_removed_from_remote(branch) and not self.down_branches_for(branch):
-                anno = self.annotations.get(branch)
+            if self._git.is_removed_from_remote(branch) and not self.children_of(branch):
+                anno = self._state.get_annotation(branch)
                 if anno and not anno.qualifiers.slide_out:
                     print_fmt(f"Skipping <b>{branch}</b> as it's marked as `slide-out=no`")
                 else:

--- a/git_machete/client/state.py
+++ b/git_machete/client/state.py
@@ -1,0 +1,244 @@
+from typing import Dict, List, Optional
+
+from git_machete.annotation import Annotation
+from git_machete.git_operations import LocalBranchShortName
+from git_machete.utils import flat_map
+
+
+class MacheteState:
+    """
+    In-memory representation of the branch layout (.git/machete file).
+
+    The five internal fields are kept mutually consistent:
+      - `_managed_branches`: DFS-ordered flat list of every managed branch.
+      - `_roots`: root branches (those with no parent in the layout).
+      - `_parent_of`: child → parent mapping for every non-root branch.
+      - `_children_of`: parent → ordered list of children.
+      - `_annotations`: per-branch annotation metadata.
+
+    All five fields are private.  Callers may read them freely through the
+    properties and accessor methods below, but every structural change must go
+    through the mutation methods so that the invariants above are never
+    violated.
+    """
+
+    def __init__(self) -> None:
+        self._managed_branches: List[LocalBranchShortName] = []
+        self._roots: List[LocalBranchShortName] = []
+        self._parent_of: Dict[LocalBranchShortName, LocalBranchShortName] = {}
+        self._children_of: Dict[LocalBranchShortName, List[LocalBranchShortName]] = {}
+        self._annotations: Dict[LocalBranchShortName, Annotation] = {}
+
+    # ── Read-only accessors ─────────────────────────────────────────────────
+
+    @property
+    def managed_branches(self) -> List[LocalBranchShortName]:
+        """DFS-ordered flat list of all managed branches. Returns a copy."""
+        return list(self._managed_branches)
+
+    @property
+    def roots(self) -> List[LocalBranchShortName]:
+        """Root branches (those with no parent). Returns a copy."""
+        return list(self._roots)
+
+    def is_managed(self, branch: LocalBranchShortName) -> bool:
+        return branch in self._managed_branches
+
+    def get_parent(self, branch: LocalBranchShortName) -> Optional[LocalBranchShortName]:
+        return self._parent_of.get(branch)
+
+    def has_parent(self, branch: LocalBranchShortName) -> bool:
+        return branch in self._parent_of
+
+    def get_children(self, branch: LocalBranchShortName) -> Optional[List[LocalBranchShortName]]:
+        """Returns a copy of the children list, or None if branch has no children entry."""
+        children = self._children_of.get(branch)
+        return list(children) if children is not None else None
+
+    def get_annotation(self, branch: LocalBranchShortName) -> Optional[Annotation]:
+        return self._annotations.get(branch)
+
+    def has_annotation(self, branch: LocalBranchShortName) -> bool:
+        return branch in self._annotations
+
+    # ── Adding branches ─────────────────────────────────────────────────────
+
+    def add_branch(
+        self,
+        branch: LocalBranchShortName,
+        *,
+        parent: Optional[LocalBranchShortName],
+        annotation: Optional[Annotation],
+    ) -> None:
+        """Add a branch to the layout, wiring it under parent (or as a root if parent is None)."""
+        self._managed_branches.append(branch)
+        if parent is not None:
+            self._parent_of[branch] = parent
+            if parent in self._children_of:
+                self._children_of[parent].append(branch)
+            else:
+                self._children_of[parent] = [branch]
+        else:
+            self._roots.append(branch)
+        if annotation is not None:
+            self._annotations[branch] = annotation
+
+    def bootstrap_as_single_managed(self, branch: LocalBranchShortName) -> None:
+        """Bootstrap an empty layout with branch as the sole root and managed branch."""
+        self._roots = [branch]
+        self._managed_branches = [branch]
+
+    def add_as_root(self, branch: LocalBranchShortName) -> None:
+        """Add branch as a new root, appending it to managed_branches."""
+        self._roots.append(branch)
+        self._managed_branches.append(branch)
+
+    def add_as_child(
+        self,
+        *,
+        branch: LocalBranchShortName,
+        parent: LocalBranchShortName,
+        as_first_child: bool,
+    ) -> None:
+        """Add branch as a child of parent, appending it to managed_branches."""
+        self._parent_of[branch] = parent
+        existing = self._children_of.get(parent, [])
+        self._children_of[parent] = ([branch] + existing) if as_first_child else (existing + [branch])
+        self._managed_branches.append(branch)
+
+    # ── Removing / rewiring branches ────────────────────────────────────────
+
+    def splice_out(self, branch: LocalBranchShortName) -> None:
+        """Remove a branch from the tree, wiring its children to its parent.
+
+        If branch is a root, its children become new roots in its place.
+        Removes branch from managed_branches and deletes its annotation.
+        """
+        children = list(self._children_of.get(branch) or [])
+        parent = self._parent_of.get(branch)
+
+        if parent is not None:
+            for child in children:
+                self._parent_of[child] = parent
+            self._children_of[parent] = flat_map(
+                lambda b: children if b == branch else [b],
+                self._children_of.get(parent) or [],
+            )
+        else:
+            for child in children:
+                self._parent_of.pop(child, None)
+            root_index = self._roots.index(branch)
+            self._roots = self._roots[:root_index] + children + self._roots[root_index + 1:]
+
+        self._parent_of.pop(branch, None)
+        self._children_of.pop(branch, None)
+        self._annotations.pop(branch, None)
+        self._managed_branches.remove(branch)
+
+    def remove_leaf(self, branch: LocalBranchShortName) -> None:
+        """Remove a childless branch from the layout.
+
+        Detaches it from its parent (or roots), removes it from managed_branches,
+        and deletes its annotation.
+        """
+        self._managed_branches.remove(branch)
+        self._annotations.pop(branch, None)
+        if branch in self._parent_of:
+            parent = self._parent_of.pop(branch)
+            self._children_of[parent] = [
+                b for b in (self._children_of.get(parent) or []) if b != branch
+            ]
+        else:
+            self._roots.remove(branch)
+
+    # ── Tree reset + incremental wiring (used when rebuilding from scratch) ─
+
+    def reset_tree(self, initial_roots: List[LocalBranchShortName]) -> None:
+        """Reset all tree structure to rebuild from scratch.
+
+        Clears managed_branches, parent/children mappings, and sets roots to initial_roots.
+        Annotations are preserved so they can be selectively updated afterwards.
+        """
+        self._roots = list(initial_roots)
+        self._parent_of = {}
+        self._children_of = {}
+        self._managed_branches = []
+
+    def wire_as_child(
+        self, *, parent: LocalBranchShortName, child: LocalBranchShortName
+    ) -> None:
+        """Wire child under parent without touching managed_branches.
+
+        Intended for incremental tree building when managed_branches will be
+        set in bulk afterwards via set_managed().
+        """
+        self._parent_of[child] = parent
+        if parent in self._children_of:
+            self._children_of[parent].append(child)
+        else:
+            self._children_of[parent] = [child]
+
+    def wire_as_root(self, branch: LocalBranchShortName) -> None:
+        """Append branch to roots without touching managed_branches.
+
+        Intended for incremental tree building when managed_branches will be
+        set in bulk afterwards via set_managed().
+        """
+        self._roots.append(branch)
+
+    def detach_leaf(self, branch: LocalBranchShortName) -> None:
+        """Detach a childless branch from the tree without touching managed_branches.
+
+        Intended for pruning during tree building before managed_branches is set.
+        """
+        parent = self._parent_of.pop(branch)
+        self._children_of[parent] = [
+            b for b in self._children_of.get(parent, []) if b != branch
+        ]
+
+    def set_managed(self, branches: List[LocalBranchShortName]) -> None:
+        """Overwrite managed_branches with the given DFS-ordered list."""
+        self._managed_branches = list(branches)
+
+    # ── Rename ──────────────────────────────────────────────────────────────
+
+    def rename_branch(
+        self,
+        *,
+        old_name: LocalBranchShortName,
+        new_name: LocalBranchShortName,
+    ) -> None:
+        """Rename a branch across all state fields."""
+        idx = self._managed_branches.index(old_name)
+        self._managed_branches[idx] = new_name
+
+        if old_name in self._roots:
+            ridx = self._roots.index(old_name)
+            self._roots[ridx] = new_name
+
+        if old_name in self._parent_of:
+            parent = self._parent_of.pop(old_name)
+            self._parent_of[new_name] = parent
+
+        for k in list(self._parent_of):
+            if self._parent_of[k] == old_name:
+                self._parent_of[k] = new_name
+
+        if old_name in self._children_of:
+            children = self._children_of.pop(old_name)
+            self._children_of[new_name] = children
+
+        for children_list in self._children_of.values():
+            if old_name in children_list:
+                children_list[children_list.index(old_name)] = new_name
+
+        if old_name in self._annotations:
+            self._annotations[new_name] = self._annotations.pop(old_name)
+
+    # ── Annotations ─────────────────────────────────────────────────────────
+
+    def set_annotation(self, branch: LocalBranchShortName, annotation: Annotation) -> None:
+        self._annotations[branch] = annotation
+
+    def delete_annotation(self, branch: LocalBranchShortName) -> None:
+        self._annotations.pop(branch, None)

--- a/git_machete/client/status.py
+++ b/git_machete/client/status.py
@@ -49,8 +49,8 @@ class StatusOngoingOperation(NamedTuple):
 class StatusBranch(NamedTuple):
     """Per-branch data for status output (tree structure, sync state, commits, annotations)."""
 
-    up_branch: Optional[LocalBranchShortName]
-    down_branches: List[LocalBranchShortName]
+    parent: Optional[LocalBranchShortName]
+    children: List[LocalBranchShortName]
     sync_to_parent_status: SyncToParentStatus
     commits: List[Tuple[GitLogEntry, str]]
     sync_status: str
@@ -110,7 +110,7 @@ class StatusMacheteClient(MacheteClient):
 
         def prefix_dfs(parent: LocalBranchShortName, accumulated_path: List[Optional[LocalBranchShortName]]) -> None:
             next_sibling_of_ancestor_by_branch[parent] = accumulated_path
-            children = data.branches[parent].down_branches
+            children = data.branches[parent].children
             if children:
                 shifted_children: List[Optional[LocalBranchShortName]] = children[1:]  # type: ignore[assignment]
                 for (v, nv) in zip(children, shifted_children + [None]):
@@ -138,7 +138,7 @@ class StatusMacheteClient(MacheteClient):
         for branch in data.branches_in_display_order:
             b = data.branches[branch]
             next_sibling_of_ancestor = next_sibling_of_ancestor_by_branch[branch]
-            if b.up_branch is not None:
+            if b.parent is not None:
                 write_line_prefix(branch, next_sibling_of_ancestor, "<vbar/>")
                 out.write("\n")
                 line_index += 1
@@ -215,7 +215,7 @@ class StatusMacheteClient(MacheteClient):
             first_part = (
                 f"yellow edge indicates that fork point for <b>{yellow_edge_branch}</b> "
                 f"is probably incorrectly inferred,\nor that some extra branch should be between "
-                f"<b>{data.branches[yellow_edge_branch].up_branch}</b> and <b>{yellow_edge_branch}</b>"
+                f"<b>{data.branches[yellow_edge_branch].parent}</b> and <b>{yellow_edge_branch}</b>"
             )
         else:
             affected_branches = ", ".join(f"<b>{b}</b>" for b in branches_in_sync_but_fork_point_off)
@@ -243,7 +243,7 @@ class StatusMacheteClient(MacheteClient):
         return f"{first_part}.\n\n{second_part}."
 
     def compute_status_data(self, *, flags: StatusFlags) -> StatusData:
-        managed_branches: List[LocalBranchShortName] = list(self._state.managed_branches)
+        managed_branches: List[LocalBranchShortName] = self._state.managed_branches  # already returns a copy
 
         sync_to_parent_status: Dict[LocalBranchShortName, SyncToParentStatus] = {}
         fork_point_hash_cached: Dict[LocalBranchShortName, Optional[FullCommitHash]] = {}
@@ -258,12 +258,13 @@ class StatusMacheteClient(MacheteClient):
                     fork_point_hash_cached[for_branch], fork_point_branches_cached[for_branch] = None, []
             return fork_point_hash_cached[for_branch]
 
-        for branch in self._state.up_branch_for:
-            parent_branch = self._state.up_branch_for[branch]
-            assert parent_branch is not None
+        for branch in managed_branches:
+            parent_branch = self._state.get_parent(branch)
+            if parent_branch is None:
+                continue
             if self.is_merged_to(
                     branch=branch,
-                    upstream=parent_branch,
+                    parent=parent_branch,
                     opt_squash_merge_detection=flags.opt_squash_merge_detection):
                 sync_to_parent_status[branch] = SyncToParentStatus.MERGED_TO_PARENT
             elif not self._git.is_ancestor_or_equal(parent_branch.full_name(), branch.full_name()):
@@ -283,16 +284,18 @@ class StatusMacheteClient(MacheteClient):
 
         commits_by_branch: Dict[LocalBranchShortName, List[Tuple[GitLogEntry, str]]] = {}
         if flags.opt_list_commits:
-            for branch in self._state.up_branch_for:
+            for branch in managed_branches:
+                if not self._state.has_parent(branch):
+                    continue
                 fork_point = fork_point_hash(branch)
                 if not fork_point:
                     commits: List[Tuple[GitLogEntry, str]] = []
                 elif sync_to_parent_status[branch] == SyncToParentStatus.MERGED_TO_PARENT:
                     commits = []
                 elif sync_to_parent_status[branch] == SyncToParentStatus.IN_SYNC_BUT_FORK_POINT_OFF:
-                    upstream = self._state.up_branch_for[branch]
-                    assert upstream is not None
-                    raw_commits = self._git.get_commits_between(upstream.full_name(), branch.full_name())
+                    parent = self._state.get_parent(branch)
+                    assert parent is not None
+                    raw_commits = self._git.get_commits_between(parent.full_name(), branch.full_name())
                     commits = []
                     for commit in raw_commits:
                         if commit.hash == fork_point:
@@ -313,7 +316,7 @@ class StatusMacheteClient(MacheteClient):
 
         sync_status_by_branch: Dict[LocalBranchShortName, str] = {}
         hook_output_by_branch: Dict[LocalBranchShortName, str] = {}
-        for branch in self._state.managed_branches:
+        for branch in managed_branches:
             s, remote = self._git.get_combined_remote_sync_status(branch)
             sync_status_by_branch[branch] = {
                 SyncToRemoteStatus.NO_REMOTES: "",
@@ -341,20 +344,20 @@ class StatusMacheteClient(MacheteClient):
         branches: Dict[LocalBranchShortName, StatusBranch] = {}
         for branch in managed_branches:
             branches[branch] = StatusBranch(
-                up_branch=self._state.up_branch_for.get(branch),
-                down_branches=self.down_branches_for(branch) or [],
+                parent=self._state.get_parent(branch),
+                children=self.children_of(branch) or [],
                 sync_to_parent_status=sync_to_parent_status.get(branch, SyncToParentStatus.IN_SYNC),
                 commits=commits_by_branch.get(branch, []),
                 sync_status=sync_status_by_branch[branch],
                 hook_output=hook_output_by_branch[branch],
-                annotation=self._state.annotations.get(branch),
+                annotation=self._state.get_annotation(branch),
             )
 
         return StatusData(
             flags=flags,
             branches=branches,
             branches_in_display_order=managed_branches,
-            roots=self._state.roots,
+            roots=self._state.roots,  # property returns a copy
             ongoing_operation=StatusOngoingOperation(
                 currently_bisected_branch=currently_bisected_branch,
                 currently_rebased_branch=currently_rebased_branch,

--- a/git_machete/client/traverse.py
+++ b/git_machete/client/traverse.py
@@ -13,8 +13,7 @@ from git_machete.git_operations import (GitContext, LocalBranchShortName,
                                         SyncToRemoteStatus)
 from git_machete.utils import (MacheteException, ParsableEnum,
                                UnexpectedMacheteException, abspath_posix,
-                               flat_map, green_ok, pretty_choices, print_fmt,
-                               warn)
+                               green_ok, pretty_choices, print_fmt, warn)
 
 
 class TraverseReturnTo(ParsableEnum):
@@ -200,7 +199,7 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
                 # Note that we already ensured that there is at least one managed branch.
                 dest = self.managed_branches[0]
                 self._ensure_blank_separator()
-                root_qualifier = "first root" if len(self._state.roots) > 1 else "root"
+                root_qualifier = "first root" if len(self._state.roots) > 1 else "root"  # property returns a copy
                 self._switch_branch(dest, custom_checkout_message=f"Checking out the {root_qualifier} branch (<b>{dest}</b>)")
                 current_branch = dest
             elif opt_start_from == TraverseStartFrom.HERE:
@@ -217,12 +216,14 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
 
             branch: LocalBranchShortName
             for branch in itertools.dropwhile(lambda x: x != current_branch, self.managed_branches.copy()):
-                upstream = self.up_branch_for(branch)
+                parent = self.parent_of(branch)
 
-                needs_slide_out: bool = self._is_merged_to_upstream(
+                branch_anno = self._state.get_annotation(branch)
+
+                needs_slide_out: bool = self._is_merged_to_parent(
                     branch, opt_squash_merge_detection=opt_squash_merge_detection)
-                if needs_slide_out and branch in self.annotations:
-                    needs_slide_out = self.annotations[branch].qualifiers.slide_out
+                if needs_slide_out and branch_anno is not None:
+                    needs_slide_out = branch_anno.qualifiers.slide_out
                 s, remote = self._git.get_combined_remote_sync_status(branch)
                 if s in (
                         SyncToRemoteStatus.BEHIND_REMOTE,
@@ -233,8 +234,8 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
                         SyncToRemoteStatus.AHEAD_OF_REMOTE,
                         SyncToRemoteStatus.DIVERGED_FROM_AND_NEWER_THAN_REMOTE):
                     needs_remote_sync = True
-                    if branch in self.annotations:
-                        needs_remote_sync = self.annotations[branch].qualifiers.push
+                    if branch_anno is not None:
+                        needs_remote_sync = branch_anno.qualifiers.push
                     if not opt_push_tracked and not opt_push_untracked:
                         needs_remote_sync = False
                 else:
@@ -249,16 +250,16 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
                             f"Multiple {spec.pr_short_name}s have <b>{branch}</b> as its {spec.head_branch_name} branch: " +
                             ", ".join(_pr.short_display_text() for _pr in prs))
                     pr = prs[0] if prs else None
-                    needs_retarget_pr = pr is not None and upstream is not None and pr.base != upstream
+                    needs_retarget_pr = pr is not None and parent is not None and pr.base != parent
 
                 needs_create_pr = False
                 if opt_sync_github_prs or opt_sync_gitlab_mrs:
-                    if upstream:
+                    if parent:
                         prs = [_pr for _pr in self._get_all_open_prs() if _pr.head == branch]
                         if not prs:
                             needs_create_pr = True
 
-                use_merge = opt_merge or (branch in self.annotations and self.annotations[branch].qualifiers.update_with_merge)
+                use_merge = opt_merge or (branch_anno is not None and branch_anno.qualifiers.update_with_merge)
 
                 skipping_parent_sync = False
 
@@ -269,19 +270,19 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
                     needs_parent_sync: bool = False
                 elif s in (SyncToRemoteStatus.BEHIND_REMOTE, SyncToRemoteStatus.DIVERGED_FROM_AND_OLDER_THAN_REMOTE):
                     needs_parent_sync = False
-                    skipping_parent_sync = bool(upstream)
+                    skipping_parent_sync = bool(parent)
                 elif use_merge:
                     needs_parent_sync = bool(
-                        upstream and not self._git.is_ancestor_or_equal(upstream.full_name(), branch.full_name()))
+                        parent and not self._git.is_ancestor_or_equal(parent.full_name(), branch.full_name()))
                 else:  # using rebase
                     needs_parent_sync = bool(
-                        upstream and
-                        not (self._git.is_ancestor_or_equal(upstream.full_name(), branch.full_name()) and
-                             (self._git.get_commit_hash_by_revision(upstream) ==
+                        parent and
+                        not (self._git.is_ancestor_or_equal(parent.full_name(), branch.full_name()) and
+                             (self._git.get_commit_hash_by_revision(parent) ==
                               self.fork_point(branch, use_overrides=True)))
                     )
-                    if needs_parent_sync and branch in self.annotations:
-                        needs_parent_sync = self.annotations[branch].qualifiers.rebase
+                    if needs_parent_sync and branch_anno is not None:
+                        needs_parent_sync = branch_anno.qualifiers.rebase
 
                 needs_any_action = needs_slide_out or needs_parent_sync or needs_remote_sync or needs_retarget_pr or needs_create_pr
                 if branch != current_branch and needs_any_action:
@@ -299,30 +300,23 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
                 if needs_slide_out:
                     any_action_suggested = True
                     self._ensure_blank_separator()
-                    assert upstream is not None
-                    ans: str = self.ask_if(f"Branch <b>{branch}</b> is merged into <b>{upstream}</b>. "
+                    assert parent is not None
+                    ans: str = self.ask_if(f"Branch <b>{branch}</b> is merged into <b>{parent}</b>. "
                                            f"Slide <b>{branch}</b> out of the tree of branch dependencies?" +
                                            pretty_choices('y', 'N', 'q', 'yq'),
-                                           f"Branch <b>{branch}</b> is merged into <b>{upstream}</b>. "
+                                           f"Branch <b>{branch}</b> is merged into <b>{parent}</b>. "
                                            f"Sliding <b>{branch}</b> out of the tree of branch dependencies...",
                                            opt_yes=opt_yes)
                     if ans in ('y', 'yes', 'yq'):
-                        dbb = self.down_branches_for(branch) or []
+                        children = self._state.get_children(branch) or []
                         if nearest_remaining_branch == branch:
-                            if dbb:
-                                nearest_remaining_branch = dbb[0]
+                            if children:
+                                nearest_remaining_branch = children[0]
                             else:
-                                nearest_remaining_branch = upstream
-                        for down_branch in dbb:
-                            self._state.up_branch_for[down_branch] = upstream
-                        self._state.down_branches_for[upstream] = flat_map(
-                            lambda ud: dbb if ud == branch else [ud],
-                            self._state.down_branches_for[upstream] or [])
-                        if branch in self._state.annotations:
-                            del self._state.annotations[branch]
-                        self._state.managed_branches.remove(branch)
+                                nearest_remaining_branch = parent
+                        self._state.splice_out(branch)
                         self.save_branch_layout_file()
-                        self._run_post_slide_out_hook(new_upstream=upstream, slid_out_branch=branch, new_downstreams=dbb)
+                        self._run_post_slide_out_hook(new_upstream=parent, slid_out_branch=branch, new_downstreams=children)
                         if ans == 'yq':
                             return
                         else:
@@ -338,16 +332,16 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
                 elif needs_parent_sync:
                     any_action_suggested = True
                     self._ensure_blank_separator()
-                    assert upstream is not None
+                    assert parent is not None
                     if use_merge:
-                        ans = self.ask_if(f"Merge <b>{upstream}</b> into <b>{branch}</b>?" + pretty_choices('y', 'N', 'q', 'yq'),
-                                          f"Merging <b>{upstream}</b> into <b>{branch}</b>...", opt_yes=opt_yes)
+                        ans = self.ask_if(f"Merge <b>{parent}</b> into <b>{branch}</b>?" + pretty_choices('y', 'N', 'q', 'yq'),
+                                          f"Merging <b>{parent}</b> into <b>{branch}</b>...", opt_yes=opt_yes)
                     else:
-                        ans = self.ask_if(f"Rebase <b>{branch}</b> onto <b>{upstream}</b>?" + pretty_choices('y', 'N', 'q', 'yq'),
-                                          f"Rebasing <b>{branch}</b> onto <b>{upstream}</b>...", opt_yes=opt_yes)
+                        ans = self.ask_if(f"Rebase <b>{branch}</b> onto <b>{parent}</b>?" + pretty_choices('y', 'N', 'q', 'yq'),
+                                          f"Rebasing <b>{branch}</b> onto <b>{parent}</b>...", opt_yes=opt_yes)
                     if ans in ('y', 'yes', 'yq'):
                         if use_merge:
-                            self._git.merge(branch=upstream, into=branch, opt_no_edit_merge=opt_no_edit_merge)
+                            self._git.merge(branch=parent, into=branch, opt_no_edit_merge=opt_no_edit_merge)
                             # It's clearly possible that merge can be in progress
                             # after 'git merge' returned non-zero exit code;
                             # this happens most commonly in case of conflicts.
@@ -364,7 +358,7 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
                             fork_point = self.fork_point(branch, use_overrides=True)
 
                             self.rebase(
-                                onto=LocalBranchShortName.of(upstream).full_name(),
+                                onto=LocalBranchShortName.of(parent).full_name(),
                                 from_exclusive=fork_point,
                                 branch=branch,
                                 opt_no_interactive_rebase=opt_no_interactive_rebase)
@@ -399,8 +393,8 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
                                 SyncToRemoteStatus.AHEAD_OF_REMOTE,
                                 SyncToRemoteStatus.DIVERGED_FROM_AND_NEWER_THAN_REMOTE):
                             needs_remote_sync = True
-                            if branch in self.annotations:
-                                needs_remote_sync = self.annotations[branch].qualifiers.push
+                            if branch_anno is not None:
+                                needs_remote_sync = branch_anno.qualifiers.push
                         else:
                             needs_remote_sync = False
 
@@ -408,36 +402,37 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
                         return
 
                 if skipping_parent_sync:
-                    assert upstream is not None
+                    assert parent is not None
                     self._ensure_blank_separator()
                     if s == SyncToRemoteStatus.BEHIND_REMOTE:
                         reason = "behind its remote counterpart"
                     else:
                         reason = "diverged from (and has older commits than) its remote counterpart"
-                    print_fmt(f"Skipping sync of <b>{branch}</b> with <b>{upstream}</b>; <b>{branch}</b> is {reason}")
+                    print_fmt(f"Skipping sync of <b>{branch}</b> with <b>{parent}</b>; <b>{branch}</b> is {reason}")
 
                 if needs_retarget_pr:
                     any_action_suggested = True
                     assert pr is not None
-                    assert upstream is not None
+                    assert parent is not None
                     spec = self.code_hosting_spec
                     self._ensure_blank_separator()
                     ans_intro = f"Branch <b>{branch}</b> has a different {spec.pr_short_name} {spec.base_branch_name} (<b>{pr.base}</b>) " \
-                        f"in {spec.display_name} than in machete file (<b>{upstream}</b>).\n"
+                        f"in {spec.display_name} than in machete file (<b>{parent}</b>).\n"
                     ans = self.ask_if(
-                        ans_intro + f"Retarget {pr.display_text()} to <b>{upstream}</b>?" + pretty_choices('y', 'N', 'q', 'yq'),
-                        ans_intro + f"Retargeting {pr.display_text()} to <b>{upstream}</b>...",
+                        ans_intro + f"Retarget {pr.display_text()} to <b>{parent}</b>?" + pretty_choices('y', 'N', 'q', 'yq'),
+                        ans_intro + f"Retargeting {pr.display_text()} to <b>{parent}</b>...",
                         opt_yes=opt_yes)
                     if ans in ('y', 'yes', 'yq'):
-                        self.code_hosting_client.set_base_of_pull_request(pr.number, base=upstream)
+                        self.code_hosting_client.set_base_of_pull_request(pr.number, base=parent)
                         print_fmt(
                             f'{spec.base_branch_name.capitalize()} branch of {pr.display_text()} '
-                            f'has been switched to <b>{upstream}</b>')
-                        pr.base = upstream
+                            f'has been switched to <b>{parent}</b>')
+                        pr.base = parent
 
-                        anno = self._state.annotations.get(branch)
-                        self._state.annotations[branch] = Annotation(self._pull_request_annotation(pr, current_user),
-                                                                     anno.qualifiers if anno else Qualifiers())
+                        anno = self._state.get_annotation(branch)
+                        self._state.set_annotation(branch, Annotation(
+                            self._pull_request_annotation(pr, current_user),
+                            anno.qualifiers if anno else Qualifiers()))
                         self.save_branch_layout_file()
 
                         new_description = self._get_updated_pull_request_description(pr)
@@ -495,16 +490,16 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
 
                 if needs_create_pr:
                     any_action_suggested = True
-                    assert upstream is not None
+                    assert parent is not None
                     spec = self.code_hosting_spec
                     self._ensure_blank_separator()
                     ans_intro = f"Branch <b>{branch}</b> does not have {spec.pr_short_name_article} {spec.pr_short_name}" \
                         f" in {spec.display_name}.\n"
                     ans = self.ask_if(
                         ans_intro + f"Create {spec.pr_short_name_article} {spec.pr_short_name} "
-                        f"from <b>{branch}</b> to <b>{upstream}</b>?" + pretty_choices('y', 'd[raft]', 'N', 'q', 'yq'),
+                        f"from <b>{branch}</b> to <b>{parent}</b>?" + pretty_choices('y', 'd[raft]', 'N', 'q', 'yq'),
                         ans_intro + f"Creating {spec.pr_short_name_article} {spec.pr_short_name} "
-                        f"from <b>{branch}</b> to <b>{upstream}</b>...",
+                        f"from <b>{branch}</b> to <b>{parent}</b>...",
                         opt_yes=opt_yes)
                     if ans in ('y', 'yes', 'yq', 'd', 'draft'):
                         self.create_pull_request(
@@ -545,7 +540,7 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
                     f"No successor of <b>{current_branch}</b> needs to be slid out or synced "
                     "with upstream branch or remote")
             print_fmt(f"{msg}; nothing left to update")
-            if not any_action_suggested and initial_branch not in self._state.roots:
+            if not any_action_suggested and initial_branch not in self._state.roots:  # property returns a copy
                 print_fmt("Tip: `traverse` by default starts from the current branch, "
                           "use flags (`--start-from=`, `--whole` or `-w`, `-W`) to change this behavior.\n"
                           "Further info under `git machete traverse --help`.")

--- a/git_machete/client/update.py
+++ b/git_machete/client/update.py
@@ -14,9 +14,10 @@ class UpdateMacheteClient(MacheteClient):
         if opt_fork_point is not None:
             self.check_that_fork_point_is_ancestor_or_equal_to_tip_of_branch(
                 fork_point=opt_fork_point, branch=current_branch)
-        use_merge = opt_merge or (current_branch in self.annotations and self.annotations[current_branch].qualifiers.update_with_merge)
+        anno = self._state.get_annotation(current_branch)
+        use_merge = opt_merge or (anno is not None and anno.qualifiers.update_with_merge)
         if use_merge:
-            with_branch = self.get_or_infer_up_branch_for(
+            with_branch = self.get_or_infer_parent_of(
                 current_branch,
                 prompt_if_inferred_msg=("Branch <b>%s</b> not found in the tree of branch dependencies. "
                                         "Merge with the inferred upstream <b>%s</b>?" + pretty_choices('y', 'N')),
@@ -24,7 +25,7 @@ class UpdateMacheteClient(MacheteClient):
                                                 "Merging with the inferred upstream <b>%s</b>..."))
             self._git.merge(branch=with_branch, into=current_branch, opt_no_edit_merge=opt_no_edit_merge)
         else:
-            onto_branch = self.get_or_infer_up_branch_for(
+            onto_branch = self.get_or_infer_parent_of(
                 current_branch,
                 prompt_if_inferred_msg=("Branch <b>%s</b> not found in the tree of branch dependencies. "
                                         "Rebase onto the inferred upstream <b>%s</b>?" + pretty_choices('y', 'N')),

--- a/git_machete/client/with_code_hosting.py
+++ b/git_machete/client/with_code_hosting.py
@@ -65,34 +65,35 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             if LocalBranchShortName.of(pr.head) in self.managed_branches:
                 debug(f'{pr} corresponds to a managed branch')
                 anno: str = self._pull_request_annotation(pr, current_user, include_url=include_urls)
-                upstream: Optional[LocalBranchShortName] = self.up_branch_for(LocalBranchShortName.of(pr.head))
-                if upstream is not None:
-                    counterpart = self._git.get_combined_counterpart_for_fetching_of_branch(upstream)
+                parent: Optional[LocalBranchShortName] = self.parent_of(LocalBranchShortName.of(pr.head))
+                if parent is not None:
+                    counterpart = self._git.get_combined_counterpart_for_fetching_of_branch(parent)
                 else:
                     counterpart = None
-                upstream_tracking_branch = upstream if counterpart is None else '/'.join(counterpart.split('/')[1:])
+                upstream_tracking_branch = parent if counterpart is None else '/'.join(counterpart.split('/')[1:])
 
                 if pr.base != upstream_tracking_branch:
                     warn(
                         f'branch <b>{pr.head}</b> has a different base in {pr.display_text()} (<b>{pr.base}</b>) '
-                        f'than in machete file ({f"<b>{upstream}</b>" if upstream else "<none, is a root>"})')
+                        f'than in machete file ({f"<b>{parent}</b>" if parent else "<none, is a root>"})')
                     anno += (f" WRONG {spec.pr_short_name} {spec.base_branch_name.upper()} or MACHETE PARENT? "
                              f"{spec.pr_short_name} has {pr.base}")
                 old_annotation_text = ''
                 old_annotation_qualifiers = Qualifiers()
-                if LocalBranchShortName.of(pr.head) in self._state.annotations:
-                    old_annotation = self._state.annotations[LocalBranchShortName.of(pr.head)]
+                head_branch = LocalBranchShortName.of(pr.head)
+                old_annotation = self._state.get_annotation(head_branch)
+                if old_annotation is not None:
                     old_annotation_text = old_annotation.text_without_qualifiers
                     old_annotation_qualifiers = old_annotation.qualifiers
 
                 if pr.user != current_user and old_annotation_qualifiers.is_default():
                     if verbose:
                         print_fmt(f'Annotating <b>{pr.head}</b> as `{anno} rebase=no push=no`')
-                    self._state.annotations[LocalBranchShortName.of(pr.head)] = Annotation(anno, Qualifiers(rebase=False, push=False))
+                    self._state.set_annotation(head_branch, Annotation(anno, Qualifiers(rebase=False, push=False)))
                 elif old_annotation_text != anno:
                     if verbose:
                         print_fmt(f'Annotating <b>{pr.head}</b> as `{anno}`')
-                    self._state.annotations[LocalBranchShortName.of(pr.head)] = Annotation(anno, old_annotation_qualifiers)
+                    self._state.set_annotation(head_branch, Annotation(anno, old_annotation_qualifiers))
             else:
                 debug(f'{pr} does NOT correspond to a managed branch')
         self.save_branch_layout_file()
@@ -139,7 +140,7 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
                     "`discover` or `edit` or agree on adding the branch to the "
                     f"branch layout file during the execution of `{subcommand}` subcommand.")
 
-        up_branch: Optional[LocalBranchShortName] = self.up_branch_for(current_branch)
+        up_branch: Optional[LocalBranchShortName] = self.parent_of(current_branch)
         if not up_branch:
             raise MacheteException(
                 f'Branch <b>{current_branch}</b> does not have a parent branch (it is a root), '
@@ -156,7 +157,8 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             SyncToRemoteStatus.AHEAD_OF_REMOTE,
             SyncToRemoteStatus.DIVERGED_FROM_AND_NEWER_THAN_REMOTE)
         if s in statuses_to_push:
-            if current_branch not in self.annotations or self.annotations[current_branch].qualifiers.push:
+            anno = self._state.get_annotation(current_branch)
+            if anno is None or anno.qualifiers.push:
                 if s == SyncToRemoteStatus.AHEAD_OF_REMOTE:
                     assert remote is not None
                     self._handle_ahead_state(
@@ -231,8 +233,8 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             opt_update_related_descriptions: bool,
             opt_yes: bool
     ) -> None:
-        # Use provided base branch if --base flag is specified (undocumented), otherwise use upstream branch from .git/machete
-        base: Optional[LocalBranchShortName] = opt_base or self.up_branch_for(LocalBranchShortName.of(head))
+        # Use provided base branch if --base flag is specified (undocumented), otherwise use parent branch from .git/machete
+        base: Optional[LocalBranchShortName] = opt_base or self.parent_of(LocalBranchShortName.of(head))
         spec = self.code_hosting_spec
         if not base:
             raise UnexpectedMacheteException(f'could not determine {spec.base_branch_name} branch for {spec.pr_short_name}. '
@@ -411,7 +413,7 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             self.code_hosting_client.add_reviewers_to_pull_request(pr.number, reviewers)
             print_fmt(green_ok())
 
-        self._state.annotations[head] = Annotation(self._pull_request_annotation(pr, current_user), qualifiers=Qualifiers())
+        self._state.set_annotation(head, Annotation(self._pull_request_annotation(pr, current_user), qualifiers=Qualifiers()))
         self.save_branch_layout_file()
 
         if opt_update_related_descriptions:
@@ -436,7 +438,8 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             SyncToRemoteStatus.AHEAD_OF_REMOTE,
             SyncToRemoteStatus.DIVERGED_FROM_AND_NEWER_THAN_REMOTE)
         if s in statuses_to_push:
-            if current_branch in self.annotations and not self.annotations[current_branch].qualifiers.push:
+            anno = self._state.get_annotation(current_branch)
+            if anno is not None and not anno.qualifiers.push:
                 subcommand = "retarget-" + spec.pr_short_name.lower()
                 raise MacheteException(
                     f'Branch <b>{current_branch}</b> is marked as `push=no`; aborting the restack.\n'
@@ -535,7 +538,7 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
         if pr is None:
             return
 
-        new_base: Optional[LocalBranchShortName] = self.up_branch_for(LocalBranchShortName.of(head))
+        new_base: Optional[LocalBranchShortName] = self.parent_of(LocalBranchShortName.of(head))
         if not new_base:
             raise MacheteException(
                 f'Branch <b>{head}</b> does not have a parent branch (it is a root) '
@@ -559,9 +562,9 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             print_fmt(f'Description of {pr.display_text()} has been updated')
 
         current_user: Optional[str] = self.code_hosting_client.get_current_user_login()
-        anno = self._state.annotations.get(head)
+        anno = self._state.get_annotation(head)
         qualifiers = anno.qualifiers if anno else Qualifiers()
-        self._state.annotations[head] = Annotation(self._pull_request_annotation(pr, current_user), qualifiers)
+        self._state.set_annotation(head, Annotation(self._pull_request_annotation(pr, current_user), qualifiers))
         self.save_branch_layout_file()
 
         if opt_update_related_descriptions:
@@ -735,7 +738,7 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             return ''
 
         prepend = f'{self.START_GIT_MACHETE_GENERATED_COMMENT}\n\n'
-        # In FULL mode, we're likely to generate a non-empty intro even when there are NO upstream PRs above
+        # In FULL mode, we're likely to generate a non-empty intro even when there are NO parent PRs above
         if len(prs_for_base_branch) >= 1:
             prepend += f'# Based on {prs_for_base_branch[0].display_text(fmt=False)}\n\n'
 
@@ -973,7 +976,7 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
                 return []
             return result
         elif related_to:
-            # Always update the entire stack (both upstream and downstream) when --related is used,
+            # Always update the entire stack (both parent and downstream) when --related is used,
             # regardless of prDescriptionIntroStyle setting.
             result = list(reversed(self.__get_upwards_path_including_pr(related_to)))
             result += [downstream_pr for downstream_pr, _ in self.__get_downwards_tree_excluding_pr(related_to)]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from git_machete.annotation import Annotation
 from git_machete.client.base import MacheteClient
 from git_machete.git_operations import GitContext, LocalBranchShortName
@@ -58,56 +56,53 @@ class TestClient(BaseTest):
         rewrite_branch_layout_file(body)
         machete_client = MacheteClient(GitContext())
         machete_client.read_branch_layout_file(interactively_slide_out_invalid_branches=False)
-        annotations: Dict[LocalBranchShortName, Annotation] = machete_client.annotations
 
-        feature_2_branch = LocalBranchShortName.of('feature2')
-        assert annotations[feature_2_branch].unformatted_full_text == 'annotation'
-        assert annotations[feature_2_branch].qualifiers.rebase is True
-        assert annotations[feature_2_branch].qualifiers.push is True
-        assert annotations[feature_2_branch].text_without_qualifiers == 'annotation'
-        assert str(annotations[feature_2_branch].qualifiers) == ''
+        def anno(branch_name: str) -> Annotation:
+            result = machete_client._state.get_annotation(LocalBranchShortName.of(branch_name))
+            assert result is not None
+            return result
 
-        feature_3_branch = LocalBranchShortName.of('feature3')
-        assert annotations[feature_3_branch].unformatted_full_text == 'annotation rebase=no push=no'
-        assert annotations[feature_3_branch].qualifiers.rebase is False
-        assert annotations[feature_3_branch].qualifiers.push is False
-        assert annotations[feature_3_branch].text_without_qualifiers == 'annotation'
-        assert str(annotations[feature_3_branch].qualifiers) == 'rebase=no push=no'
+        assert anno('feature2').unformatted_full_text == 'annotation'
+        assert anno('feature2').qualifiers.rebase is True
+        assert anno('feature2').qualifiers.push is True
+        assert anno('feature2').text_without_qualifiers == 'annotation'
+        assert str(anno('feature2').qualifiers) == ''
 
-        feature_4_branch = LocalBranchShortName.of('feature4')
-        assert annotations[feature_4_branch].unformatted_full_text == 'annotation rebase=no push=no'
-        assert annotations[feature_4_branch].qualifiers.rebase is False
-        assert annotations[feature_4_branch].qualifiers.push is False
-        assert annotations[feature_4_branch].text_without_qualifiers == 'annotation'
-        assert str(annotations[feature_4_branch].qualifiers) == 'rebase=no push=no'
+        assert anno('feature3').unformatted_full_text == 'annotation rebase=no push=no'
+        assert anno('feature3').qualifiers.rebase is False
+        assert anno('feature3').qualifiers.push is False
+        assert anno('feature3').text_without_qualifiers == 'annotation'
+        assert str(anno('feature3').qualifiers) == 'rebase=no push=no'
 
-        feature_5_branch = LocalBranchShortName.of('feature5')
-        assert annotations[feature_5_branch].unformatted_full_text == 'annotation1 annotation2 annotation3 rebase=no push=no'
-        assert annotations[feature_5_branch].qualifiers.rebase is False
-        assert annotations[feature_5_branch].qualifiers.push is False
-        assert annotations[feature_5_branch].text_without_qualifiers == 'annotation1 annotation2 annotation3'
-        assert str(annotations[feature_5_branch].qualifiers) == 'rebase=no push=no'
+        assert anno('feature4').unformatted_full_text == 'annotation rebase=no push=no'
+        assert anno('feature4').qualifiers.rebase is False
+        assert anno('feature4').qualifiers.push is False
+        assert anno('feature4').text_without_qualifiers == 'annotation'
+        assert str(anno('feature4').qualifiers) == 'rebase=no push=no'
 
-        feature_6_branch = LocalBranchShortName.of('feature6')
-        assert annotations[feature_6_branch].unformatted_full_text == 'annotation1 rebase=nopush=no annotation2'
-        assert annotations[feature_6_branch].qualifiers.rebase is True
-        assert annotations[feature_6_branch].qualifiers.push is True
-        assert annotations[feature_6_branch].text_without_qualifiers == 'annotation1 rebase=nopush=no annotation2'
-        assert str(annotations[feature_6_branch].qualifiers) == ''
+        assert anno('feature5').unformatted_full_text == 'annotation1 annotation2 annotation3 rebase=no push=no'
+        assert anno('feature5').qualifiers.rebase is False
+        assert anno('feature5').qualifiers.push is False
+        assert anno('feature5').text_without_qualifiers == 'annotation1 annotation2 annotation3'
+        assert str(anno('feature5').qualifiers) == 'rebase=no push=no'
 
-        feature_7_branch = LocalBranchShortName.of('feature7')
-        assert annotations[feature_7_branch].unformatted_full_text == 'annotation1rebase=no push=noannotation2'
-        assert annotations[feature_7_branch].qualifiers.rebase is True
-        assert annotations[feature_7_branch].qualifiers.push is True
-        assert annotations[feature_7_branch].text_without_qualifiers == 'annotation1rebase=no push=noannotation2'
-        assert str(annotations[feature_7_branch].qualifiers) == ''
+        assert anno('feature6').unformatted_full_text == 'annotation1 rebase=nopush=no annotation2'
+        assert anno('feature6').qualifiers.rebase is True
+        assert anno('feature6').qualifiers.push is True
+        assert anno('feature6').text_without_qualifiers == 'annotation1 rebase=nopush=no annotation2'
+        assert str(anno('feature6').qualifiers) == ''
 
-        feature_8_branch = LocalBranchShortName.of('feature8')
-        assert annotations[feature_8_branch].unformatted_full_text == 'annotation rebase=no push=no'
-        assert annotations[feature_8_branch].qualifiers.rebase is False
-        assert annotations[feature_8_branch].qualifiers.push is False
-        assert annotations[feature_8_branch].text_without_qualifiers == 'annotation'
-        assert str(annotations[feature_8_branch].qualifiers) == 'rebase=no push=no'
+        assert anno('feature7').unformatted_full_text == 'annotation1rebase=no push=noannotation2'
+        assert anno('feature7').qualifiers.rebase is True
+        assert anno('feature7').qualifiers.push is True
+        assert anno('feature7').text_without_qualifiers == 'annotation1rebase=no push=noannotation2'
+        assert str(anno('feature7').qualifiers) == ''
+
+        assert anno('feature8').unformatted_full_text == 'annotation rebase=no push=no'
+        assert anno('feature8').qualifiers.rebase is False
+        assert anno('feature8').qualifiers.push is False
+        assert anno('feature8').text_without_qualifiers == 'annotation'
+        assert str(anno('feature8').qualifiers) == 'rebase=no push=no'
 
     def test_branch_layout_leading_hash_comment_lines_ignored(self) -> None:
         create_repo_with_remote()
@@ -133,7 +128,7 @@ class TestClient(BaseTest):
             LocalBranchShortName.of('master'),
             LocalBranchShortName.of('feature'),
         ]
-        assert machete_client.down_branches_for(LocalBranchShortName.of('master')) == [
+        assert machete_client.children_of(LocalBranchShortName.of('master')) == [
             LocalBranchShortName.of('feature')]
 
     def test_branch_layout_hash_not_leading_whitespace_is_branch_or_annotation(self) -> None:
@@ -158,7 +153,8 @@ class TestClient(BaseTest):
             LocalBranchShortName.of('master'),
             feature,
         ]
-        assert machete_client.annotations[feature].unformatted_full_text == 'note #123'
+        assert machete_client._state.get_annotation(feature) is not None
+        assert machete_client._state.get_annotation(feature).unformatted_full_text == 'note #123'  # type: ignore[union-attr]
 
     def test_save_branch_layout_file_does_not_preserve_hash_comment_lines(self) -> None:
         create_repo_with_remote()


### PR DESCRIPTION
## Summary

- Extracts `MacheteState` into a dedicated `git_machete/client/state.py` file
- Makes all five internal fields private (`_managed_branches`, `_roots`, `_up_branch_for`, `_down_branches_for`, `_annotations`); all structural mutations go through command-agnostic methods (`splice_out`, `remove_leaf`, `wire_as_child`, `wire_as_root`, `reset_tree`, `set_managed`, `rename_branch`, `set_annotation`, `delete_annotation`, …) so the five fields stay mutually consistent
- Exposes read access through copy-returning properties and per-branch accessor methods (`get_upstream`, `get_children`, `get_annotation`) rather than raw dict/list access
