### PR TITLE
Extract branch layout file I/O into BranchLayoutFile

### DIFF
--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -1,4 +1,3 @@
-import itertools
 import os
 import re
 import shlex
@@ -9,7 +8,7 @@ from enum import Enum, auto
 from typing import Callable, Dict, Iterator, List, NoReturn, Optional, Tuple
 
 from git_machete import utils
-from git_machete.annotation import Annotation
+from git_machete.client import branch_layout
 from git_machete.client.state import MacheteState
 from git_machete.config import MacheteConfig, SquashMergeDetection
 from git_machete.constants import (INITIAL_COMMIT_COUNT_FOR_LOG,
@@ -141,61 +140,12 @@ class MacheteClient:
                 * `git machete gitlab checkout-mrs --mine`"""[1:]))
 
     def read_branch_layout_file(self, *, interactively_slide_out_invalid_branches: bool = False, verify_branches: bool = True) -> None:
-        with open(self._branch_layout_file_path) as file:
-            lines: List[str] = [line.rstrip() for line in file.readlines()]
+        self._state, self.__indent = branch_layout.parse(self._branch_layout_file_path)
 
-        at_depth = {}
-        last_depth = -1
-        hint = "Edit the branch layout file manually with `git machete edit`"
-
-        invalid_branches: List[LocalBranchShortName] = []
-        for index, line in enumerate(lines):
-            if line == "":
-                continue
-            # Undocumented: lines whose first non-whitespace character is `#` are ignored as comments.
-            # They are not preserved when git-machete writes the branch layout file;
-            # supporting that would need an explicit strategy for comment placement and merging with programmatic edits.
-            if line.lstrip().startswith("#"):
-                continue
-            prefix = "".join(itertools.takewhile(str.isspace, line))
-            if prefix and not self.__indent:
-                self.__indent = prefix
-
-            branch_and_maybe_annotation: List[LocalBranchShortName] = [LocalBranchShortName.of(entry) for entry in
-                                                                       line.strip().split(" ", 1)]
-            branch = branch_and_maybe_annotation[0]
-            annotation = Annotation.parse(branch_and_maybe_annotation[1]) if len(branch_and_maybe_annotation) > 1 else None
-            if self._state.is_managed(branch):
-                raise MacheteException(
-                    f"{self._branch_layout_file_path}, line {index + 1}: branch "
-                    f"<b>{branch}</b> re-appears in the branch layout. {hint}")
-            if verify_branches and branch not in self._git.get_local_branches():
-                invalid_branches += [branch]
-
-            if prefix:
-                assert self.__indent is not None
-                depth: int = len(prefix) // len(self.__indent)
-                if prefix != self.__indent * depth:
-                    mapping: Dict[str, str] = {" ": "<SPACE>", "\t": "<TAB>"}
-                    prefix_expanded: str = "".join(mapping[c] for c in prefix)
-                    indent_expanded: str = "".join(mapping[c] for c in self.__indent)
-                    raise MacheteException(
-                        f"{self._branch_layout_file_path}, line {index + 1}: "
-                        f"invalid indent <b>{prefix_expanded}</b>, expected a multiply"
-                        f" of <b>{indent_expanded}</b>. {hint}")
-            else:
-                depth = 0
-
-            if depth > last_depth + 1:
-                raise MacheteException(
-                    f"{self._branch_layout_file_path}, line {index + 1}: too much "
-                    f"indent (level {depth}, expected at most {last_depth + 1}) "
-                    f"for the branch <b>{branch}</b>. {hint}")
-            last_depth = depth
-
-            at_depth[depth] = branch
-            parent = at_depth[depth - 1] if depth else None
-            self._state.add_branch(branch, parent=parent, annotation=annotation)
+        if not verify_branches:
+            return
+        local_branches = self._git.get_local_branches()
+        invalid_branches = [b for b in self._state.managed_branches if b not in local_branches]
 
         if not invalid_branches:
             return
@@ -230,26 +180,11 @@ class MacheteClient:
             self.__init_state()
             self.read_branch_layout_file(verify_branches=verify_branches)
 
-    def render_branch_layout_file(self, indent: str) -> List[str]:
-        def render_dfs(branch: LocalBranchShortName, depth: int) -> List[str]:
-            anno = self._state.get_annotation(branch)
-            annotation = (" " + anno.unformatted_full_text) if anno is not None else ""
-            res: List[str] = [depth * indent + branch + annotation]
-            for child in self.children_of(branch) or []:
-                res += render_dfs(child, depth + 1)
-            return res
-
-        result: List[str] = []
-        for root in self._state.roots:  # property returns a copy
-            result += render_dfs(root, depth=0)
-        return result
-
     def back_up_branch_layout_file(self) -> None:
         shutil.copyfile(self._branch_layout_file_path, self._branch_layout_file_path + "~")
 
     def save_branch_layout_file(self) -> None:
-        with open(self._branch_layout_file_path, "w") as file:
-            file.write("\n".join(self.render_branch_layout_file(indent=self.__indent or "  ")) + "\n")
+        branch_layout.save(self._branch_layout_file_path, self._state, indent=self.__indent or "  ")
 
     def add(self,
             *,

--- a/git_machete/client/branch_layout.py
+++ b/git_machete/client/branch_layout.py
@@ -1,0 +1,104 @@
+import itertools
+from typing import Dict, List, Optional, Tuple
+
+from git_machete.annotation import Annotation
+from git_machete.client.state import MacheteState
+from git_machete.git_operations import LocalBranchShortName
+from git_machete.utils import MacheteException
+
+
+def parse(path: str) -> Tuple[MacheteState, Optional[str]]:
+    """Parse the branch layout file at *path*.
+
+    Returns a new `MacheteState` populated from the file together with
+    the indent string detected in the file (`None` when no indented
+    line was found, e.g. a single-root flat layout).
+
+    Raises `MacheteException` for structural errors (duplicate branch,
+    bad indent, excess depth).
+    """
+    with open(path) as f:
+        lines: List[str] = [line.rstrip() for line in f.readlines()]
+
+    state = MacheteState()
+    indent: Optional[str] = None
+    at_depth: Dict[int, LocalBranchShortName] = {}
+    last_depth = -1
+    hint = "Edit the branch layout file manually with `git machete edit`"
+
+    for index, line in enumerate(lines):
+        if line == "":
+            continue
+        # Undocumented: lines whose first non-whitespace character is `#`
+        # are ignored as comments.  They are not preserved when
+        # git-machete writes the branch layout file.
+        if line.lstrip().startswith("#"):
+            continue
+
+        prefix = "".join(itertools.takewhile(str.isspace, line))
+        if prefix and not indent:
+            indent = prefix
+
+        branch_and_maybe_annotation: List[LocalBranchShortName] = [
+            LocalBranchShortName.of(entry) for entry in line.strip().split(" ", 1)
+        ]
+        branch = branch_and_maybe_annotation[0]
+        annotation = (
+            Annotation.parse(branch_and_maybe_annotation[1])
+            if len(branch_and_maybe_annotation) > 1
+            else None
+        )
+
+        if state.is_managed(branch):
+            raise MacheteException(
+                f"{path}, line {index + 1}: branch "
+                f"<b>{branch}</b> re-appears in the branch layout. {hint}")
+
+        if prefix:
+            assert indent is not None
+            depth: int = len(prefix) // len(indent)
+            if prefix != indent * depth:
+                mapping: Dict[str, str] = {" ": "<SPACE>", "\t": "<TAB>"}
+                prefix_expanded = "".join(mapping[c] for c in prefix)
+                indent_expanded = "".join(mapping[c] for c in indent)
+                raise MacheteException(
+                    f"{path}, line {index + 1}: "
+                    f"invalid indent <b>{prefix_expanded}</b>, expected a multiply"
+                    f" of <b>{indent_expanded}</b>. {hint}")
+        else:
+            depth = 0
+
+        if depth > last_depth + 1:
+            raise MacheteException(
+                f"{path}, line {index + 1}: too much "
+                f"indent (level {depth}, expected at most {last_depth + 1}) "
+                f"for the branch <b>{branch}</b>. {hint}")
+        last_depth = depth
+
+        at_depth[depth] = branch
+        parent = at_depth[depth - 1] if depth else None
+        state.add_branch(branch, parent=parent, annotation=annotation)
+
+    return state, indent
+
+
+def render(state: MacheteState, indent: str) -> List[str]:
+    """Return lines representing *state*, ready to join with newlines."""
+    def render_dfs(branch: LocalBranchShortName, depth: int) -> List[str]:
+        anno = state.get_annotation(branch)
+        annotation = (" " + anno.unformatted_full_text) if anno is not None else ""
+        result: List[str] = [depth * indent + branch + annotation]
+        for child in (state.get_children(branch) or []):
+            result += render_dfs(child, depth + 1)
+        return result
+
+    lines: List[str] = []
+    for root in state.roots:
+        lines += render_dfs(root, depth=0)
+    return lines
+
+
+def save(path: str, state: MacheteState, *, indent: str) -> None:
+    """Write *state* to the branch layout file at *path*."""
+    with open(path, "w") as f:
+        f.write("\n".join(render(state, indent)) + "\n")


### PR DESCRIPTION
Move parsing, rendering, saving, and back-up logic out of MacheteClient
into a dedicated git_machete/client/branch_layout.py.  BranchLayoutFile
owns the file path and the indent detected during parsing, removing
__indent from the client entirely.  MacheteClient now only orchestrates
the interactive/validation layer (invalid-branch prompts, edit loop).