### PR TITLE
refactor: remove displayed_warnings global state

### DIFF
--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -569,8 +569,7 @@ def update_cli_options_using_parsed_args(
         elif opt == "n":
             cli_opts.opt_n = True
         elif opt == "no_detect_squash_merges":
-            warn("`--no-detect-squash-merges` is deprecated, use `--squash-merge-detection=none` instead",
-                 extra_newline=True)
+            warn("`--no-detect-squash-merges` is deprecated, use `--squash-merge-detection=none` instead\n")
             cli_opts.opt_squash_merge_detection_string = "none"
             cli_opts.opt_squash_merge_detection_origin = "`--no-detect-squash-merges` flag"
         elif opt == "no_edit_merge":

--- a/git_machete/client/traverse.py
+++ b/git_machete/client/traverse.py
@@ -167,6 +167,7 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
 
         self._mark_trailing_blank_line()
         any_action_suggested: bool = False
+        status_shown_already: bool = False
 
         if opt_fetch:
             for rem in self._git.get_remotes():
@@ -291,10 +292,11 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
                     current_branch = branch
                     self._ensure_blank_separator()
                     self.status(
-                        warn_when_branch_in_sync_but_fork_point_off=True,
+                        warn_when_branch_in_sync_but_fork_point_off=not status_shown_already,
                         opt_list_commits=opt_list_commits,
                         opt_list_commits_with_hashes=False,
                         opt_squash_merge_detection=opt_squash_merge_detection)
+                    status_shown_already = True
                     self._ensure_blank_separator()
                     self._mark_trailing_blank_line()
                 if needs_slide_out:
@@ -528,7 +530,7 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
 
             self._ensure_blank_separator()
             self.status(
-                warn_when_branch_in_sync_but_fork_point_off=True,
+                warn_when_branch_in_sync_but_fork_point_off=not status_shown_already,
                 opt_list_commits=opt_list_commits,
                 opt_list_commits_with_hashes=False,
                 opt_squash_merge_detection=opt_squash_merge_detection)

--- a/git_machete/utils.py
+++ b/git_machete/utils.py
@@ -10,15 +10,12 @@ import time
 from enum import Enum, IntEnum
 from pathlib import Path, PurePosixPath
 from typing import (Any, Callable, Dict, Iterable, List, NamedTuple, Optional,
-                    Sequence, Set, Tuple, Type, TypeVar)
+                    Sequence, Tuple, Type, TypeVar)
 
 T = TypeVar('T')
 U = TypeVar('U')
 E = TypeVar('E', bound=Enum)
 
-
-# To avoid displaying the same warning multiple times during a single run.
-displayed_warnings: Set[str] = set()
 
 # Let's keep the flag to avoid checking for current directory's existence
 # every time any command is being popened or run.
@@ -197,13 +194,8 @@ def input_fmt(prompt: str) -> str:
     return input(_fmt(prompt, use_ansi_escapes=use_ansi_escapes_in_stdout))
 
 
-def warn(msg: str, *, extra_newline: bool = False) -> None:
-    if msg not in displayed_warnings:
-        line = f"<orange>Warn: </orange>{msg}"
-        if extra_newline:
-            line += "\n"
-        print_fmt(line, file=sys.stderr)
-        displayed_warnings.add(msg)
+def warn(msg: str) -> None:
+    print_fmt(f"<orange>Warn: </orange>{msg}", file=sys.stderr)
 
 
 def green_ok() -> str:

--- a/tests/cli_runner.py
+++ b/tests/cli_runner.py
@@ -4,7 +4,7 @@ import textwrap
 from contextlib import redirect_stderr, redirect_stdout
 from typing import Iterable, Optional, Tuple, Type
 
-from git_machete import cli, utils
+from git_machete import cli
 from git_machete.utils import MacheteException
 
 
@@ -13,7 +13,6 @@ def launch_command_capturing_output_and_exception(*cmd_and_args: str) -> Tuple[O
         try:
             with redirect_stdout(out):
                 with redirect_stderr(out):
-                    utils.displayed_warnings = set()
                     cli.launch(list(cmd_and_args))
                 output = out.getvalue()
                 return output, None
@@ -26,7 +25,6 @@ def launch_command(*cmd_and_args: str) -> str:
     with io.StringIO() as out:
         with redirect_stdout(out):
             with redirect_stderr(out):
-                utils.displayed_warnings = set()
                 cli.launch(list(cmd_and_args))
         output = out.getvalue()
         return output

--- a/tests/test_traverse.py
+++ b/tests/test_traverse.py
@@ -1952,7 +1952,6 @@ class TestTraverse(BaseTest):
               {E.YELLOW}│{E.ENDC}
               {E.YELLOW}└─{E.ENDC}{E.BOLD}{E.UNDERLINE}feature-2{E.ENDC_UNDERLINE}{E.ENDC_BOLD_DIM}
 
-
             Rebase {E.BOLD}feature-2{E.ENDC_BOLD_DIM} onto {E.BOLD}master{E.ENDC_BOLD_DIM}? {pc}
 
               {E.BOLD}master{E.ENDC_BOLD_DIM}
@@ -1960,7 +1959,6 @@ class TestTraverse(BaseTest):
               {E.YELLOW}├─{E.ENDC}{E.BOLD}feature-1{E.ENDC_BOLD_DIM}
               {E.YELLOW}│{E.ENDC}
               {E.YELLOW}└─{E.ENDC}{E.BOLD}{E.UNDERLINE}feature-2{E.ENDC_UNDERLINE}{E.ENDC_BOLD_DIM}
-
 
             Reached branch {E.BOLD}feature-2{E.ENDC_BOLD_DIM} which has no successor; nothing left to update
             Returned to the initial branch {E.BOLD}feature-2{E.ENDC_BOLD_DIM}


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1665

## Chain of upstream PRs as of 2026-05-07

* PR #1665:
  `develop` ← `refactor/reorder-git-ops`

  * **PR #1666 (THIS ONE)**:
    `refactor/reorder-git-ops` ← `refactor/warn-simplify`

<!-- end git-machete generated -->

Replace the persistent global set with a local status_shown_already flag
in traverse(), limiting fork-point warning deduplication to its natural
scope. warn() is now a simple one-liner with no deduplication logic.