### PR TITLE
refactor: rename git/code-hosting layer; reorganize and slim down client/base.py

### DIFF
--- a/ci/checks/enforce-mocking-only-whitelisted-methods.sh
+++ b/ci/checks/enforce-mocking-only-whitelisted-methods.sh
@@ -11,7 +11,7 @@ builtins.input
 git_machete.client.go_interactive.GoInteractiveMacheteClient._get_stdin_fd
 git_machete.client.go_interactive.GoInteractiveMacheteClient._read_stdin
 git_machete.code_hosting.OrganizationAndRepository.from_url
-git_machete.git_operations.GitContext.fetch_remote
+git_machete.git.Git.fetch_remote
 git_machete.github.GitHubClient.MAX_PULLS_PER_PAGE_COUNT
 git_machete.github.GitHubToken.for_domain
 git_machete.gitlab.GitLabClient.MAX_PULLS_PER_PAGE_COUNT

--- a/ci/checks/enforce-mocking-only-whitelisted-methods.sh
+++ b/ci/checks/enforce-mocking-only-whitelisted-methods.sh
@@ -12,9 +12,9 @@ git_machete.client.go_interactive.GoInteractiveMacheteClient._get_stdin_fd
 git_machete.client.go_interactive.GoInteractiveMacheteClient._read_stdin
 git_machete.code_hosting.OrganizationAndRepository.from_url
 git_machete.git.Git.fetch_remote
-git_machete.github.GitHubClient.MAX_PULLS_PER_PAGE_COUNT
+git_machete.github.GitHubApi.MAX_PULLS_PER_PAGE_COUNT
 git_machete.github.GitHubToken.for_domain
-git_machete.gitlab.GitLabClient.MAX_PULLS_PER_PAGE_COUNT
+git_machete.gitlab.GitLabApi.MAX_PULLS_PER_PAGE_COUNT
 git_machete.gitlab.GitLabToken.for_domain
 git_machete.utils._subproc._run_cmd
 git_machete.utils.date.get_current_date

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -33,7 +33,7 @@ from git_machete.config import MacheteConfig, SquashMergeDetection
 from git_machete.github import GITHUB_CLIENT_SPEC
 from git_machete.gitlab import GITLAB_CLIENT_SPEC
 
-from .git_operations import AnyRevision, GitContext, LocalBranchShortName
+from .git import AnyRevision, Git, LocalBranchShortName
 from .help import (MacheteHelpAction, alias_by_command, commands_and_aliases,
                    get_help_description, version)
 from .utils import cmd, debug_log, markup, terminal
@@ -654,7 +654,7 @@ def update_cli_options_using_parsed_args(
 
 def update_cli_options_using_config_keys(
         cli_opts: git_machete.options.CommandLineOptions,
-        git: GitContext
+        git: Git
 ) -> None:
     traverse_push = MacheteConfig(git).traverse_push()
     if traverse_push is not None:
@@ -682,7 +682,7 @@ def launch_internal(orig_args: List[str]) -> None:
 
     try:
         cli_opts = git_machete.options.CommandLineOptions()
-        git = GitContext()
+        git = Git()
 
         direct_args = list(itertools.takewhile(lambda arg: arg != "--", orig_args))
         pass_through_args = list(itertools.dropwhile(lambda arg: arg != "--", orig_args))

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -30,8 +30,8 @@ from git_machete.client.traverse import (TraverseMacheteClient,
 from git_machete.client.update import UpdateMacheteClient
 from git_machete.client.with_code_hosting import MacheteClientWithCodeHosting
 from git_machete.config import MacheteConfig, SquashMergeDetection
-from git_machete.github import GITHUB_CLIENT_SPEC
-from git_machete.gitlab import GITLAB_CLIENT_SPEC
+from git_machete.github import GITHUB_API_SPEC
+from git_machete.gitlab import GITLAB_API_SPEC
 
 from .git import AnyRevision, Git, LocalBranchShortName
 from .help import (MacheteHelpAction, alias_by_command, commands_and_aliases,
@@ -771,7 +771,7 @@ def launch_internal(orig_args: List[str]) -> None:
             advance_client.read_branch_layout_file()
             advance_client.advance(opt_yes=cli_opts.opt_yes)
         elif cmd == "anno":
-            spec = GITHUB_CLIENT_SPEC if cli_opts.opt_sync_github_prs else GITLAB_CLIENT_SPEC
+            spec = GITHUB_API_SPEC if cli_opts.opt_sync_github_prs else GITLAB_API_SPEC
             anno_client = AnnoMacheteClient(git, spec)
             anno_client.read_branch_layout_file(verify_branches=False)
             if cli_opts.opt_sync_github_prs or cli_opts.opt_sync_gitlab_mrs:
@@ -784,7 +784,7 @@ def launch_internal(orig_args: List[str]) -> None:
                 else:
                     anno_client.print_annotation(branch)
         elif cmd == "clean":
-            clean_client = MacheteClientWithCodeHosting(git, GITHUB_CLIENT_SPEC)
+            clean_client = MacheteClientWithCodeHosting(git, GITHUB_API_SPEC)
             clean_client.read_branch_layout_file()
             if 'checkout_my_github_prs' in parsed_cli:
                 clean_client.checkout_pull_requests(pr_numbers=[], mine=True)
@@ -869,7 +869,7 @@ def launch_internal(orig_args: List[str]) -> None:
                 print(fork_point_client.fork_point(branch=branch, use_overrides=True))
         elif cmd in {"github", "gitlab"}:
             subcommand = parsed_cli.subcommand
-            spec = GITHUB_CLIENT_SPEC if cmd == "github" else GITLAB_CLIENT_SPEC
+            spec = GITHUB_API_SPEC if cmd == "github" else GITLAB_API_SPEC
             pr_or_mr = spec.pr_short_name.lower()
 
             if "request_id" in parsed_cli and subcommand != f"checkout-{pr_or_mr}s":
@@ -1097,7 +1097,7 @@ def launch_internal(orig_args: List[str]) -> None:
             opt_return_to = TraverseReturnTo.from_string(cli_opts.opt_return_to, "`--return-to` flag")
             opt_start_from = TraverseStartFrom.from_string_or_branch(cli_opts.opt_start_from, git)
 
-            spec = GITHUB_CLIENT_SPEC if cli_opts.opt_sync_github_prs else GITLAB_CLIENT_SPEC
+            spec = GITHUB_API_SPEC if cli_opts.opt_sync_github_prs else GITLAB_API_SPEC
             traverse_client = TraverseMacheteClient(git, spec)
             traverse_client.read_branch_layout_file(interactively_slide_out_invalid_branches=terminal.is_stdout_a_tty())
             traverse_client.traverse(

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -992,20 +992,20 @@ def launch_internal(orig_args: List[str]) -> None:
             list_client.read_branch_layout_file()
             res = []
             if category == "addable":
-                res = list_client.addable_branches
+                res = list_client.addable_branches()
             elif category == "childless":
-                res = list_client.childless_managed_branches
+                res = list_client.childless_managed_branches()
             elif category == "managed":
                 res = list_client.managed_branches
             elif category == "slidable":
-                res = list_client.slidable_branches
+                res = list_client.slidable_branches()
             elif category == "slidable-after":
                 list_client.expect_in_managed_branches(parsed_cli.branch)
                 res = list_client.get_slidable_after(parsed_cli.branch)
             elif category == "unmanaged":
-                res = list_client.unmanaged_branches
+                res = list_client.unmanaged_branches()
             elif category == "with-overridden-fork-point":
-                res = list_client.branches_with_overridden_fork_point
+                res = list_client.branches_with_overridden_fork_point()
             else:  # an unknown category is handled by argparse
                 raise UnexpectedMacheteException(f"Invalid category: `{category}`")
 

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -19,6 +19,7 @@ from git_machete.client.discover import DiscoverMacheteClient
 from git_machete.client.fork_point import ForkPointMacheteClient
 from git_machete.client.go_interactive import GoInteractiveMacheteClient
 from git_machete.client.go_show import GoShowMacheteClient
+from git_machete.client.list import ListMacheteClient
 from git_machete.client.log import LogMacheteClient
 from git_machete.client.reapply import ReapplyMacheteClient
 from git_machete.client.rename import RenameMacheteClient
@@ -987,7 +988,7 @@ def launch_internal(orig_args: List[str]) -> None:
             elif category != 'slidable-after' and cli_opts.opt_branch:
                 raise MacheteException(f"`git machete list {category}` does not expect extra arguments")
 
-            list_client = MacheteClient(git)
+            list_client = ListMacheteClient(git)
             list_client.read_branch_layout_file()
             res = []
             if category == "addable":

--- a/git_machete/client/advance.py
+++ b/git_machete/client/advance.py
@@ -1,13 +1,12 @@
 from git_machete.client.base import MacheteClient
 from git_machete.config import SquashMergeDetection
-from git_machete.git_operations import (GitContext, LocalBranchShortName,
-                                        SyncToRemoteStatus)
+from git_machete.git import Git, LocalBranchShortName, SyncToRemoteStatus
 from git_machete.utils.exceptions import MacheteException
 from git_machete.utils.markup import pretty_choices, warn
 
 
 class AdvanceMacheteClient(MacheteClient):
-    def __init__(self, git: GitContext) -> None:
+    def __init__(self, git: Git) -> None:
         super().__init__(git)
 
     def advance(self, *, opt_yes: bool) -> None:

--- a/git_machete/client/anno.py
+++ b/git_machete/client/anno.py
@@ -2,7 +2,7 @@ from typing import List
 
 from git_machete.annotation import Annotation
 from git_machete.client.with_code_hosting import MacheteClientWithCodeHosting
-from git_machete.git_operations import LocalBranchShortName
+from git_machete.git import LocalBranchShortName
 
 
 class AnnoMacheteClient(MacheteClientWithCodeHosting):

--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -1,6 +1,5 @@
 import os
 import shlex
-import shutil
 import sys
 import textwrap
 from enum import Enum, auto
@@ -105,9 +104,9 @@ class MacheteClient:
 
     def expect_at_least_one_managed_branch(self) -> None:
         if not self._state.roots:  # property returns a copy; falsy check works fine
-            self.__raise_no_branches_error()
+            self._raise_no_branches_error()
 
-    def __raise_no_branches_error(self) -> NoReturn:
+    def _raise_no_branches_error(self) -> NoReturn:
         raise MacheteException(
             textwrap.dedent(f"""
                 No branches listed in {self._branch_layout_file_path}. Consider one of:
@@ -163,9 +162,6 @@ class MacheteClient:
             self.__init_state()
             self.read_branch_layout_file(verify_branches=verify_branches)
 
-    def back_up_branch_layout_file(self) -> None:
-        shutil.copyfile(self._branch_layout_file_path, self._branch_layout_file_path + "~")
-
     def save_branch_layout_file(self) -> None:
         branch_layout.save(self._branch_layout_file_path, self._state, indent=self.__indent or "  ")
 
@@ -175,48 +171,6 @@ class MacheteClient:
         self.save_branch_layout_file()
 
     # === Branch navigation ===
-
-    def first_branch_for(self, branch: LocalBranchShortName) -> LocalBranchShortName:
-        root = self.root_branch_for(branch, if_unmanaged=PickRoot.FIRST)
-        root_children = self.children_of(root)
-        return root_children[0] if root_children else root
-
-    def last_branch_for(self, branch: LocalBranchShortName) -> LocalBranchShortName:
-        destination = self.root_branch_for(branch, if_unmanaged=PickRoot.LAST)
-        while True:
-            children = self._state.get_children(destination)
-            if not children:
-                break
-            destination = children[-1]
-        return destination
-
-    def next_branch_for(self, branch: LocalBranchShortName) -> LocalBranchShortName:
-        self.expect_in_managed_branches(branch)
-        index: int = self.managed_branches.index(branch) + 1
-        if index == len(self.managed_branches):
-            raise MacheteException(f"Branch <b>{branch}</b> has no successor")
-        return self.managed_branches[index]
-
-    def prev_branch_for(self, branch: LocalBranchShortName) -> LocalBranchShortName:
-        self.expect_in_managed_branches(branch)
-        index: int = self.managed_branches.index(branch) - 1
-        if index == -1:
-            raise MacheteException(f"Branch <b>{branch}</b> has no predecessor")
-        return self.managed_branches[index]
-
-    def first_root_branch(self) -> LocalBranchShortName:
-        roots = self._state.roots
-        if roots:
-            return roots[0]
-        else:
-            self.__raise_no_branches_error()  # pragma: no cover; this case should never happen
-
-    def last_root_branch(self) -> LocalBranchShortName:
-        roots = self._state.roots
-        if roots:
-            return roots[-1]
-        else:
-            self.__raise_no_branches_error()  # pragma: no cover; this case should never happen
 
     def root_branch_for(self, branch: LocalBranchShortName, if_unmanaged: PickRoot) -> LocalBranchShortName:
         if branch not in self.managed_branches:
@@ -233,24 +187,12 @@ class MacheteClient:
                         f"{roots[-1]}{' (the last root)' if len(roots) > 1 else ''} instead as root")
                     return roots[-1]
             else:
-                self.__raise_no_branches_error()
+                self._raise_no_branches_error()
         parent = self.parent_of(branch)
         while parent:
             branch = parent
             parent = self.parent_of(branch)
         return branch
-
-    def get_or_pick_child_of(self, branch: LocalBranchShortName, *, pick_if_multiple: bool) -> List[LocalBranchShortName]:
-        self.expect_in_managed_branches(branch)
-        children = self.children_of(branch)
-        if not children:
-            raise MacheteException(f"Branch <b>{branch}</b> has no downstream branch")
-        elif len(children) == 1:
-            return [children[0]]
-        elif pick_if_multiple:
-            return [self.pick(children, "downstream branch")]
-        else:
-            return children
 
     def get_or_infer_parent_of(self,
                                branch: LocalBranchShortName,

--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -12,12 +12,10 @@ from git_machete.client.state import MacheteState
 from git_machete.config import MacheteConfig, SquashMergeDetection
 from git_machete.constants import (INITIAL_COMMIT_COUNT_FOR_LOG,
                                    TOTAL_COMMIT_COUNT_FOR_LOG)
-from git_machete.git_operations import (HEAD, AnyBranchName, AnyRevision,
-                                        BranchPair, ForkPointOverrideData,
-                                        FullCommitHash, GitContext,
-                                        LocalBranchShortName,
-                                        RemoteBranchShortName,
-                                        SyncToRemoteStatus)
+from git_machete.git import (HEAD, AnyBranchName, AnyRevision, BranchPair,
+                             ForkPointOverrideData, FullCommitHash, Git,
+                             LocalBranchShortName, RemoteBranchShortName,
+                             SyncToRemoteStatus)
 from git_machete.utils.cmd import run_cmd
 from git_machete.utils.collections import (excluding, get_second,
                                            map_truthy_only, tupled)
@@ -37,8 +35,8 @@ class PickRoot(Enum):
 
 class MacheteClient:
 
-    def __init__(self, git: GitContext) -> None:
-        self._git: GitContext = git
+    def __init__(self, git: Git) -> None:
+        self._git: Git = git
         self._config: MacheteConfig = MacheteConfig(git)
         git.owner = self
 

--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -1,5 +1,4 @@
 import os
-import re
 import shlex
 import shutil
 import sys
@@ -17,8 +16,7 @@ from git_machete.git import (HEAD, AnyBranchName, AnyRevision, BranchPair,
                              LocalBranchShortName, RemoteBranchShortName,
                              SyncToRemoteStatus)
 from git_machete.utils.cmd import run_cmd
-from git_machete.utils.collections import (excluding, get_second,
-                                           map_truthy_only, tupled)
+from git_machete.utils.collections import excluding, get_second, tupled
 from git_machete.utils.debug_log import debug
 from git_machete.utils.exceptions import (InteractionStopped, MacheteException,
                                           UnexpectedMacheteException)
@@ -86,31 +84,6 @@ class MacheteClient:
     @property
     def managed_branches(self) -> List[LocalBranchShortName]:
         return self._state.managed_branches  # returns a copy
-
-    @property
-    def addable_branches(self) -> List[LocalBranchShortName]:
-        def strip_remote_name(remote_branch: RemoteBranchShortName) -> LocalBranchShortName:
-            return LocalBranchShortName.of(re.sub("^[^/]+/", "", remote_branch))
-
-        remote_counterparts_of_local_branches = map_truthy_only(
-            self._git.get_combined_counterpart_for_fetching_of_branch,
-            self._git.get_local_branches())
-        qualifying_remote_branches: List[RemoteBranchShortName] = \
-            excluding(self._git.get_remote_branches(), remote_counterparts_of_local_branches)
-        return excluding(self._git.get_local_branches(), self.managed_branches) + [
-            strip_remote_name(branch) for branch in qualifying_remote_branches]
-
-    @property
-    def unmanaged_branches(self) -> List[LocalBranchShortName]:
-        return excluding(self._git.get_local_branches(), self.managed_branches)
-
-    @property
-    def childless_managed_branches(self) -> List[LocalBranchShortName]:
-        return [b for b in self._state.managed_branches if not self._state.get_children(b)]
-
-    @property
-    def branches_with_overridden_fork_point(self) -> List[LocalBranchShortName]:
-        return [branch for branch in self._git.get_local_branches() if self.has_any_fork_point_override_config(branch)]
 
     def parent_of(self, branch: LocalBranchShortName) -> Optional[LocalBranchShortName]:
         return self._state.get_parent(branch)
@@ -309,20 +282,6 @@ class MacheteClient:
                 raise MacheteException(
                     f"Branch <b>{branch}</b> not found in the tree of branch "
                     f"dependencies and its upstream could not be inferred")
-
-    # === Slide-out support ===
-
-    @property
-    def slidable_branches(self) -> List[LocalBranchShortName]:
-        # All managed branches can be slid out, including root branches
-        return self.managed_branches
-
-    def get_slidable_after(self, branch: LocalBranchShortName) -> List[LocalBranchShortName]:
-        if self._state.has_parent(branch):
-            children = self.children_of(branch)
-            if children and len(children) == 1:
-                return children
-        return []
 
     # === Fork-point computation ===
 
@@ -563,6 +522,7 @@ class MacheteClient:
 
     # === Fork-point overrides ===
 
+    # Also includes config that is invalid (corresponding to a non-existent/GCed commit etc.).
     def has_any_fork_point_override_config(self, branch: LocalBranchShortName) -> bool:
         return (self._config.fork_point_override_to_value(branch) or
                 self._config.fork_point_override_while_descendant_of_value(branch)) is not None
@@ -1250,10 +1210,3 @@ class MacheteClient:
 
     def flush_caches(self) -> None:
         self.__branch_pairs_by_hash_in_reflog = None
-
-    # === Miscellaneous ===
-
-    def remote_enabled_for_traverse_fetch(self, remote: str) -> bool:
-        return self._config.traverse_fetch_for_remote(remote)
-
-    # Also includes config that is invalid (corresponding to a non-existent/GCed commit etc.).

--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -35,6 +35,8 @@ class PickRoot(Enum):
 
 class MacheteClient:
 
+    # === Initialization ===
+
     def __init__(self, git: Git) -> None:
         self._git: Git = git
         self._config: MacheteConfig = MacheteConfig(git)
@@ -79,9 +81,7 @@ class MacheteClient:
         self.__has_trailing_blank_line: Optional[bool] = None
         self.__branch_pairs_by_hash_in_reflog: Optional[Dict[FullCommitHash, List[BranchPair]]] = None
 
-    @property
-    def branch_layout_file_path(self) -> str:
-        return self._branch_layout_file_path
+    # === Branch listing ===
 
     @property
     def managed_branches(self) -> List[LocalBranchShortName]:
@@ -118,6 +118,8 @@ class MacheteClient:
     def children_of(self, branch: LocalBranchShortName) -> Optional[List[LocalBranchShortName]]:
         return self._state.get_children(branch)
 
+    # === Branch existence assertions ===
+
     def expect_in_managed_branches(self, branch: LocalBranchShortName) -> None:
         if branch not in self.managed_branches:
             raise MacheteException(
@@ -140,6 +142,12 @@ class MacheteClient:
                 * `git machete edit` or edit {self._branch_layout_file_path} manually
                 * `git machete github checkout-prs --mine`
                 * `git machete gitlab checkout-mrs --mine`"""[1:]))
+
+    # === Branch layout file I/O ===
+
+    @property
+    def branch_layout_file_path(self) -> str:
+        return self._branch_layout_file_path
 
     def read_branch_layout_file(self, *, interactively_slide_out_invalid_branches: bool = False, verify_branches: bool = True) -> None:
         self._state, self.__indent = branch_layout.parse(self._branch_layout_file_path)
@@ -188,255 +196,135 @@ class MacheteClient:
     def save_branch_layout_file(self) -> None:
         branch_layout.save(self._branch_layout_file_path, self._state, indent=self.__indent or "  ")
 
-    def add(self,
-            *,
-            branch: LocalBranchShortName,
-            opt_onto: Optional[LocalBranchShortName],
-            opt_as_first_child: bool,
-            opt_as_root: bool,
-            opt_yes: bool,
-            verbose: bool,
-            switch_head_if_new_branch: bool
-            ) -> None:
-        if branch in self.managed_branches:
-            raise MacheteException(f"Branch <b>{branch}</b> already exists in the tree of branch dependencies")
-
-        if opt_onto:
-            self.expect_in_managed_branches(opt_onto)
-
-        if branch not in self._git.get_local_branches():
-            remote_branch: Optional[RemoteBranchShortName] = self._git.get_sole_remote_branch(branch)
-            if remote_branch:
-                common_line = (
-                    f"A local branch <b>{branch}</b> does not exist, but a remote "
-                    f"branch <b>{remote_branch}</b> exists.\n")
-                msg = common_line + f"Check out <b>{branch}</b> locally?" + pretty_choices('y', 'N')
-                opt_yes_msg = common_line + f"Checking out <b>{branch}</b> locally..."
-                if self.ask_if(msg, opt_yes_msg, opt_yes=opt_yes, verbose=verbose) in ('y', 'yes'):
-                    self._git.create_branch(branch, remote_branch.full_name(), switch_head=switch_head_if_new_branch)
-                else:
-                    return
-                # Not dealing with `onto` here. If it hasn't been explicitly
-                # specified via `--onto`, we'll try to infer it now.
-            else:
-                out_of = LocalBranchShortName.of(opt_onto).full_name() if opt_onto else HEAD
-                out_of_str = f"<b>{opt_onto}</b>" if opt_onto else "the current HEAD"
-                msg = (f"A local branch <b>{branch}</b> does not exist. Create out "
-                       f"of {out_of_str}?" + pretty_choices('y', 'N'))
-                opt_yes_msg = (f"A local branch <b>{branch}</b> does not exist. "
-                               f"Creating out of {out_of_str}")
-                if self.ask_if(msg, opt_yes_msg, opt_yes=opt_yes, verbose=verbose) in ('y', 'yes'):
-                    # If `--onto` hasn't been explicitly specified, let's try to
-                    # assess if the current branch would be a good `onto`.
-                    if not opt_onto:
-                        current_branch = self._git.get_current_branch_or_none()
-                        if self._state.roots:
-                            if current_branch and current_branch in self.managed_branches:
-                                opt_onto = current_branch
-                        else:
-                            if current_branch:
-                                # In this case (empty .git/machete, creating a new branch with `git machete add`)
-                                # it's usually pretty obvious that the current branch needs to be added as root first.
-                                # Let's skip interactive questions so as not to confuse new users.
-                                self._state.bootstrap_as_single_managed(current_branch)
-                                # This section of code is only ever executed in verbose mode, but let's leave the `if` for consistency
-                                if verbose:  # pragma: no branch
-                                    print_fmt(f"Added branch <b>{current_branch}</b> as a new root")
-                                opt_onto = current_branch
-                    self._git.create_branch(branch, out_of, switch_head=switch_head_if_new_branch)
-                else:
-                    return
-
-        if opt_as_root or not self._state.roots:
-            self._state.add_as_root(branch)
-            if verbose:
-                print_fmt(f"Added branch <b>{branch}</b> as a new root")
-        else:
-            if not opt_onto:
-                parent = self._infer_upstream(
-                    branch,
-                    condition=lambda x: x in self.managed_branches,
-                    reject_reason_message="this candidate is not a managed branch")
-                if not parent:
-                    raise MacheteException(
-                        f"Could not automatically infer upstream (parent) branch for <b>{branch}</b>.\n"
-                        "You can either:\n"
-                        "1) specify the desired upstream branch with `--onto` or\n"
-                        f"2) pass `--as-root` to attach <b>{branch}</b> as a new root or\n"
-                        "3) edit the branch layout file manually with `git machete edit`")
-                else:
-                    msg = (f"Add <b>{branch}</b> onto the inferred upstream (parent) "
-                           f"branch <b>{parent}</b>?" + pretty_choices('y', 'N'))
-                    opt_yes_msg = (f"Adding <b>{branch}</b> onto the inferred upstream"
-                                   f" (parent) branch <b>{parent}</b>")
-                    if self.ask_if(msg, opt_yes_msg, opt_yes=opt_yes, verbose=verbose) in ('y', 'yes'):
-                        opt_onto = parent
-                    else:
-                        return
-
-            self._state.add_as_child(branch=branch, parent=opt_onto, as_first_child=opt_as_first_child)
-            if verbose:
-                print_fmt(f"Added branch <b>{branch}</b> onto <b>{opt_onto}</b>")
-
+    def _remove_branches_from_layout(self, branches_to_delete: List[LocalBranchShortName]) -> None:
+        for branch in branches_to_delete:
+            self._state.remove_leaf(branch)
         self.save_branch_layout_file()
 
-    def _mark_trailing_blank_line(self) -> None:
-        self.__has_trailing_blank_line = True
+    # === Branch navigation ===
 
-    def _ensure_blank_separator(self) -> None:
-        if not self.__has_trailing_blank_line:
-            print("")
-        self.__has_trailing_blank_line = False
+    def first_branch_for(self, branch: LocalBranchShortName) -> LocalBranchShortName:
+        root = self.root_branch_for(branch, if_unmanaged=PickRoot.FIRST)
+        root_children = self.children_of(root)
+        return root_children[0] if root_children else root
 
-    def __run_hook(self, *args: str, cwd: str) -> int:
-        self._git.flush_caches()
-        if sys.platform == "win32":
-            return run_cmd("sh", *args, cwd=cwd)
+    def last_branch_for(self, branch: LocalBranchShortName) -> LocalBranchShortName:
+        destination = self.root_branch_for(branch, if_unmanaged=PickRoot.LAST)
+        while True:
+            children = self._state.get_children(destination)
+            if not children:
+                break
+            destination = children[-1]
+        return destination
+
+    def next_branch_for(self, branch: LocalBranchShortName) -> LocalBranchShortName:
+        self.expect_in_managed_branches(branch)
+        index: int = self.managed_branches.index(branch) + 1
+        if index == len(self.managed_branches):
+            raise MacheteException(f"Branch <b>{branch}</b> has no successor")
+        return self.managed_branches[index]
+
+    def prev_branch_for(self, branch: LocalBranchShortName) -> LocalBranchShortName:
+        self.expect_in_managed_branches(branch)
+        index: int = self.managed_branches.index(branch) - 1
+        if index == -1:
+            raise MacheteException(f"Branch <b>{branch}</b> has no predecessor")
+        return self.managed_branches[index]
+
+    def first_root_branch(self) -> LocalBranchShortName:
+        roots = self._state.roots
+        if roots:
+            return roots[0]
         else:
-            return run_cmd(*args, cwd=cwd)
+            self.__raise_no_branches_error()  # pragma: no cover; this case should never happen
 
-    def rebase(
-            self, *,
-            onto: AnyRevision,
-            from_exclusive: AnyRevision,
-            branch: LocalBranchShortName,
-            opt_no_interactive_rebase: bool
-    ) -> None:
-        self._git.expect_no_operation_in_progress()
+    def last_root_branch(self) -> LocalBranchShortName:
+        roots = self._state.roots
+        if roots:
+            return roots[-1]
+        else:
+            self.__raise_no_branches_error()  # pragma: no cover; this case should never happen
 
-        anno = self._state.get_annotation(branch)
-        if anno and not anno.qualifiers.rebase:
-            raise MacheteException(f"Branch <b>{branch}</b> is annotated with `rebase=no` qualifier, aborting.\n"
-                                   f"Remove the qualifier using `git machete anno` or edit branch layout file directly.")
-        # Let's use `OPTS` suffix for consistency with git's built-in env var `GIT_DIFF_OPTS`
-        extra_rebase_opts = os.environ.get('GIT_MACHETE_REBASE_OPTS', '').split()
+    def root_branch_for(self, branch: LocalBranchShortName, if_unmanaged: PickRoot) -> LocalBranchShortName:
+        if branch not in self.managed_branches:
+            roots = self._state.roots
+            if roots:
+                if if_unmanaged == PickRoot.FIRST:
+                    warn(
+                        f"<b>{branch}</b> is not a managed branch, assuming "
+                        f"{roots[0]}{' (the first root)' if len(roots) > 1 else ''} instead as root")
+                    return roots[0]
+                else:  # if_unmanaged == PickRoot.LAST
+                    warn(
+                        f"<b>{branch}</b> is not a managed branch, assuming "
+                        f"{roots[-1]}{' (the last root)' if len(roots) > 1 else ''} instead as root")
+                    return roots[-1]
+            else:
+                self.__raise_no_branches_error()
+        parent = self.parent_of(branch)
+        while parent:
+            branch = parent
+            parent = self.parent_of(branch)
+        return branch
 
-        hook_path = self._git.get_hook_path("machete-pre-rebase")
-        if self._git.check_hook_executable(hook_path):
-            debug(f"running machete-pre-rebase hook ({hook_path})")
-            exit_code = self.__run_hook(hook_path, onto, from_exclusive, branch, cwd=self._git.get_current_worktree_root_dir())
-            if exit_code == 0:
-                self._git.rebase(
-                    onto, from_exclusive, branch,
-                    opt_no_interactive_rebase=opt_no_interactive_rebase,
-                    extra_rebase_opts=extra_rebase_opts)
+    def get_or_pick_child_of(self, branch: LocalBranchShortName, *, pick_if_multiple: bool) -> List[LocalBranchShortName]:
+        self.expect_in_managed_branches(branch)
+        children = self.children_of(branch)
+        if not children:
+            raise MacheteException(f"Branch <b>{branch}</b> has no downstream branch")
+        elif len(children) == 1:
+            return [children[0]]
+        elif pick_if_multiple:
+            return [self.pick(children, "downstream branch")]
+        else:
+            return children
+
+    def get_or_infer_parent_of(self,
+                               branch: LocalBranchShortName,
+                               prompt_if_inferred_msg: Optional[str],
+                               prompt_if_inferred_yes_opt_msg: Optional[str]) -> LocalBranchShortName:
+        if branch in self.managed_branches:
+            parent = self.parent_of(branch)
+            if parent:
+                return parent
+            else:
+                raise MacheteException(f"Branch <b>{branch}</b> has no upstream branch")
+        else:
+            parent = self._infer_upstream(branch)
+            if parent:
+                if prompt_if_inferred_msg and prompt_if_inferred_yes_opt_msg:
+                    if self.ask_if(
+                            prompt_if_inferred_msg % (branch, parent),
+                            prompt_if_inferred_yes_opt_msg % (branch, parent),
+                            opt_yes=False
+                    ) in ('y', 'yes'):
+                        return parent
+                    raise MacheteException("Aborting.")
+                else:
+                    warn(
+                        f"branch <b>{branch}</b> not found in the tree of branch "
+                        f"dependencies; the upstream has been inferred to <b>{parent}</b>")
+                    return parent
             else:
                 raise MacheteException(
-                    f"The machete-pre-rebase hook refused to rebase. Error code: {exit_code}")
-        else:
-            self._git.rebase(
-                onto, from_exclusive, branch,
-                opt_no_interactive_rebase=opt_no_interactive_rebase,
-                extra_rebase_opts=extra_rebase_opts)
+                    f"Branch <b>{branch}</b> not found in the tree of branch "
+                    f"dependencies and its upstream could not be inferred")
 
-    def delete_unmanaged(self, *, opt_squash_merge_detection: SquashMergeDetection, opt_yes: bool) -> None:
-        print('Checking for unmanaged branches...')
-        branches_to_delete = sorted(excluding(self._git.get_local_branches(), self.managed_branches))
-        self._delete_branches(branches_to_delete=branches_to_delete,
-                              opt_squash_merge_detection=opt_squash_merge_detection, opt_yes=opt_yes)
+    # === Slide-out support ===
 
-    def _delete_branches(
-        self,
-        branches_to_delete: List[LocalBranchShortName],
-        *,
-        opt_squash_merge_detection: SquashMergeDetection,
-        opt_yes: bool
-    ) -> None:
-        current_branch = self._git.get_current_branch_or_none()
-        if current_branch and current_branch in branches_to_delete:
-            branches_to_delete = excluding(branches_to_delete, [current_branch])
-            print_fmt(f"Skipping current branch <b>{current_branch}</b>")
-        if not branches_to_delete:
-            print("No branches to delete")
-            return
+    @property
+    def slidable_branches(self) -> List[LocalBranchShortName]:
+        # All managed branches can be slid out, including root branches
+        return self.managed_branches
 
-        if opt_yes:
-            for branch in branches_to_delete:
-                print_fmt(f"Deleting branch <b>{branch}</b>...")
-                self._git.delete_branch(branch, force=True)
-        else:
-            for branch in branches_to_delete:
-                if self.is_merged_to(branch=branch, parent=AnyBranchName('HEAD'), opt_squash_merge_detection=opt_squash_merge_detection):
-                    remote_branch = self._git.get_strict_counterpart_for_fetching_of_branch(branch)
-                    if remote_branch:
-                        is_merged_to_remote = self.is_merged_to(
-                            branch=branch,
-                            parent=remote_branch,
-                            opt_squash_merge_detection=opt_squash_merge_detection)
-                    else:
-                        is_merged_to_remote = True
-                    if is_merged_to_remote:
-                        msg_core_suffix = ''
-                    else:
-                        msg_core_suffix = f', but not merged to <b>{remote_branch}</b>'
-                    msg_core = f"<b>{branch}</b> (merged to HEAD{msg_core_suffix})"
-                else:
-                    msg_core = f"<b>{branch}</b> (unmerged to HEAD)"
-                msg = f"Delete branch {msg_core}?" + pretty_choices('y', 'N', 'q')
-                ans = self.ask_if(msg, msg_if_opt_yes=None, opt_yes=False)
-                if ans in ('y', 'yes'):
-                    self._git.delete_branch(branch, force=True)
-                elif ans in ('q', 'quit'):
-                    return
-
-    def edit(self) -> int:
-        default_editor_with_args: List[str] = self.__get_editor_with_args()
-        if not default_editor_with_args:
-            raise MacheteException(
-                f"Cannot determine editor. Set `GIT_MACHETE_EDITOR` environment "
-                f"variable or edit {self._branch_layout_file_path} directly.")
-
-        command = default_editor_with_args[0]
-        args = default_editor_with_args[1:] + [self._branch_layout_file_path]
-        return run_cmd(command, *args)
-
-    def __get_editor_with_args(self) -> List[str]:
-        # Based on the git's own algorithm for identifying the editor.
-        # '$GIT_MACHETE_EDITOR', 'editor' (to please Debian-based systems) and 'nano' have been added.
-        git_machete_editor_var = "GIT_MACHETE_EDITOR"
-        proposed_editor_funs: List[Tuple[str, Callable[[], Optional[str]]]] = [
-            ("$" + git_machete_editor_var, lambda: os.environ.get(git_machete_editor_var)),
-            ("$GIT_EDITOR", lambda: os.environ.get("GIT_EDITOR")),
-            ("git config core.editor", lambda: self._config.core_editor()),
-            ("$VISUAL", lambda: os.environ.get("VISUAL")),
-            ("$EDITOR", lambda: os.environ.get("EDITOR")),
-            ("editor", lambda: "editor"),
-            ("nano", lambda: "nano"),
-            ("vi", lambda: "vi"),
-        ]
-
-        for name, fun in proposed_editor_funs:
-            editor = fun()
-            if not editor:
-                debug(f"'{name}' is undefined")
-            else:
-                editor_parsed = shlex.split(editor)
-                if not editor_parsed:
-                    debug(f"'{name}' shlexes into an empty list")
-                    continue
-                editor_command = editor_parsed[0]
-                editor_repr = "'" + name + "'" + ((' (' + editor + ')') if editor_command != name else '')
-
-                if not fs.find_executable(editor_command):
-                    debug(f"'{editor_command}' executable ('{name}') not found")
-                    if name == "$" + git_machete_editor_var:
-                        # In this specific case, when GIT_MACHETE_EDITOR is defined but doesn't point to a valid executable,
-                        # it's more reasonable/less confusing to raise an error and exit without opening anything.
-                        raise MacheteException(f"<b>{editor_repr}</b> is not available")
-                else:
-                    debug(f"'{editor_command}' executable ('{name}') found")
-                    if name != "$" + git_machete_editor_var and self._config.advice_machete_editor_selection():
-                        sample_alternative = 'nano' if editor_command.startswith('vi') else 'vi'
-                        print_fmt(f"Opening <b>{editor_repr}</b>.\n"
-                                  f"To override this choice, use <b>{git_machete_editor_var}</b> env var, e.g. `export "
-                                  f"{git_machete_editor_var}={sample_alternative}`.\n\n"
-                                  "See `git machete help edit` and `git machete edit --debug` for more details.\n\n"
-                                  "Use `git config --global advice.macheteEditorSelection false` to suppress this message.",
-                                  file=sys.stderr)
-                    return editor_parsed
-
-        # This case is extremely unlikely on a modern Unix-like system.
+    def get_slidable_after(self, branch: LocalBranchShortName) -> List[LocalBranchShortName]:
+        if self._state.has_parent(branch):
+            children = self.children_of(branch)
+            if children and len(children) == 1:
+                return children
         return []
+
+    # === Fork-point computation ===
 
     def fork_point_and_containing_branch_pairs(
         self,
@@ -543,149 +431,14 @@ class MacheteClient:
         except MacheteException:
             return None
 
-    def get_or_pick_child_of(self, branch: LocalBranchShortName, *, pick_if_multiple: bool) -> List[LocalBranchShortName]:
-        self.expect_in_managed_branches(branch)
-        children = self.children_of(branch)
-        if not children:
-            raise MacheteException(f"Branch <b>{branch}</b> has no downstream branch")
-        elif len(children) == 1:
-            return [children[0]]
-        elif pick_if_multiple:
-            return [self.pick(children, "downstream branch")]
-        else:
-            return children
-
-    def first_branch_for(self, branch: LocalBranchShortName) -> LocalBranchShortName:
-        root = self.root_branch_for(branch, if_unmanaged=PickRoot.FIRST)
-        root_children = self.children_of(root)
-        return root_children[0] if root_children else root
-
-    def last_branch_for(self, branch: LocalBranchShortName) -> LocalBranchShortName:
-        destination = self.root_branch_for(branch, if_unmanaged=PickRoot.LAST)
-        while True:
-            children = self._state.get_children(destination)
-            if not children:
-                break
-            destination = children[-1]
-        return destination
-
-    def next_branch_for(self, branch: LocalBranchShortName) -> LocalBranchShortName:
-        self.expect_in_managed_branches(branch)
-        index: int = self.managed_branches.index(branch) + 1
-        if index == len(self.managed_branches):
-            raise MacheteException(f"Branch <b>{branch}</b> has no successor")
-        return self.managed_branches[index]
-
-    def prev_branch_for(self, branch: LocalBranchShortName) -> LocalBranchShortName:
-        self.expect_in_managed_branches(branch)
-        index: int = self.managed_branches.index(branch) - 1
-        if index == -1:
-            raise MacheteException(f"Branch <b>{branch}</b> has no predecessor")
-        return self.managed_branches[index]
-
-    def first_root_branch(self) -> LocalBranchShortName:
-        roots = self._state.roots
-        if roots:
-            return roots[0]
-        else:
-            self.__raise_no_branches_error()  # pragma: no cover; this case should never happen
-
-    def last_root_branch(self) -> LocalBranchShortName:
-        roots = self._state.roots
-        if roots:
-            return roots[-1]
-        else:
-            self.__raise_no_branches_error()  # pragma: no cover; this case should never happen
-
-    def root_branch_for(self, branch: LocalBranchShortName, if_unmanaged: PickRoot) -> LocalBranchShortName:
-        if branch not in self.managed_branches:
-            roots = self._state.roots
-            if roots:
-                if if_unmanaged == PickRoot.FIRST:
-                    warn(
-                        f"<b>{branch}</b> is not a managed branch, assuming "
-                        f"{roots[0]}{' (the first root)' if len(roots) > 1 else ''} instead as root")
-                    return roots[0]
-                else:  # if_unmanaged == PickRoot.LAST
-                    warn(
-                        f"<b>{branch}</b> is not a managed branch, assuming "
-                        f"{roots[-1]}{' (the last root)' if len(roots) > 1 else ''} instead as root")
-                    return roots[-1]
-            else:
-                self.__raise_no_branches_error()
-        parent = self.parent_of(branch)
-        while parent:
-            branch = parent
-            parent = self.parent_of(branch)
-        return branch
-
-    def get_or_infer_parent_of(self,
-                               branch: LocalBranchShortName,
-                               prompt_if_inferred_msg: Optional[str],
-                               prompt_if_inferred_yes_opt_msg: Optional[str]) -> LocalBranchShortName:
-        if branch in self.managed_branches:
-            parent = self.parent_of(branch)
-            if parent:
-                return parent
-            else:
-                raise MacheteException(f"Branch <b>{branch}</b> has no upstream branch")
-        else:
-            parent = self._infer_upstream(branch)
-            if parent:
-                if prompt_if_inferred_msg and prompt_if_inferred_yes_opt_msg:
-                    if self.ask_if(
-                            prompt_if_inferred_msg % (branch, parent),
-                            prompt_if_inferred_yes_opt_msg % (branch, parent),
-                            opt_yes=False
-                    ) in ('y', 'yes'):
-                        return parent
-                    raise MacheteException("Aborting.")
-                else:
-                    warn(
-                        f"branch <b>{branch}</b> not found in the tree of branch "
-                        f"dependencies; the upstream has been inferred to <b>{parent}</b>")
-                    return parent
-            else:
-                raise MacheteException(
-                    f"Branch <b>{branch}</b> not found in the tree of branch "
-                    f"dependencies and its upstream could not be inferred")
-
-    @property
-    def slidable_branches(self) -> List[LocalBranchShortName]:
-        # All managed branches can be slid out, including root branches
-        return self.managed_branches
-
-    def get_slidable_after(self, branch: LocalBranchShortName) -> List[LocalBranchShortName]:
-        if self._state.has_parent(branch):
-            children = self.children_of(branch)
-            if children and len(children) == 1:
-                return children
-        return []
-
-    def _is_merged_to_parent(
-            self, branch: LocalBranchShortName, *, opt_squash_merge_detection: SquashMergeDetection) -> bool:
-        parent = self.parent_of(branch)
-        if not parent:
-            return False
-        return self.is_merged_to(branch=branch, parent=parent, opt_squash_merge_detection=opt_squash_merge_detection)
-
-    def _run_post_slide_out_hook(
-        self,
-        *,
-        new_upstream: Optional[LocalBranchShortName],
-        slid_out_branch: LocalBranchShortName,
-        new_downstreams: List[LocalBranchShortName]
-    ) -> None:
-        hook_path = self._git.get_hook_path("machete-post-slide-out")
-        if self._git.check_hook_executable(hook_path):
-            debug(f"running machete-post-slide-out hook ({hook_path})")
-            new_downstreams_strings: List[str] = [str(db) for db in new_downstreams]
-            # When sliding out root branches, new_upstream is None; pass empty string to the hook
-            new_upstream_str = str(new_upstream) if new_upstream is not None else ""
-            exit_code = self.__run_hook(hook_path, new_upstream_str, slid_out_branch, *new_downstreams_strings,
-                                        cwd=self._git.get_current_worktree_root_dir())
-            if exit_code != 0:
-                raise MacheteException(f"The machete-post-slide-out hook exited with {exit_code}, aborting.")
+    def check_that_fork_point_is_ancestor_or_equal_to_tip_of_branch(
+            self, *, fork_point: AnyRevision, branch: AnyBranchName) -> None:
+        if not self._git.is_ancestor_or_equal(
+                earlier_revision=fork_point.full_name(),
+                later_revision=branch.full_name()):
+            raise MacheteException(
+                f"Fork point <b>{fork_point}</b> is not ancestor of or the tip "
+                f"of the <b>{branch}</b> branch.")
 
     def filtered_reflog(self, branch: AnyBranchName) -> List[FullCommitHash]:
         def is_excluded_reflog_subject(entry_hash: str, reflog_subject: str) -> bool:
@@ -808,10 +561,8 @@ class MacheteClient:
                     debug(f"upstream candidate {candidate} rejected ({reject_reason_message})")
         return None
 
-    def remote_enabled_for_traverse_fetch(self, remote: str) -> bool:
-        return self._config.traverse_fetch_for_remote(remote)
+    # === Fork-point overrides ===
 
-    # Also includes config that is invalid (corresponding to a non-existent/GCed commit etc.).
     def has_any_fork_point_override_config(self, branch: LocalBranchShortName) -> bool:
         return (self._config.fork_point_override_to_value(branch) or
                 self._config.fork_point_override_while_descendant_of_value(branch)) is not None
@@ -839,6 +590,328 @@ class MacheteClient:
             return None
         debug(f"since branch {branch} is descendant of {to}, fork point of {branch} is overridden to {to}")
         return to
+
+    # === Merge detection ===
+
+    def is_merged_to(
+            self,
+            *,
+            branch: AnyBranchName,
+            parent: AnyBranchName,
+            opt_squash_merge_detection: SquashMergeDetection
+    ) -> bool:
+        if self._git.is_ancestor_or_equal(branch.full_name(), parent.full_name()):
+            # If branch is ancestor of or equal to the parent, we need to distinguish between the
+            # case of branch being "recently" created from the parent and the case of
+            # branch being fast-forward-merged to the parent.
+            # The applied heuristics is to check if the filtered reflog of the branch
+            # (reflog stripped of trivial events like branch creation, reset etc.)
+            # is non-empty.
+            return bool(self.filtered_reflog(branch))
+        elif opt_squash_merge_detection == SquashMergeDetection.NONE:
+            return False
+        elif opt_squash_merge_detection == SquashMergeDetection.SIMPLE:
+            # In the default mode.
+            # If a commit with an identical tree state to branch is reachable from parent,
+            # then branch may have been squashed or rebase-merged into parent.
+            return self._git.is_equivalent_tree_reachable(equivalent_to=branch, reachable_from=parent)
+        elif opt_squash_merge_detection == SquashMergeDetection.EXACT:
+            # Let's try another way, a little more complex but takes into account the possibility
+            # that there were other commits between the common ancestor of the two branches and the squashed merge.
+            return self._git.is_equivalent_tree_reachable(equivalent_to=branch, reachable_from=parent) or \
+                self._git.is_equivalent_patch_reachable(equivalent_to=branch, reachable_from=parent)
+        else:  # pragma: no cover
+            raise UnexpectedMacheteException(f"Invalid squash merged detection mode: {opt_squash_merge_detection}.")
+
+    def _is_merged_to_parent(
+            self, branch: LocalBranchShortName, *, opt_squash_merge_detection: SquashMergeDetection) -> bool:
+        parent = self.parent_of(branch)
+        if not parent:
+            return False
+        return self.is_merged_to(branch=branch, parent=parent, opt_squash_merge_detection=opt_squash_merge_detection)
+
+    # === Branch addition ===
+
+    def add(self,
+            *,
+            branch: LocalBranchShortName,
+            opt_onto: Optional[LocalBranchShortName],
+            opt_as_first_child: bool,
+            opt_as_root: bool,
+            opt_yes: bool,
+            verbose: bool,
+            switch_head_if_new_branch: bool
+            ) -> None:
+        if branch in self.managed_branches:
+            raise MacheteException(f"Branch <b>{branch}</b> already exists in the tree of branch dependencies")
+
+        if opt_onto:
+            self.expect_in_managed_branches(opt_onto)
+
+        if branch not in self._git.get_local_branches():
+            remote_branch: Optional[RemoteBranchShortName] = self._git.get_sole_remote_branch(branch)
+            if remote_branch:
+                common_line = (
+                    f"A local branch <b>{branch}</b> does not exist, but a remote "
+                    f"branch <b>{remote_branch}</b> exists.\n")
+                msg = common_line + f"Check out <b>{branch}</b> locally?" + pretty_choices('y', 'N')
+                opt_yes_msg = common_line + f"Checking out <b>{branch}</b> locally..."
+                if self.ask_if(msg, opt_yes_msg, opt_yes=opt_yes, verbose=verbose) in ('y', 'yes'):
+                    self._git.create_branch(branch, remote_branch.full_name(), switch_head=switch_head_if_new_branch)
+                else:
+                    return
+                # Not dealing with `onto` here. If it hasn't been explicitly
+                # specified via `--onto`, we'll try to infer it now.
+            else:
+                out_of = LocalBranchShortName.of(opt_onto).full_name() if opt_onto else HEAD
+                out_of_str = f"<b>{opt_onto}</b>" if opt_onto else "the current HEAD"
+                msg = (f"A local branch <b>{branch}</b> does not exist. Create out "
+                       f"of {out_of_str}?" + pretty_choices('y', 'N'))
+                opt_yes_msg = (f"A local branch <b>{branch}</b> does not exist. "
+                               f"Creating out of {out_of_str}")
+                if self.ask_if(msg, opt_yes_msg, opt_yes=opt_yes, verbose=verbose) in ('y', 'yes'):
+                    # If `--onto` hasn't been explicitly specified, let's try to
+                    # assess if the current branch would be a good `onto`.
+                    if not opt_onto:
+                        current_branch = self._git.get_current_branch_or_none()
+                        if self._state.roots:
+                            if current_branch and current_branch in self.managed_branches:
+                                opt_onto = current_branch
+                        else:
+                            if current_branch:
+                                # In this case (empty .git/machete, creating a new branch with `git machete add`)
+                                # it's usually pretty obvious that the current branch needs to be added as root first.
+                                # Let's skip interactive questions so as not to confuse new users.
+                                self._state.bootstrap_as_single_managed(current_branch)
+                                # This section of code is only ever executed in verbose mode, but let's leave the `if` for consistency
+                                if verbose:  # pragma: no branch
+                                    print_fmt(f"Added branch <b>{current_branch}</b> as a new root")
+                                opt_onto = current_branch
+                    self._git.create_branch(branch, out_of, switch_head=switch_head_if_new_branch)
+                else:
+                    return
+
+        if opt_as_root or not self._state.roots:
+            self._state.add_as_root(branch)
+            if verbose:
+                print_fmt(f"Added branch <b>{branch}</b> as a new root")
+        else:
+            if not opt_onto:
+                parent = self._infer_upstream(
+                    branch,
+                    condition=lambda x: x in self.managed_branches,
+                    reject_reason_message="this candidate is not a managed branch")
+                if not parent:
+                    raise MacheteException(
+                        f"Could not automatically infer upstream (parent) branch for <b>{branch}</b>.\n"
+                        "You can either:\n"
+                        "1) specify the desired upstream branch with `--onto` or\n"
+                        f"2) pass `--as-root` to attach <b>{branch}</b> as a new root or\n"
+                        "3) edit the branch layout file manually with `git machete edit`")
+                else:
+                    msg = (f"Add <b>{branch}</b> onto the inferred upstream (parent) "
+                           f"branch <b>{parent}</b>?" + pretty_choices('y', 'N'))
+                    opt_yes_msg = (f"Adding <b>{branch}</b> onto the inferred upstream"
+                                   f" (parent) branch <b>{parent}</b>")
+                    if self.ask_if(msg, opt_yes_msg, opt_yes=opt_yes, verbose=verbose) in ('y', 'yes'):
+                        opt_onto = parent
+                    else:
+                        return
+
+            self._state.add_as_child(branch=branch, parent=opt_onto, as_first_child=opt_as_first_child)
+            if verbose:
+                print_fmt(f"Added branch <b>{branch}</b> onto <b>{opt_onto}</b>")
+
+        self.save_branch_layout_file()
+
+    # === Branch deletion ===
+
+    def delete_unmanaged(self, *, opt_squash_merge_detection: SquashMergeDetection, opt_yes: bool) -> None:
+        print('Checking for unmanaged branches...')
+        branches_to_delete = sorted(excluding(self._git.get_local_branches(), self.managed_branches))
+        self._delete_branches(branches_to_delete=branches_to_delete,
+                              opt_squash_merge_detection=opt_squash_merge_detection, opt_yes=opt_yes)
+
+    def delete_untracked(self, *, opt_yes: bool) -> None:
+        print_fmt("<b>Checking for untracked managed branches with no downstream...</b>")
+        branches_to_delete: List[LocalBranchShortName] = []
+        for branch in self.managed_branches.copy():
+            status, _ = self._git.get_combined_remote_sync_status(branch)
+            if status == SyncToRemoteStatus.UNTRACKED and not self.children_of(branch):
+                branches_to_delete.append(branch)
+
+        self._remove_branches_from_layout(branches_to_delete)
+        self._delete_branches(branches_to_delete, opt_squash_merge_detection=SquashMergeDetection.NONE, opt_yes=opt_yes)
+
+    def _delete_branches(
+        self,
+        branches_to_delete: List[LocalBranchShortName],
+        *,
+        opt_squash_merge_detection: SquashMergeDetection,
+        opt_yes: bool
+    ) -> None:
+        current_branch = self._git.get_current_branch_or_none()
+        if current_branch and current_branch in branches_to_delete:
+            branches_to_delete = excluding(branches_to_delete, [current_branch])
+            print_fmt(f"Skipping current branch <b>{current_branch}</b>")
+        if not branches_to_delete:
+            print("No branches to delete")
+            return
+
+        if opt_yes:
+            for branch in branches_to_delete:
+                print_fmt(f"Deleting branch <b>{branch}</b>...")
+                self._git.delete_branch(branch, force=True)
+        else:
+            for branch in branches_to_delete:
+                if self.is_merged_to(branch=branch, parent=AnyBranchName('HEAD'), opt_squash_merge_detection=opt_squash_merge_detection):
+                    remote_branch = self._git.get_strict_counterpart_for_fetching_of_branch(branch)
+                    if remote_branch:
+                        is_merged_to_remote = self.is_merged_to(
+                            branch=branch,
+                            parent=remote_branch,
+                            opt_squash_merge_detection=opt_squash_merge_detection)
+                    else:
+                        is_merged_to_remote = True
+                    if is_merged_to_remote:
+                        msg_core_suffix = ''
+                    else:
+                        msg_core_suffix = f', but not merged to <b>{remote_branch}</b>'
+                    msg_core = f"<b>{branch}</b> (merged to HEAD{msg_core_suffix})"
+                else:
+                    msg_core = f"<b>{branch}</b> (unmerged to HEAD)"
+                msg = f"Delete branch {msg_core}?" + pretty_choices('y', 'N', 'q')
+                ans = self.ask_if(msg, msg_if_opt_yes=None, opt_yes=False)
+                if ans in ('y', 'yes'):
+                    self._git.delete_branch(branch, force=True)
+                elif ans in ('q', 'quit'):
+                    return
+
+    # === Rebase ===
+
+    def rebase(
+            self, *,
+            onto: AnyRevision,
+            from_exclusive: AnyRevision,
+            branch: LocalBranchShortName,
+            opt_no_interactive_rebase: bool
+    ) -> None:
+        self._git.expect_no_operation_in_progress()
+
+        anno = self._state.get_annotation(branch)
+        if anno and not anno.qualifiers.rebase:
+            raise MacheteException(f"Branch <b>{branch}</b> is annotated with `rebase=no` qualifier, aborting.\n"
+                                   f"Remove the qualifier using `git machete anno` or edit branch layout file directly.")
+        # Let's use `OPTS` suffix for consistency with git's built-in env var `GIT_DIFF_OPTS`
+        extra_rebase_opts = os.environ.get('GIT_MACHETE_REBASE_OPTS', '').split()
+
+        hook_path = self._git.get_hook_path("machete-pre-rebase")
+        if self._git.check_hook_executable(hook_path):
+            debug(f"running machete-pre-rebase hook ({hook_path})")
+            exit_code = self.__run_hook(hook_path, onto, from_exclusive, branch, cwd=self._git.get_current_worktree_root_dir())
+            if exit_code == 0:
+                self._git.rebase(
+                    onto, from_exclusive, branch,
+                    opt_no_interactive_rebase=opt_no_interactive_rebase,
+                    extra_rebase_opts=extra_rebase_opts)
+            else:
+                raise MacheteException(
+                    f"The machete-pre-rebase hook refused to rebase. Error code: {exit_code}")
+        else:
+            self._git.rebase(
+                onto, from_exclusive, branch,
+                opt_no_interactive_rebase=opt_no_interactive_rebase,
+                extra_rebase_opts=extra_rebase_opts)
+
+    # === Editor (edit subcommand) ===
+
+    def edit(self) -> int:
+        default_editor_with_args: List[str] = self.__get_editor_with_args()
+        if not default_editor_with_args:
+            raise MacheteException(
+                f"Cannot determine editor. Set `GIT_MACHETE_EDITOR` environment "
+                f"variable or edit {self._branch_layout_file_path} directly.")
+
+        command = default_editor_with_args[0]
+        args = default_editor_with_args[1:] + [self._branch_layout_file_path]
+        return run_cmd(command, *args)
+
+    def __get_editor_with_args(self) -> List[str]:
+        # Based on the git's own algorithm for identifying the editor.
+        # '$GIT_MACHETE_EDITOR', 'editor' (to please Debian-based systems) and 'nano' have been added.
+        git_machete_editor_var = "GIT_MACHETE_EDITOR"
+        proposed_editor_funs: List[Tuple[str, Callable[[], Optional[str]]]] = [
+            ("$" + git_machete_editor_var, lambda: os.environ.get(git_machete_editor_var)),
+            ("$GIT_EDITOR", lambda: os.environ.get("GIT_EDITOR")),
+            ("git config core.editor", lambda: self._config.core_editor()),
+            ("$VISUAL", lambda: os.environ.get("VISUAL")),
+            ("$EDITOR", lambda: os.environ.get("EDITOR")),
+            ("editor", lambda: "editor"),
+            ("nano", lambda: "nano"),
+            ("vi", lambda: "vi"),
+        ]
+
+        for name, fun in proposed_editor_funs:
+            editor = fun()
+            if not editor:
+                debug(f"'{name}' is undefined")
+            else:
+                editor_parsed = shlex.split(editor)
+                if not editor_parsed:
+                    debug(f"'{name}' shlexes into an empty list")
+                    continue
+                editor_command = editor_parsed[0]
+                editor_repr = "'" + name + "'" + ((' (' + editor + ')') if editor_command != name else '')
+
+                if not fs.find_executable(editor_command):
+                    debug(f"'{editor_command}' executable ('{name}') not found")
+                    if name == "$" + git_machete_editor_var:
+                        # In this specific case, when GIT_MACHETE_EDITOR is defined but doesn't point to a valid executable,
+                        # it's more reasonable/less confusing to raise an error and exit without opening anything.
+                        raise MacheteException(f"<b>{editor_repr}</b> is not available")
+                else:
+                    debug(f"'{editor_command}' executable ('{name}') found")
+                    if name != "$" + git_machete_editor_var and self._config.advice_machete_editor_selection():
+                        sample_alternative = 'nano' if editor_command.startswith('vi') else 'vi'
+                        print_fmt(f"Opening <b>{editor_repr}</b>.\n"
+                                  f"To override this choice, use <b>{git_machete_editor_var}</b> env var, e.g. `export "
+                                  f"{git_machete_editor_var}={sample_alternative}`.\n\n"
+                                  "See `git machete help edit` and `git machete edit --debug` for more details.\n\n"
+                                  "Use `git config --global advice.macheteEditorSelection false` to suppress this message.",
+                                  file=sys.stderr)
+                    return editor_parsed
+
+        # This case is extremely unlikely on a modern Unix-like system.
+        return []
+
+    # === Hooks ===
+
+    def __run_hook(self, *args: str, cwd: str) -> int:
+        self._git.flush_caches()
+        if sys.platform == "win32":
+            return run_cmd("sh", *args, cwd=cwd)
+        else:
+            return run_cmd(*args, cwd=cwd)
+
+    def _run_post_slide_out_hook(
+        self,
+        *,
+        new_upstream: Optional[LocalBranchShortName],
+        slid_out_branch: LocalBranchShortName,
+        new_downstreams: List[LocalBranchShortName]
+    ) -> None:
+        hook_path = self._git.get_hook_path("machete-post-slide-out")
+        if self._git.check_hook_executable(hook_path):
+            debug(f"running machete-post-slide-out hook ({hook_path})")
+            new_downstreams_strings: List[str] = [str(db) for db in new_downstreams]
+            # When sliding out root branches, new_upstream is None; pass empty string to the hook
+            new_upstream_str = str(new_upstream) if new_upstream is not None else ""
+            exit_code = self.__run_hook(hook_path, new_upstream_str, slid_out_branch, *new_downstreams_strings,
+                                        cwd=self._git.get_current_worktree_root_dir())
+            if exit_code != 0:
+                raise MacheteException(f"The machete-post-slide-out hook exited with {exit_code}, aborting.")
+
+    # === Sync-to-remote state handlers ===
 
     def __pick_remote(
             self,
@@ -1000,110 +1073,6 @@ class MacheteClient:
         elif ans in ('q', 'quit'):
             raise InteractionStopped
 
-    def is_merged_to(
-            self,
-            *,
-            branch: AnyBranchName,
-            parent: AnyBranchName,
-            opt_squash_merge_detection: SquashMergeDetection
-    ) -> bool:
-        if self._git.is_ancestor_or_equal(branch.full_name(), parent.full_name()):
-            # If branch is ancestor of or equal to the parent, we need to distinguish between the
-            # case of branch being "recently" created from the parent and the case of
-            # branch being fast-forward-merged to the parent.
-            # The applied heuristics is to check if the filtered reflog of the branch
-            # (reflog stripped of trivial events like branch creation, reset etc.)
-            # is non-empty.
-            return bool(self.filtered_reflog(branch))
-        elif opt_squash_merge_detection == SquashMergeDetection.NONE:
-            return False
-        elif opt_squash_merge_detection == SquashMergeDetection.SIMPLE:
-            # In the default mode.
-            # If a commit with an identical tree state to branch is reachable from parent,
-            # then branch may have been squashed or rebase-merged into parent.
-            return self._git.is_equivalent_tree_reachable(equivalent_to=branch, reachable_from=parent)
-        elif opt_squash_merge_detection == SquashMergeDetection.EXACT:
-            # Let's try another way, a little more complex but takes into account the possibility
-            # that there were other commits between the common ancestor of the two branches and the squashed merge.
-            return self._git.is_equivalent_tree_reachable(equivalent_to=branch, reachable_from=parent) or \
-                self._git.is_equivalent_patch_reachable(equivalent_to=branch, reachable_from=parent)
-        else:  # pragma: no cover
-            raise UnexpectedMacheteException(f"Invalid squash merged detection mode: {opt_squash_merge_detection}.")
-
-    @staticmethod
-    def ask_if(
-            msg: str,
-            msg_if_opt_yes: Optional[str],
-            *,
-            opt_yes: bool,
-            override_answer: Optional[str] = None,
-            verbose: bool = True
-    ) -> str:
-        if override_answer:
-            return override_answer
-        if opt_yes and msg_if_opt_yes:
-            if verbose:
-                print_fmt(msg_if_opt_yes)
-            return 'y'
-        try:
-            ans: str = input_fmt(msg).lower().strip()
-        except InterruptedError:
-            sys.exit(1)
-        return ans
-
-    @staticmethod
-    def pick(choices: List[LocalBranchShortName], name: str) -> LocalBranchShortName:
-        xs: str = "".join(f"[{index + 1}] {x}\n" for index, x in enumerate(choices))
-        msg: str = xs + f"Specify {name} or hit <return> to skip: "
-        try:
-            ans: str = input_fmt(msg)
-            if not ans:
-                sys.exit(0)
-            index: int = int(ans) - 1
-        except ValueError:
-            sys.exit(1)
-        if index not in range(len(choices)):
-            raise MacheteException(f"Invalid index: {index + 1}")
-        return choices[index]
-
-    def flush_caches(self) -> None:
-        self.__branch_pairs_by_hash_in_reflog = None
-
-    def check_that_fork_point_is_ancestor_or_equal_to_tip_of_branch(
-            self, *, fork_point: AnyRevision, branch: AnyBranchName) -> None:
-        if not self._git.is_ancestor_or_equal(
-                earlier_revision=fork_point.full_name(),
-                later_revision=branch.full_name()):
-            raise MacheteException(
-                f"Fork point <b>{fork_point}</b> is not ancestor of or the tip "
-                f"of the <b>{branch}</b> branch.")
-
-    def _handle_diverged_and_newer_state(
-            self,
-            *,
-            current_branch: LocalBranchShortName,
-            remote: str,
-            is_called_from_traverse: bool = True,
-            opt_push_tracked: bool,
-            opt_yes: bool
-    ) -> None:
-        self._ensure_blank_separator()
-        remote_branch = self._git.get_combined_counterpart_for_fetching_of_branch(current_branch)
-        assert remote_branch is not None
-        choices = pretty_choices(*('y', 'N', 'q', 'yq') if is_called_from_traverse else ('y', 'N', 'q'))
-        ans = self.ask_if(
-            f"Branch <b>{current_branch}</b> diverged from (and has newer commits than) its remote counterpart <b>{remote_branch}</b>.\n"
-            f"Push <b>{current_branch}</b> with force-with-lease to <b>{remote}</b>?" + choices,
-            f"Branch <b>{current_branch}</b> diverged from (and has newer commits than) its remote counterpart <b>{remote_branch}</b>.\n"
-            f"Pushing <b>{current_branch}</b> with force-with-lease to <b>{remote}</b>...",
-            override_answer=None if opt_push_tracked else "N", opt_yes=opt_yes)
-        if ans in ('y', 'yes', 'yq'):
-            self._git.push(remote, current_branch, force_with_lease=True)
-            if ans == 'yq':
-                raise InteractionStopped
-        elif ans in ('q', 'quit'):
-            raise InteractionStopped
-
     def _handle_untracked_state(
             self,
             *,
@@ -1169,23 +1138,6 @@ class MacheteClient:
         elif ans in ('q', 'quit'):
             raise InteractionStopped
 
-    def _handle_diverged_and_older_state(self, branch: LocalBranchShortName, *, opt_yes: bool) -> None:
-        self._ensure_blank_separator()
-        remote_branch = self._git.get_combined_counterpart_for_fetching_of_branch(branch)
-        assert remote_branch is not None
-        ans = self.ask_if(
-            f"Branch <b>{branch}</b> diverged from (and has older commits than) its remote counterpart <b>{remote_branch}</b>.\n"
-            f"Reset branch <b>{branch}</b> to the commit pointed by <b>{remote_branch}</b>?" + pretty_choices('y', 'N', 'q', 'yq'),
-            f"Branch <b>{branch}</b> diverged from (and has older commits than) its remote counterpart <b>{remote_branch}</b>.\n"
-            f"Resetting branch <b>{branch}</b> to the commit pointed by <b>{remote_branch}</b>...",
-            opt_yes=opt_yes)
-        if ans in ('y', 'yes', 'yq'):
-            self._git.reset_keep(remote_branch)
-            if ans == 'yq':
-                raise InteractionStopped
-        elif ans in ('q', 'quit'):
-            raise InteractionStopped
-
     def _handle_behind_state(self, *, branch: LocalBranchShortName, remote: str, opt_yes: bool) -> None:
         self._ensure_blank_separator()
         remote_branch = self._git.get_combined_counterpart_for_fetching_of_branch(branch)
@@ -1203,18 +1155,105 @@ class MacheteClient:
         elif ans in ('q', 'quit'):
             raise InteractionStopped
 
-    def delete_untracked(self, *, opt_yes: bool) -> None:
-        print_fmt("<b>Checking for untracked managed branches with no downstream...</b>")
-        branches_to_delete: List[LocalBranchShortName] = []
-        for branch in self.managed_branches.copy():
-            status, _ = self._git.get_combined_remote_sync_status(branch)
-            if status == SyncToRemoteStatus.UNTRACKED and not self.children_of(branch):
-                branches_to_delete.append(branch)
+    def _handle_diverged_and_newer_state(
+            self,
+            *,
+            current_branch: LocalBranchShortName,
+            remote: str,
+            is_called_from_traverse: bool = True,
+            opt_push_tracked: bool,
+            opt_yes: bool
+    ) -> None:
+        self._ensure_blank_separator()
+        remote_branch = self._git.get_combined_counterpart_for_fetching_of_branch(current_branch)
+        assert remote_branch is not None
+        choices = pretty_choices(*('y', 'N', 'q', 'yq') if is_called_from_traverse else ('y', 'N', 'q'))
+        ans = self.ask_if(
+            f"Branch <b>{current_branch}</b> diverged from (and has newer commits than) its remote counterpart <b>{remote_branch}</b>.\n"
+            f"Push <b>{current_branch}</b> with force-with-lease to <b>{remote}</b>?" + choices,
+            f"Branch <b>{current_branch}</b> diverged from (and has newer commits than) its remote counterpart <b>{remote_branch}</b>.\n"
+            f"Pushing <b>{current_branch}</b> with force-with-lease to <b>{remote}</b>...",
+            override_answer=None if opt_push_tracked else "N", opt_yes=opt_yes)
+        if ans in ('y', 'yes', 'yq'):
+            self._git.push(remote, current_branch, force_with_lease=True)
+            if ans == 'yq':
+                raise InteractionStopped
+        elif ans in ('q', 'quit'):
+            raise InteractionStopped
 
-        self._remove_branches_from_layout(branches_to_delete)
-        self._delete_branches(branches_to_delete, opt_squash_merge_detection=SquashMergeDetection.NONE, opt_yes=opt_yes)
+    def _handle_diverged_and_older_state(self, branch: LocalBranchShortName, *, opt_yes: bool) -> None:
+        self._ensure_blank_separator()
+        remote_branch = self._git.get_combined_counterpart_for_fetching_of_branch(branch)
+        assert remote_branch is not None
+        ans = self.ask_if(
+            f"Branch <b>{branch}</b> diverged from (and has older commits than) its remote counterpart <b>{remote_branch}</b>.\n"
+            f"Reset branch <b>{branch}</b> to the commit pointed by <b>{remote_branch}</b>?" + pretty_choices('y', 'N', 'q', 'yq'),
+            f"Branch <b>{branch}</b> diverged from (and has older commits than) its remote counterpart <b>{remote_branch}</b>.\n"
+            f"Resetting branch <b>{branch}</b> to the commit pointed by <b>{remote_branch}</b>...",
+            opt_yes=opt_yes)
+        if ans in ('y', 'yes', 'yq'):
+            self._git.reset_keep(remote_branch)
+            if ans == 'yq':
+                raise InteractionStopped
+        elif ans in ('q', 'quit'):
+            raise InteractionStopped
 
-    def _remove_branches_from_layout(self, branches_to_delete: List[LocalBranchShortName]) -> None:
-        for branch in branches_to_delete:
-            self._state.remove_leaf(branch)
-        self.save_branch_layout_file()
+    # === Output formatting ===
+
+    def _mark_trailing_blank_line(self) -> None:
+        self.__has_trailing_blank_line = True
+
+    def _ensure_blank_separator(self) -> None:
+        if not self.__has_trailing_blank_line:
+            print("")
+        self.__has_trailing_blank_line = False
+
+    # === User prompts ===
+
+    @staticmethod
+    def ask_if(
+            msg: str,
+            msg_if_opt_yes: Optional[str],
+            *,
+            opt_yes: bool,
+            override_answer: Optional[str] = None,
+            verbose: bool = True
+    ) -> str:
+        if override_answer:
+            return override_answer
+        if opt_yes and msg_if_opt_yes:
+            if verbose:
+                print_fmt(msg_if_opt_yes)
+            return 'y'
+        try:
+            ans: str = input_fmt(msg).lower().strip()
+        except InterruptedError:
+            sys.exit(1)
+        return ans
+
+    @staticmethod
+    def pick(choices: List[LocalBranchShortName], name: str) -> LocalBranchShortName:
+        xs: str = "".join(f"[{index + 1}] {x}\n" for index, x in enumerate(choices))
+        msg: str = xs + f"Specify {name} or hit <return> to skip: "
+        try:
+            ans: str = input_fmt(msg)
+            if not ans:
+                sys.exit(0)
+            index: int = int(ans) - 1
+        except ValueError:
+            sys.exit(1)
+        if index not in range(len(choices)):
+            raise MacheteException(f"Invalid index: {index + 1}")
+        return choices[index]
+
+    # === Cache management ===
+
+    def flush_caches(self) -> None:
+        self.__branch_pairs_by_hash_in_reflog = None
+
+    # === Miscellaneous ===
+
+    def remote_enabled_for_traverse_fetch(self, remote: str) -> bool:
+        return self._config.traverse_fetch_for_remote(remote)
+
+    # Also includes config that is invalid (corresponding to a non-existent/GCed commit etc.).

--- a/git_machete/client/branch_layout.py
+++ b/git_machete/client/branch_layout.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional, Tuple
 
 from git_machete.annotation import Annotation
 from git_machete.client.state import MacheteState
-from git_machete.git_operations import LocalBranchShortName
+from git_machete.git import LocalBranchShortName
 from git_machete.utils.exceptions import MacheteException
 
 

--- a/git_machete/client/diff.py
+++ b/git_machete/client/diff.py
@@ -2,7 +2,7 @@ import os
 from typing import List, Optional
 
 from git_machete.client.base import MacheteClient
-from git_machete.git_operations import LocalBranchShortName
+from git_machete.git import LocalBranchShortName
 
 
 class DiffMacheteClient(MacheteClient):

--- a/git_machete/client/discover.py
+++ b/git_machete/client/discover.py
@@ -1,6 +1,7 @@
 import datetime
 import itertools
 import os
+import shutil
 from typing import List, Optional, Tuple
 
 from git_machete.client.status import StatusMacheteClient
@@ -15,6 +16,9 @@ from git_machete.utils.markup import pretty_choices, print_fmt, warn
 
 
 class DiscoverMacheteClient(StatusMacheteClient):
+    def back_up_branch_layout_file(self) -> None:
+        shutil.copyfile(self._branch_layout_file_path, self._branch_layout_file_path + "~")
+
     def discover(
             self,
             *,

--- a/git_machete/client/discover.py
+++ b/git_machete/client/discover.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Tuple
 from git_machete.client.status import StatusMacheteClient
 from git_machete.config import SquashMergeDetection
 from git_machete.constants import DISCOVER_DEFAULT_FRESH_BRANCH_COUNT
-from git_machete.git_operations import LocalBranchShortName
+from git_machete.git import LocalBranchShortName
 from git_machete.utils.collections import excluding, tupled
 from git_machete.utils.debug_log import debug
 from git_machete.utils.exceptions import MacheteException

--- a/git_machete/client/fork_point.py
+++ b/git_machete/client/fork_point.py
@@ -1,5 +1,5 @@
 from git_machete.client.base import MacheteClient
-from git_machete.git_operations import AnyRevision, LocalBranchShortName
+from git_machete.git import AnyRevision, LocalBranchShortName
 from git_machete.utils.exceptions import MacheteException
 from git_machete.utils.markup import print_fmt
 

--- a/git_machete/client/go_interactive.py
+++ b/git_machete/client/go_interactive.py
@@ -11,7 +11,7 @@ except ImportError:  # pragma: no cover; Windows-specific
 
 from git_machete.client.status import (StatusData, StatusFlags,
                                        StatusMacheteClient)
-from git_machete.git_operations import LocalBranchShortName
+from git_machete.git import LocalBranchShortName
 from git_machete.utils.collections import index_or_none
 from git_machete.utils.exceptions import (MacheteException,
                                           UnexpectedMacheteException)

--- a/git_machete/client/go_show.py
+++ b/git_machete/client/go_show.py
@@ -7,6 +7,60 @@ from git_machete.utils.exceptions import (MacheteException,
 
 
 class GoShowMacheteClient(MacheteClient):
+    def first_branch_for(self, branch: LocalBranchShortName) -> LocalBranchShortName:
+        root = self.root_branch_for(branch, if_unmanaged=PickRoot.FIRST)
+        root_children = self.children_of(root)
+        return root_children[0] if root_children else root
+
+    def last_branch_for(self, branch: LocalBranchShortName) -> LocalBranchShortName:
+        destination = self.root_branch_for(branch, if_unmanaged=PickRoot.LAST)
+        while True:
+            children = self._state.get_children(destination)
+            if not children:
+                break
+            destination = children[-1]
+        return destination
+
+    def next_branch_for(self, branch: LocalBranchShortName) -> LocalBranchShortName:
+        self.expect_in_managed_branches(branch)
+        index: int = self.managed_branches.index(branch) + 1
+        if index == len(self.managed_branches):
+            raise MacheteException(f"Branch <b>{branch}</b> has no successor")
+        return self.managed_branches[index]
+
+    def prev_branch_for(self, branch: LocalBranchShortName) -> LocalBranchShortName:
+        self.expect_in_managed_branches(branch)
+        index: int = self.managed_branches.index(branch) - 1
+        if index == -1:
+            raise MacheteException(f"Branch <b>{branch}</b> has no predecessor")
+        return self.managed_branches[index]
+
+    def first_root_branch(self) -> LocalBranchShortName:
+        roots = self._state.roots
+        if roots:
+            return roots[0]
+        else:
+            self._raise_no_branches_error()  # pragma: no cover; this case should never happen
+
+    def last_root_branch(self) -> LocalBranchShortName:
+        roots = self._state.roots
+        if roots:
+            return roots[-1]
+        else:
+            self._raise_no_branches_error()  # pragma: no cover; this case should never happen
+
+    def get_or_pick_child_of(self, branch: LocalBranchShortName, *, pick_if_multiple: bool) -> List[LocalBranchShortName]:
+        self.expect_in_managed_branches(branch)
+        children = self.children_of(branch)
+        if not children:
+            raise MacheteException(f"Branch <b>{branch}</b> has no downstream branch")
+        elif len(children) == 1:
+            return [children[0]]
+        elif pick_if_multiple:
+            return [self.pick(children, "downstream branch")]
+        else:
+            return children
+
     def parse_direction(
         self,
         param: str,

--- a/git_machete/client/go_show.py
+++ b/git_machete/client/go_show.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
 from git_machete.client.base import MacheteClient, PickRoot
-from git_machete.git_operations import LocalBranchShortName
+from git_machete.git import LocalBranchShortName
 from git_machete.utils.exceptions import (MacheteException,
                                           UnexpectedMacheteException)
 

--- a/git_machete/client/list.py
+++ b/git_machete/client/list.py
@@ -1,0 +1,46 @@
+import re
+from typing import List
+
+from git_machete.client.base import MacheteClient
+from git_machete.git import LocalBranchShortName, RemoteBranchShortName
+from git_machete.utils.collections import excluding, map_truthy_only
+
+
+class ListMacheteClient(MacheteClient):
+
+    @property
+    def addable_branches(self) -> List[LocalBranchShortName]:
+        def strip_remote_name(remote_branch: RemoteBranchShortName) -> LocalBranchShortName:
+            return LocalBranchShortName.of(re.sub("^[^/]+/", "", remote_branch))
+
+        remote_counterparts_of_local_branches = map_truthy_only(
+            self._git.get_combined_counterpart_for_fetching_of_branch,
+            self._git.get_local_branches())
+        qualifying_remote_branches: List[RemoteBranchShortName] = \
+            excluding(self._git.get_remote_branches(), remote_counterparts_of_local_branches)
+        return excluding(self._git.get_local_branches(), self.managed_branches) + [
+            strip_remote_name(branch) for branch in qualifying_remote_branches]
+
+    @property
+    def unmanaged_branches(self) -> List[LocalBranchShortName]:
+        return excluding(self._git.get_local_branches(), self.managed_branches)
+
+    @property
+    def childless_managed_branches(self) -> List[LocalBranchShortName]:
+        return [b for b in self._state.managed_branches if not self._state.get_children(b)]
+
+    @property
+    def branches_with_overridden_fork_point(self) -> List[LocalBranchShortName]:
+        return [branch for branch in self._git.get_local_branches() if self.has_any_fork_point_override_config(branch)]
+
+    @property
+    def slidable_branches(self) -> List[LocalBranchShortName]:
+        # All managed branches can be slid out, including root branches
+        return self.managed_branches
+
+    def get_slidable_after(self, branch: LocalBranchShortName) -> List[LocalBranchShortName]:
+        if self._state.has_parent(branch):
+            children = self.children_of(branch)
+            if children and len(children) == 1:
+                return children
+        return []

--- a/git_machete/client/list.py
+++ b/git_machete/client/list.py
@@ -7,8 +7,6 @@ from git_machete.utils.collections import excluding, map_truthy_only
 
 
 class ListMacheteClient(MacheteClient):
-
-    @property
     def addable_branches(self) -> List[LocalBranchShortName]:
         def strip_remote_name(remote_branch: RemoteBranchShortName) -> LocalBranchShortName:
             return LocalBranchShortName.of(re.sub("^[^/]+/", "", remote_branch))
@@ -21,19 +19,15 @@ class ListMacheteClient(MacheteClient):
         return excluding(self._git.get_local_branches(), self.managed_branches) + [
             strip_remote_name(branch) for branch in qualifying_remote_branches]
 
-    @property
     def unmanaged_branches(self) -> List[LocalBranchShortName]:
         return excluding(self._git.get_local_branches(), self.managed_branches)
 
-    @property
     def childless_managed_branches(self) -> List[LocalBranchShortName]:
         return [b for b in self._state.managed_branches if not self._state.get_children(b)]
 
-    @property
     def branches_with_overridden_fork_point(self) -> List[LocalBranchShortName]:
         return [branch for branch in self._git.get_local_branches() if self.has_any_fork_point_override_config(branch)]
 
-    @property
     def slidable_branches(self) -> List[LocalBranchShortName]:
         # All managed branches can be slid out, including root branches
         return self.managed_branches

--- a/git_machete/client/log.py
+++ b/git_machete/client/log.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from git_machete.client.base import MacheteClient
-from git_machete.git_operations import LocalBranchShortName
+from git_machete.git import LocalBranchShortName
 
 
 class LogMacheteClient(MacheteClient):

--- a/git_machete/client/reapply.py
+++ b/git_machete/client/reapply.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from git_machete.client.base import MacheteClient
-from git_machete.git_operations import AnyRevision
+from git_machete.git import AnyRevision
 
 
 class ReapplyMacheteClient(MacheteClient):

--- a/git_machete/client/rename.py
+++ b/git_machete/client/rename.py
@@ -1,6 +1,5 @@
 from git_machete.client.base import MacheteClient
-from git_machete.git_operations import (LocalBranchShortName,
-                                        RemoteBranchShortName)
+from git_machete.git import LocalBranchShortName, RemoteBranchShortName
 from git_machete.utils.exceptions import MacheteException
 from git_machete.utils.markup import print_fmt
 

--- a/git_machete/client/slide_out.py
+++ b/git_machete/client/slide_out.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 from git_machete.client.base import MacheteClient
 from git_machete.config import SquashMergeDetection
-from git_machete.git_operations import AnyRevision, LocalBranchShortName
+from git_machete.git import AnyRevision, LocalBranchShortName
 from git_machete.utils.exceptions import MacheteException
 from git_machete.utils.markup import green_ok, print_fmt
 

--- a/git_machete/client/squash.py
+++ b/git_machete/client/squash.py
@@ -2,9 +2,8 @@ import os
 from typing import List, Optional
 
 from git_machete.client.base import MacheteClient
-from git_machete.git_operations import (AnyRevision, FullCommitHash,
-                                        GitFormatPatterns, GitLogEntry,
-                                        LocalBranchShortName)
+from git_machete.git import (AnyRevision, FullCommitHash, GitFormatPatterns,
+                             GitLogEntry, LocalBranchShortName)
 from git_machete.utils.exceptions import MacheteException
 from git_machete.utils.markup import print_fmt
 

--- a/git_machete/client/state.py
+++ b/git_machete/client/state.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Optional
 
 from git_machete.annotation import Annotation
-from git_machete.git_operations import LocalBranchShortName
+from git_machete.git import LocalBranchShortName
 from git_machete.utils.collections import flat_map
 
 

--- a/git_machete/client/status.py
+++ b/git_machete/client/status.py
@@ -8,9 +8,8 @@ from typing import Dict, List, NamedTuple, Optional, Tuple
 
 from git_machete.annotation import Annotation
 from git_machete.config import SquashMergeDetection
-from git_machete.git_operations import (BranchPair, FullCommitHash,
-                                        GitLogEntry, LocalBranchShortName,
-                                        SyncToRemoteStatus)
+from git_machete.git import (BranchPair, FullCommitHash, GitLogEntry,
+                             LocalBranchShortName, SyncToRemoteStatus)
 from git_machete.utils._subproc import PopenResult
 from git_machete.utils.cmd import popen_cmd
 from git_machete.utils.debug_log import debug

--- a/git_machete/client/traverse.py
+++ b/git_machete/client/traverse.py
@@ -171,7 +171,7 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
 
         if opt_fetch:
             for rem in self._git.get_remotes():
-                if self.remote_enabled_for_traverse_fetch(rem):
+                if self._config.traverse_fetch_for_remote(rem):
                     print_fmt(f"Fetching <b>{rem}</b>...")
                     self._git.fetch_remote(rem)
             if self._git.get_remotes():

--- a/git_machete/client/traverse.py
+++ b/git_machete/client/traverse.py
@@ -9,8 +9,7 @@ from git_machete.client.with_code_hosting import MacheteClientWithCodeHosting
 from git_machete.code_hosting import CodeHostingSpec, PullRequest
 from git_machete.config import (SquashMergeDetection,
                                 TraverseWhenBranchNotCheckedOutInAnyWorktree)
-from git_machete.git_operations import (GitContext, LocalBranchShortName,
-                                        SyncToRemoteStatus)
+from git_machete.git import Git, LocalBranchShortName, SyncToRemoteStatus
 from git_machete.utils.exceptions import (MacheteException, ParsableEnum,
                                           UnexpectedMacheteException)
 from git_machete.utils.markup import green_ok, pretty_choices, print_fmt, warn
@@ -30,7 +29,7 @@ class TraverseStartFrom(ParsableEnum):
 
     @classmethod
     def from_string_or_branch(cls: Type['TraverseStartFrom'], value: str,
-                              git_context: GitContext) -> Union['TraverseStartFrom', LocalBranchShortName]:
+                              git_context: Git) -> Union['TraverseStartFrom', LocalBranchShortName]:
         """Parse value as enum (case-insensitive) or as branch name.
         If value matches both a special value and an existing branch name, the branch takes priority."""
         local_branches = git_context.get_local_branches()
@@ -50,7 +49,7 @@ class TraverseStartFrom(ParsableEnum):
 
 class TraverseMacheteClient(MacheteClientWithCodeHosting):
 
-    def __init__(self, git: GitContext, spec: CodeHostingSpec):
+    def __init__(self, git: Git, spec: CodeHostingSpec):
         super().__init__(git, spec)
         self.__temporary_worktree_path: Optional[str] = None
         self.__dir_before_temporary_worktree: Optional[str] = None

--- a/git_machete/client/update.py
+++ b/git_machete/client/update.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from git_machete.client.base import MacheteClient
-from git_machete.git_operations import AnyRevision, LocalBranchShortName
+from git_machete.git import AnyRevision, LocalBranchShortName
 from git_machete.utils.markup import pretty_choices
 
 

--- a/git_machete/client/with_code_hosting.py
+++ b/git_machete/client/with_code_hosting.py
@@ -4,7 +4,7 @@ from typing import Dict, Iterator, List, Optional, Set, Tuple
 
 from git_machete.annotation import Annotation, Qualifiers
 from git_machete.client.status import StatusMacheteClient
-from git_machete.code_hosting import (CodeHostingClient, CodeHostingSpec,
+from git_machete.code_hosting import (CodeHostingApi, CodeHostingSpec,
                                       OrganizationAndRepository,
                                       OrganizationAndRepositoryAndRemote,
                                       PullRequest, is_matching_remote_url)
@@ -28,7 +28,7 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
     def __init__(self, git: Git, spec: CodeHostingSpec):
         super().__init__(git)
         self.__code_hosting_spec: CodeHostingSpec = spec
-        self.__code_hosting_client: Optional[CodeHostingClient] = None
+        self.__code_hosting_client: Optional[CodeHostingApi] = None
         self.__all_open_prs: Optional[List[PullRequest]] = None
 
     @property
@@ -36,13 +36,13 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
         return self.__code_hosting_spec
 
     @property
-    def code_hosting_client(self) -> CodeHostingClient:
+    def code_hosting_client(self) -> CodeHostingApi:
         if self.__code_hosting_client is None:
             raise UnexpectedMacheteException("Code hosting client has not been initialized, this is an unexpected state.")
         return self.__code_hosting_client
 
     @code_hosting_client.setter
-    def code_hosting_client(self, value: CodeHostingClient) -> None:
+    def code_hosting_client(self, value: CodeHostingApi) -> None:
         self.__code_hosting_client = value
 
     def _get_all_open_prs(self) -> List[PullRequest]:

--- a/git_machete/client/with_code_hosting.py
+++ b/git_machete/client/with_code_hosting.py
@@ -9,10 +9,9 @@ from git_machete.code_hosting import (CodeHostingClient, CodeHostingSpec,
                                       OrganizationAndRepositoryAndRemote,
                                       PullRequest, is_matching_remote_url)
 from git_machete.config import PRDescriptionIntroStyle, SquashMergeDetection
-from git_machete.git_operations import (GitContext, GitFormatPatterns,
-                                        GitLogEntry, LocalBranchShortName,
-                                        RemoteBranchShortName,
-                                        SyncToRemoteStatus)
+from git_machete.git import (Git, GitFormatPatterns, GitLogEntry,
+                             LocalBranchShortName, RemoteBranchShortName,
+                             SyncToRemoteStatus)
 from git_machete.utils.collections import find_or_none, get_non_empty_lines
 from git_machete.utils.debug_log import debug
 from git_machete.utils.exceptions import (MacheteException,
@@ -26,7 +25,7 @@ from ..utils import date
 
 
 class MacheteClientWithCodeHosting(StatusMacheteClient):
-    def __init__(self, git: GitContext, spec: CodeHostingSpec):
+    def __init__(self, git: Git, spec: CodeHostingSpec):
         super().__init__(git)
         self.__code_hosting_spec: CodeHostingSpec = spec
         self.__code_hosting_client: Optional[CodeHostingClient] = None

--- a/git_machete/code_hosting.py
+++ b/git_machete/code_hosting.py
@@ -3,7 +3,7 @@ import ssl
 from abc import ABCMeta, abstractmethod
 from typing import Dict, List, NamedTuple, Optional
 
-from git_machete.git_operations import GitContext, LocalBranchShortName
+from git_machete.git import Git, LocalBranchShortName
 
 
 class PullRequest:
@@ -201,7 +201,7 @@ class CodeHostingClient(metaclass=ABCMeta):  # pragma: no cover
     @staticmethod
     def __create_ssl_context() -> ssl.SSLContext:
         ctx = ssl.create_default_context()
-        ssl_verify = GitContext().get_boolean_config_attr_or_none("http.sslVerify")
+        ssl_verify = Git().get_boolean_config_attr_or_none("http.sslVerify")
         if not ssl_verify:
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE

--- a/git_machete/code_hosting.py
+++ b/git_machete/code_hosting.py
@@ -184,13 +184,13 @@ class CodeHostingSpec(NamedTuple):
     def __str__(self) -> str:
         return f"CodeHostingSpec({self.display_name})"
 
-    def create_client(self, domain: str, organization: str, repository: str) -> "CodeHostingClient":
+    def create_client(self, domain: str, organization: str, repository: str) -> "CodeHostingApi":
         return self.client_class(domain=domain, organization=organization, repository=repository)  # type: ignore[no-any-return]
 
 
 # flake8: noqa U100
 # So that flake8 doesn't complain about unused params in abstract class.
-class CodeHostingClient(metaclass=ABCMeta):  # pragma: no cover
+class CodeHostingApi(metaclass=ABCMeta):  # pragma: no cover
     def __init__(self, domain: str, organization: str, repository: str) -> None:
         self.domain: str = domain
         self.organization: str = organization

--- a/git_machete/config.py
+++ b/git_machete/config.py
@@ -4,7 +4,7 @@ from enum import auto
 from typing import Optional
 
 from git_machete.code_hosting import CodeHostingGitConfigKeys
-from git_machete.git_operations import GitContext
+from git_machete.git import Git
 from git_machete.utils.exceptions import ParsableEnum
 
 
@@ -50,8 +50,8 @@ class MacheteConfig:
     _TRAVERSE_WHEN_BRANCH_NOT_CHECKED_OUT_IN_ANY_WORKTREE = 'machete.traverse.whenBranchNotCheckedOutInAnyWorktree'
     _WORKTREE_USE_TOP_LEVEL_MACHETE_FILE = 'machete.worktree.useTopLevelMacheteFile'
 
-    def __init__(self, git: GitContext) -> None:
-        self._git: GitContext = git
+    def __init__(self, git: Git) -> None:
+        self._git: Git = git
 
     def advice_machete_editor_selection(self) -> bool:
         return self._git.get_config_attr_or_none(self._ADVICE_MACHETE_EDITOR_SELECTION) != 'false'

--- a/git_machete/git.py
+++ b/git_machete/git.py
@@ -224,7 +224,7 @@ class GitFormatPatterns(Enum):
     MESSAGE_BODY = "%b"
 
 
-class GitContext:
+class Git:
 
     # === Initialization & cache management ===
 

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -15,7 +15,7 @@ from git_machete.code_hosting import (CodeHostingClient,
                                       OrganizationAndRepository,
                                       OrganizationAndRepositoryAndGitUrl,
                                       PullRequest)
-from git_machete.git_operations import LocalBranchShortName
+from git_machete.git import LocalBranchShortName
 from git_machete.utils.cmd import popen_cmd
 from git_machete.utils.debug_log import compact_dict, debug
 from git_machete.utils.exceptions import (MacheteException,

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -9,8 +9,7 @@ import urllib.request
 from pathlib import Path
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
-from git_machete.code_hosting import (CodeHostingClient,
-                                      CodeHostingGitConfigKeys,
+from git_machete.code_hosting import (CodeHostingApi, CodeHostingGitConfigKeys,
                                       CodeHostingSpec,
                                       OrganizationAndRepository,
                                       OrganizationAndRepositoryAndGitUrl,
@@ -67,7 +66,7 @@ class GitHubToken(NamedTuple):
                 if line.rstrip().endswith(" " + domain):
                     token = line.split(" ")[0]
                     return cls(value=token, provider=provider)
-                elif domain == GitHubClient.DEFAULT_GITHUB_DOMAIN and " " not in line.rstrip():
+                elif domain == GitHubApi.DEFAULT_GITHUB_DOMAIN and " " not in line.rstrip():
                     return cls(value=line.rstrip(), provider=provider)
         return None
 
@@ -151,7 +150,7 @@ class GitHubToken(NamedTuple):
         return None
 
 
-class GitHubClient(CodeHostingClient):
+class GitHubApi(CodeHostingApi):
     DEFAULT_GITHUB_DOMAIN = "github.com"
     # As of Dec 2022, GitHub API never returns more than 100 PRs, even if per_page query param is above 100.
     MAX_PULLS_PER_PAGE_COUNT = 100
@@ -239,7 +238,7 @@ class GitHubClient(CodeHostingClient):
                 # TODO (#164): make a dedicated exception here
                 raise MacheteException(
                     f'`{method} {url}` request ended up in 404 response from GitHub. A valid GitHub API token is required.\n'
-                    f'Provide a GitHub API token with `repo` access via one of the: {GITHUB_CLIENT_SPEC.token_providers_message} '
+                    f'Provide a GitHub API token with `repo` access via one of the: {GITHUB_API_SPEC.token_providers_message} '
                     f'Visit `https://{self.domain}/settings/tokens` to generate a new one.')
             # See https://stackoverflow.com/a/62385184 for why 307 for POST/PATCH isn't automatically followed by urllib,
             # unlike 307 for GET, or 301/302 for all HTTP methods.
@@ -429,10 +428,10 @@ class GitHubClient(CodeHostingClient):
         return f"pull/{pr_number}/head"
 
 
-GITHUB_CLIENT_SPEC = CodeHostingSpec(
+GITHUB_API_SPEC = CodeHostingSpec(
     base_branch_name='base',
-    client_class=GitHubClient,
-    default_domain=GitHubClient.DEFAULT_GITHUB_DOMAIN,
+    client_class=GitHubApi,
+    default_domain=GitHubApi.DEFAULT_GITHUB_DOMAIN,
     display_name='GitHub',
     git_machete_command='github',
     head_branch_name='head',

--- a/git_machete/gitlab.py
+++ b/git_machete/gitlab.py
@@ -9,8 +9,7 @@ import urllib.parse
 import urllib.request
 from typing import Any, Dict, List, NamedTuple, Optional
 
-from git_machete.code_hosting import (CodeHostingClient,
-                                      CodeHostingGitConfigKeys,
+from git_machete.code_hosting import (CodeHostingApi, CodeHostingGitConfigKeys,
                                       CodeHostingSpec,
                                       OrganizationAndRepository,
                                       OrganizationAndRepositoryAndGitUrl,
@@ -65,7 +64,7 @@ class GitLabToken(NamedTuple):
                 if line.rstrip().endswith(" " + domain):
                     token = line.split(" ")[0]
                     return cls(value=token, provider=provider)
-                elif domain == GitLabClient.DEFAULT_GITLAB_DOMAIN and " " not in line.rstrip():
+                elif domain == GitLabApi.DEFAULT_GITLAB_DOMAIN and " " not in line.rstrip():
                     return cls(value=line.rstrip(), provider=provider)
         return None
 
@@ -101,7 +100,7 @@ class GitLabToken(NamedTuple):
         return None
 
 
-class GitLabClient(CodeHostingClient):
+class GitLabApi(CodeHostingApi):
     DEFAULT_GITLAB_DOMAIN = "gitlab.com"
     MAX_PULLS_PER_PAGE_COUNT = 100
 
@@ -178,7 +177,7 @@ class GitLabClient(CodeHostingClient):
                 # TODO (#164): make a dedicated exception here
                 raise MacheteException(
                     f'`{method} {url}` request ended up in 404 response from GitLab. A valid GitLab API token is required.\n'
-                    f'Provide a GitLab API token with `api` access via one of the: {GITLAB_CLIENT_SPEC.token_providers_message} '
+                    f'Provide a GitLab API token with `api` access via one of the: {GITLAB_API_SPEC.token_providers_message} '
                     f'Visit `https://{self.domain}/-/user_settings/personal_access_tokens` to generate a new one.')
             elif err.code == http.HTTPStatus.METHOD_NOT_ALLOWED:
                 error_response = json.loads(err.read().decode())
@@ -336,10 +335,10 @@ class GitLabClient(CodeHostingClient):
         return f"merge-requests/{mr_number}/head"
 
 
-GITLAB_CLIENT_SPEC = CodeHostingSpec(
+GITLAB_API_SPEC = CodeHostingSpec(
     base_branch_name='target',
-    client_class=GitLabClient,
-    default_domain=GitLabClient.DEFAULT_GITLAB_DOMAIN,
+    client_class=GitLabApi,
+    default_domain=GitLabApi.DEFAULT_GITLAB_DOMAIN,
     display_name='GitLab',
     git_machete_command='gitlab',
     head_branch_name='source',

--- a/git_machete/gitlab.py
+++ b/git_machete/gitlab.py
@@ -15,7 +15,7 @@ from git_machete.code_hosting import (CodeHostingClient,
                                       OrganizationAndRepository,
                                       OrganizationAndRepositoryAndGitUrl,
                                       PullRequest)
-from git_machete.git_operations import LocalBranchShortName
+from git_machete.git import LocalBranchShortName
 from git_machete.utils.cmd import popen_cmd
 from git_machete.utils.collections import map_truthy_only
 from git_machete.utils.debug_log import compact_dict, debug

--- a/git_machete/options.py
+++ b/git_machete/options.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from .git_operations import AnyRevision, LocalBranchShortName
+from .git import AnyRevision, LocalBranchShortName
 
 
 class CommandLineOptions:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,6 @@
 from git_machete.annotation import Annotation
 from git_machete.client.base import MacheteClient
-from git_machete.git_operations import GitContext, LocalBranchShortName
+from git_machete.git import Git, LocalBranchShortName
 
 from .base_test import BaseTest
 from .cli_runner import read_branch_layout_file, rewrite_branch_layout_file
@@ -54,7 +54,7 @@ class TestClient(BaseTest):
             feature8 annotation rebase=no push=no rebase=no push=no
             """
         rewrite_branch_layout_file(body)
-        machete_client = MacheteClient(GitContext())
+        machete_client = MacheteClient(Git())
         machete_client.read_branch_layout_file(interactively_slide_out_invalid_branches=False)
 
         def anno(branch_name: str) -> Annotation:
@@ -121,7 +121,7 @@ class TestClient(BaseTest):
             # develop
               feature
             """)
-        machete_client = MacheteClient(GitContext())
+        machete_client = MacheteClient(Git())
         machete_client.read_branch_layout_file(interactively_slide_out_invalid_branches=False)
 
         assert machete_client.managed_branches == [
@@ -145,7 +145,7 @@ class TestClient(BaseTest):
             master
             feature  note #123
             """)
-        machete_client = MacheteClient(GitContext())
+        machete_client = MacheteClient(Git())
         machete_client.read_branch_layout_file(interactively_slide_out_invalid_branches=False)
 
         feature = LocalBranchShortName.of('feature')
@@ -170,7 +170,7 @@ class TestClient(BaseTest):
             master
             # feature
             """)
-        machete_client = MacheteClient(GitContext())
+        machete_client = MacheteClient(Git())
         machete_client.read_branch_layout_file(interactively_slide_out_invalid_branches=False)
         machete_client.save_branch_layout_file()
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,8 +1,7 @@
 import os
 
-from git_machete.git_operations import (AnyBranchName, AnyRevision,
-                                        FullCommitHash, GitContext,
-                                        LocalBranchShortName)
+from git_machete.git import (AnyBranchName, AnyRevision, FullCommitHash, Git,
+                             LocalBranchShortName)
 
 from .base_test import BaseTest
 from .git_repository import (add_worktree, check_out, commit, create_repo,
@@ -20,7 +19,7 @@ class TestGitOperations(BaseTest):
         commit("master first commit")
         master_branch_first_commit_hash = get_current_commit_hash()
 
-        git = GitContext()
+        git = Git()
         assert git._run_git("rev-parse", "--verify", "--quiet",
                             master_branch_first_commit_hash + "^{commit}", allow_non_zero=True, flush_caches=False) == 0  # noqa: FS003
         assert git._run_git("rev-parse", "HEAD", flush_caches=False) == 0
@@ -36,7 +35,7 @@ class TestGitOperations(BaseTest):
         new_branch("feature")
         commit("feature commit")
 
-        git = GitContext()
+        git = Git()
 
         def is_commit_present_in_repository(revision: AnyRevision) -> bool:
             return git._popen_git("rev-parse", "--verify", "--quiet",
@@ -58,7 +57,7 @@ class TestGitOperations(BaseTest):
         commit("feature commit")
         check_out("master")
 
-        git = GitContext()
+        git = Git()
         assert git._run_git("merge", "--squash", "feature", flush_caches=False) == 0
         assert git._run_git("commit", "-m", "squashed", flush_caches=False) == 0
 
@@ -78,7 +77,7 @@ class TestGitOperations(BaseTest):
         check_out("master")
         commit("extra commit")
 
-        git = GitContext()
+        git = Git()
         assert git._run_git("merge", "--squash", "feature", flush_caches=False) == 0
         assert git._run_git("commit", "-m", "squashed", flush_caches=False) == 0
 
@@ -105,7 +104,7 @@ class TestGitOperations(BaseTest):
         commit("feature commit")
         check_out("master")
 
-        git = GitContext()
+        git = Git()
         assert git._run_git("rebase", "feature", flush_caches=False) == 0
 
         feature = AnyRevision("feature")
@@ -133,7 +132,7 @@ class TestGitOperations(BaseTest):
         check_out("master")
         commit("extra commit")
 
-        git = GitContext()
+        git = Git()
         assert git._run_git("rebase", "feature", flush_caches=False) == 0
 
         feature = AnyRevision("feature")
@@ -160,7 +159,7 @@ class TestGitOperations(BaseTest):
         new_orphan_branch("feature")
         commit("feature commit")
 
-        git = GitContext()
+        git = Git()
         feature = AnyRevision("feature")
         master = AnyRevision("master")
 
@@ -170,7 +169,7 @@ class TestGitOperations(BaseTest):
     def test_git_config_with_newlines(self) -> None:
         create_repo()
         write_to_file(".git/config", '[foo]\n  bar = "hello\\nworld"')
-        git = GitContext()
+        git = Git()
         assert git.get_config_attr_or_none("foo.bar") == "hello\nworld"
 
     def test_get_reflog_when_log_showsignature_is_true(self) -> None:
@@ -183,7 +182,7 @@ class TestGitOperations(BaseTest):
         commit("extra commit")
         set_git_config_key("log.showSignature", "true")
 
-        git = GitContext()
+        git = Git()
 
         # If the bug reported in GitHub issue #1286 is not fixed, this method call
         # should raise an UnexpectedMacheteException.
@@ -194,7 +193,7 @@ class TestGitOperations(BaseTest):
         new_branch("feature@foo")
         commit("feature commit")
 
-        git = GitContext()
+        git = Git()
         # If the bug reported in GitHub issue #1481 is not fixed, this method call
         # should raise an UnexpectedMacheteException.
         git.get_reflog(AnyBranchName.of("feature@foo"))
@@ -214,7 +213,7 @@ class TestGitOperations(BaseTest):
         new_branch("feature-3")
         commit("feature-3 commit")
 
-        git = GitContext()
+        git = Git()
         main_worktree_path = git.get_current_worktree_root_dir()
 
         # Test 1: Main worktree on a branch, no linked worktrees
@@ -312,7 +311,7 @@ class TestGitOperations(BaseTest):
         commit("master second commit")
         master_hash2 = FullCommitHash.of(get_current_commit_hash())
 
-        git = GitContext()
+        git = Git()
         cache_path = os.path.join(git.get_main_worktree_git_dir(), "machete-merge-base-cache")
 
         # Test 1: Cache file doesn't exist - should work normally
@@ -330,7 +329,7 @@ class TestGitOperations(BaseTest):
         valid_hash2 = "b" * 40
         valid_merge_base = "c" * 40
         write_to_file(cache_path, f"{valid_hash1} {valid_hash2} {valid_merge_base}\n")
-        git = GitContext()  # New instance to test cache loading
+        git = Git()  # New instance to test cache loading
         # Access cache by calling get_merge_base (which triggers cache load)
         git.get_merge_base(master_hash, feature_hash)
         # Check that valid entry was loaded (even though these are fake hashes, they should be in cache)
@@ -347,7 +346,7 @@ class TestGitOperations(BaseTest):
         orphan_hash1 = "d" * 40
         orphan_hash2 = "e" * 40
         write_to_file(cache_path, f"{orphan_hash1} {orphan_hash2}\n")
-        git = GitContext()
+        git = Git()
         git.get_merge_base(master_hash, feature_hash)  # Trigger cache load
         assert git._merge_base_cached is not None
         # Normalize hash order
@@ -375,7 +374,7 @@ class TestGitOperations(BaseTest):
         valid_entry = f"{valid_hash1} {valid_hash2} {valid_merge_base}"
         cache_content_with_invalid = "\n".join(invalid_entries) + "\n" + valid_entry + "\n"
         write_to_file(cache_path, cache_content_with_invalid)
-        git = GitContext()
+        git = Git()
         git.get_merge_base(master_hash, feature_hash)  # Trigger cache load
         # Should still have the valid entry loaded
         assert git._merge_base_cached is not None
@@ -389,7 +388,7 @@ class TestGitOperations(BaseTest):
 
         # Test 5: Cache with empty lines and whitespace
         write_to_file(cache_path, f"\n  \n\t\n{valid_hash1} {valid_hash2} {valid_merge_base}\n\n")
-        git = GitContext()
+        git = Git()
         git.get_merge_base(master_hash, feature_hash)  # Trigger cache load
         assert git._merge_base_cached is not None
         # Normalize hash order
@@ -404,7 +403,7 @@ class TestGitOperations(BaseTest):
         hash_smaller = "a" * 40
         merge_base_normalized = "0" * 40
         write_to_file(cache_path, f"{hash_larger} {hash_smaller} {merge_base_normalized}\n")
-        git = GitContext()
+        git = Git()
         git.get_merge_base(master_hash, feature_hash)  # Trigger cache load
         assert git._merge_base_cached is not None
         # Should be normalized to (smaller, larger)
@@ -441,7 +440,7 @@ class TestGitOperations(BaseTest):
         # We'll test this by ensuring the cached value is returned
         # First, write a cache entry for real commits
         write_to_file(cache_path, f"{master_hash.full_name()} {feature_hash.full_name()} {merge_base1.full_name()}\n")
-        git2 = GitContext()
+        git2 = Git()
         # Load cache and get merge-base - should use cached value
         cached_merge_base = git2.get_merge_base(master_hash, feature_hash)
         # The result should match what we put in cache

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -34,7 +34,7 @@ FAKE_GH_ALWAYS_FAILS = 'import sys; sys.exit(1)'
 
 class TestGitHub(BaseTest):
 
-    def test_github_client_constructor(self) -> None:
+    def test_github_api_constructor(self) -> None:
         # This is solely to make mypy check if the class correctly implements abstract methods from CodeHostingApi.
         GitHubApi(domain="github.com", organization="my-org", repository="my-repo")
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -7,7 +7,7 @@ from typing import Iterator
 from pytest_mock import MockerFixture
 
 from git_machete.code_hosting import OrganizationAndRepository
-from git_machete.github import GitHubClient, GitHubToken
+from git_machete.github import GitHubApi, GitHubToken
 from tests.base_test import BaseTest
 from tests.cli_runner import (assert_failure, assert_success, launch_command,
                               rewrite_branch_layout_file)
@@ -35,8 +35,8 @@ FAKE_GH_ALWAYS_FAILS = 'import sys; sys.exit(1)'
 class TestGitHub(BaseTest):
 
     def test_github_client_constructor(self) -> None:
-        # This is solely to make mypy check if the class correctly implements abstract methods from CodeHostingClient.
-        GitHubClient(domain="github.com", organization="my-org", repository="my-repo")
+        # This is solely to make mypy check if the class correctly implements abstract methods from CodeHostingApi.
+        GitHubApi(domain="github.com", organization="my-org", repository="my-repo")
 
     def test_github_remote_patterns(self) -> None:
         organization = 'virtuslab'
@@ -48,7 +48,7 @@ class TestGitHub(BaseTest):
         urls = urls + [url + '.git' for url in urls]
 
         for url in urls:
-            org_and_repo = OrganizationAndRepository.from_url(domain=GitHubClient.DEFAULT_GITHUB_DOMAIN, url=url)
+            org_and_repo = OrganizationAndRepository.from_url(domain=GitHubApi.DEFAULT_GITHUB_DOMAIN, url=url)
             assert org_and_repo is not None, f"for {url}"
             assert org_and_repo.organization == organization
             assert org_and_repo.repository == repository
@@ -64,7 +64,7 @@ class TestGitHub(BaseTest):
 
     def test_github_api_pagination(self, mocker: MockerFixture) -> None:
         self.patch_symbol(mocker, 'builtins.input', mock_input_returning_y)
-        self.patch_symbol(mocker, 'git_machete.github.GitHubClient.MAX_PULLS_PER_PAGE_COUNT', 3)
+        self.patch_symbol(mocker, 'git_machete.github.GitHubApi.MAX_PULLS_PER_PAGE_COUNT', 3)
         self.patch_symbol(mocker, 'git_machete.github.GitHubToken.for_domain', mock_github_token_for_domain_none)
         self.patch_symbol(mocker, 'git_machete.code_hosting.OrganizationAndRepository.from_url', mock_from_url)
         self.patch_symbol(mocker, 'urllib.request.urlopen', mock_urlopen(self.github_api_state_for_test_github_api_pagination()))
@@ -248,7 +248,7 @@ class TestGitHub(BaseTest):
         with temporary_home_directory() as home, fake_executables_on_path(gh=FAKE_GH_ALWAYS_FAILS):
             write_to_file(os.path.join(home, '.github-token'), github_token_contents)
 
-            domain = GitHubClient.DEFAULT_GITHUB_DOMAIN
+            domain = GitHubApi.DEFAULT_GITHUB_DOMAIN
             github_token = GitHubToken.for_domain(domain=domain)
             assert github_token is not None
             assert github_token.provider == f'auth token for {domain} from `~/.github-token`'
@@ -364,7 +364,7 @@ class TestGitHub(BaseTest):
     # `__get_token_from_gh` (step 3) returning None so step 4 (hub) is reached;
     # FAKE_GH_ALWAYS_FAILS achieves that by failing the very first `gh --version` call.
 
-    HUB_DEFAULT_DOMAIN = GitHubClient.DEFAULT_GITHUB_DOMAIN
+    HUB_DEFAULT_DOMAIN = GitHubApi.DEFAULT_GITHUB_DOMAIN
     HUB_CUSTOM_DOMAIN = 'git.example.org'
     CONFIG_HUB_CONTENTS = textwrap.dedent(f'''\
         {HUB_DEFAULT_DOMAIN}:

--- a/tests/test_github_checkout_prs.py
+++ b/tests/test_github_checkout_prs.py
@@ -569,7 +569,7 @@ class TestGitHubCheckoutPRs(BaseTest):
         )
 
     def test_github_checkout_prs_remote_already_added(self, mocker: MockerFixture) -> None:
-        self.patch_symbol(mocker, 'git_machete.git_operations.GitContext.fetch_remote', lambda _self, _remote: None)
+        self.patch_symbol(mocker, 'git_machete.git.Git.fetch_remote', lambda _self, _remote: None)
         self.patch_symbol(mocker, "git_machete.github.GitHubToken.for_domain", mock_github_token_for_domain_fake)
         github_api_state = self.github_api_state_for_test_github_checkout_prs_single_pr()
         self.patch_symbol(mocker, 'urllib.request.urlopen', mock_urlopen(github_api_state))
@@ -591,7 +591,7 @@ class TestGitHubCheckoutPRs(BaseTest):
         )
 
     def test_github_checkout_prs_org_and_repo_from_config(self, mocker: MockerFixture) -> None:
-        self.patch_symbol(mocker, 'git_machete.git_operations.GitContext.fetch_remote', lambda _self, _remote: None)
+        self.patch_symbol(mocker, 'git_machete.git.Git.fetch_remote', lambda _self, _remote: None)
         self.patch_symbol(mocker, "git_machete.github.GitHubToken.for_domain", mock_github_token_for_domain_none)
         self.patch_symbol(mocker, 'urllib.request.urlopen', mock_urlopen(
             self.github_api_state_for_test_github_checkout_prs_single_pr()))
@@ -614,7 +614,7 @@ class TestGitHubCheckoutPRs(BaseTest):
         )
 
     def test_github_checkout_prs_remote_from_config(self, mocker: MockerFixture) -> None:
-        self.patch_symbol(mocker, 'git_machete.git_operations.GitContext.fetch_remote', lambda _self, _remote: None)
+        self.patch_symbol(mocker, 'git_machete.git.Git.fetch_remote', lambda _self, _remote: None)
         self.patch_symbol(mocker, "git_machete.github.GitHubToken.for_domain", mock_github_token_for_domain_none)
         self.patch_symbol(mocker, 'urllib.request.urlopen', mock_urlopen(
             self.github_api_state_for_test_github_checkout_prs_single_pr()))
@@ -643,7 +643,7 @@ class TestGitHubCheckoutPRs(BaseTest):
         ]
 
     def test_github_checkout_prs_main_to_main_pr(self, mocker: MockerFixture) -> None:
-        self.patch_symbol(mocker, 'git_machete.git_operations.GitContext.fetch_remote', lambda _self, _remote: None)
+        self.patch_symbol(mocker, 'git_machete.git.Git.fetch_remote', lambda _self, _remote: None)
         self.patch_symbol(mocker, 'git_machete.code_hosting.OrganizationAndRepository.from_url', mock_from_url)
         self.patch_symbol(mocker, 'git_machete.github.GitHubToken.for_domain', mock_github_token_for_domain_none)
 

--- a/tests/test_github_checkout_prs.py
+++ b/tests/test_github_checkout_prs.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 from pytest_mock import MockerFixture
 
 from git_machete.code_hosting import OrganizationAndRepository
-from git_machete.github import GitHubClient
+from git_machete.github import GitHubApi
 from tests.base_test import BaseTest
 from tests.cli_runner import (assert_failure, assert_success, launch_command,
                               rewrite_branch_layout_file)
@@ -245,7 +245,7 @@ class TestGitHubCheckoutPRs(BaseTest):
 
         # check against wrong PR number
         org_repo = OrganizationAndRepository.from_url(
-            domain=GitHubClient.DEFAULT_GITHUB_DOMAIN,
+            domain=GitHubApi.DEFAULT_GITHUB_DOMAIN,
             url=remote_path)
 
         assert org_repo is not None

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -34,7 +34,7 @@ FAKE_GLAB_ALWAYS_FAILS = 'import sys; sys.exit(1)'
 
 class TestGitLab(BaseTest):
 
-    def test_gitlab_client_constructor(self) -> None:
+    def test_gitlab_api_constructor(self) -> None:
         # This is solely to make mypy check if the class correctly implements abstract methods from CodeHostingApi.
         GitLabApi(domain="gitlab.com", organization="my-org", repository="my-repo")
 

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -7,7 +7,7 @@ from typing import Iterator
 from pytest_mock import MockerFixture
 
 from git_machete.code_hosting import OrganizationAndRepository
-from git_machete.gitlab import GitLabClient, GitLabToken
+from git_machete.gitlab import GitLabApi, GitLabToken
 from tests.base_test import BaseTest
 from tests.cli_runner import (assert_failure, assert_success, launch_command,
                               rewrite_branch_layout_file)
@@ -35,8 +35,8 @@ FAKE_GLAB_ALWAYS_FAILS = 'import sys; sys.exit(1)'
 class TestGitLab(BaseTest):
 
     def test_gitlab_client_constructor(self) -> None:
-        # This is solely to make mypy check if the class correctly implements abstract methods from CodeHostingClient.
-        GitLabClient(domain="gitlab.com", organization="my-org", repository="my-repo")
+        # This is solely to make mypy check if the class correctly implements abstract methods from CodeHostingApi.
+        GitLabApi(domain="gitlab.com", organization="my-org", repository="my-repo")
 
     def test_gitlab_remote_patterns(self) -> None:
         organization = 'virtuslab'
@@ -48,7 +48,7 @@ class TestGitLab(BaseTest):
         urls = urls + [url + '.git' for url in urls]
 
         for url in urls:
-            org_and_repo = OrganizationAndRepository.from_url(domain=GitLabClient.DEFAULT_GITLAB_DOMAIN, url=url)
+            org_and_repo = OrganizationAndRepository.from_url(domain=GitLabApi.DEFAULT_GITLAB_DOMAIN, url=url)
             assert org_and_repo is not None
             assert org_and_repo.organization == organization
             assert org_and_repo.repository == repository
@@ -64,7 +64,7 @@ class TestGitLab(BaseTest):
 
     def test_gitlab_api_pagination(self, mocker: MockerFixture) -> None:
         self.patch_symbol(mocker, 'builtins.input', mock_input_returning_y)
-        self.patch_symbol(mocker, 'git_machete.gitlab.GitLabClient.MAX_PULLS_PER_PAGE_COUNT', 3)
+        self.patch_symbol(mocker, 'git_machete.gitlab.GitLabApi.MAX_PULLS_PER_PAGE_COUNT', 3)
         self.patch_symbol(mocker, 'git_machete.gitlab.GitLabToken.for_domain', mock_gitlab_token_for_domain_none)
         self.patch_symbol(mocker, 'git_machete.code_hosting.OrganizationAndRepository.from_url', mock_from_url)
         self.patch_symbol(mocker, 'urllib.request.urlopen', mock_urlopen(self.gitlab_api_state_for_test_gitlab_api_pagination()))
@@ -249,7 +249,7 @@ class TestGitLab(BaseTest):
         with temporary_home_directory() as home, fake_executables_on_path(glab=FAKE_GLAB_ALWAYS_FAILS):
             write_to_file(os.path.join(home, '.gitlab-token'), gitlab_token_contents)
 
-            domain = GitLabClient.DEFAULT_GITLAB_DOMAIN
+            domain = GitLabApi.DEFAULT_GITLAB_DOMAIN
             gitlab_token = GitLabToken.for_domain(domain=domain)
             assert gitlab_token is not None
             assert gitlab_token.provider == f'auth token for {domain} from `~/.gitlab-token`'

--- a/tests/test_gitlab_checkout_mrs.py
+++ b/tests/test_gitlab_checkout_mrs.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 from pytest_mock import MockerFixture
 
 from git_machete.code_hosting import OrganizationAndRepository
-from git_machete.gitlab import GitLabClient
+from git_machete.gitlab import GitLabApi
 from tests.base_test import BaseTest
 from tests.cli_runner import (assert_failure, assert_success, launch_command,
                               rewrite_branch_layout_file)
@@ -248,7 +248,7 @@ class TestGitLabCheckoutMRs(BaseTest):
 
         # check against wrong MR number
         org_repo = OrganizationAndRepository.from_url(
-            domain=GitLabClient.DEFAULT_GITLAB_DOMAIN,
+            domain=GitLabApi.DEFAULT_GITLAB_DOMAIN,
             url=remote_path)
 
         assert org_repo is not None

--- a/tests/test_gitlab_checkout_mrs.py
+++ b/tests/test_gitlab_checkout_mrs.py
@@ -570,7 +570,7 @@ class TestGitLabCheckoutMRs(BaseTest):
         )
 
     def test_gitlab_checkout_mrs_remote_already_added(self, mocker: MockerFixture) -> None:
-        self.patch_symbol(mocker, 'git_machete.git_operations.GitContext.fetch_remote', lambda _self, _remote: None)
+        self.patch_symbol(mocker, 'git_machete.git.Git.fetch_remote', lambda _self, _remote: None)
         self.patch_symbol(mocker, 'git_machete.gitlab.GitLabToken.for_domain', mock_gitlab_token_for_domain_fake)
         gitlab_api_state = self.gitlab_api_state_for_test_gitlab_checkout_mrs_single_mr()
         self.patch_symbol(mocker, 'urllib.request.urlopen', mock_urlopen(gitlab_api_state))
@@ -583,7 +583,7 @@ class TestGitLabCheckoutMRs(BaseTest):
         )
 
     def test_gitlab_checkout_mrs_org_and_repo_from_config(self, mocker: MockerFixture) -> None:
-        self.patch_symbol(mocker, 'git_machete.git_operations.GitContext.fetch_remote', lambda _self, _remote: None)
+        self.patch_symbol(mocker, 'git_machete.git.Git.fetch_remote', lambda _self, _remote: None)
         self.patch_symbol(mocker, 'git_machete.gitlab.GitLabToken.for_domain', mock_gitlab_token_for_domain_fake)
         self.patch_symbol(mocker, 'urllib.request.urlopen', mock_urlopen(
             self.gitlab_api_state_for_test_gitlab_checkout_mrs_single_mr()))
@@ -607,7 +607,7 @@ class TestGitLabCheckoutMRs(BaseTest):
         )
 
     def test_gitlab_checkout_mrs_remote_from_config(self, mocker: MockerFixture) -> None:
-        self.patch_symbol(mocker, 'git_machete.git_operations.GitContext.fetch_remote', lambda _self, _remote: None)
+        self.patch_symbol(mocker, 'git_machete.git.Git.fetch_remote', lambda _self, _remote: None)
         self.patch_symbol(mocker, 'git_machete.gitlab.GitLabToken.for_domain', mock_gitlab_token_for_domain_fake)
         self.patch_symbol(mocker, 'urllib.request.urlopen', mock_urlopen(
             self.gitlab_api_state_for_test_gitlab_checkout_mrs_single_mr()))
@@ -637,7 +637,7 @@ class TestGitLabCheckoutMRs(BaseTest):
         ]
 
     def test_gitlab_checkout_mrs_main_to_main_mr(self, mocker: MockerFixture) -> None:
-        self.patch_symbol(mocker, 'git_machete.git_operations.GitContext.fetch_remote', lambda _self, _remote: None)
+        self.patch_symbol(mocker, 'git_machete.git.Git.fetch_remote', lambda _self, _remote: None)
         self.patch_symbol(mocker, 'git_machete.code_hosting.OrganizationAndRepository.from_url', mock_from_url)
         self.patch_symbol(mocker, 'git_machete.gitlab.GitLabToken.for_domain', mock_gitlab_token_for_domain_none)
 


### PR DESCRIPTION
## Summary

Five independent refactors stacked into one PR (each is its own commit, easy to review individually).

### 1. `git_operations` -> `git`, `GitContext` -> `Git` (`fae1379`)
Pure rename. `git_machete.git_operations` becomes `git_machete.git`, the central `GitContext` class becomes `Git`, and `tests/test_git_operations.py` becomes `tests/test_git.py`. The previous names predate the package-layout cleanup; the new ones are shorter, less verbose, and consistent with how callers already say `from git_machete.git import ...` after the recent `utils` refactor.

### 2. `CodeHostingClient` / `GitHubClient` / `GitLabClient` -> `*Api` (`81a129e`)
Pure rename. These classes implement the API surface for code-hosting platforms; the generic `Client` was overloaded and easy to confuse with `MacheteClient` (a completely different concept - the high-level machete-side controller). `GITHUB_CLIENT_SPEC` / `GITLAB_CLIENT_SPEC` become `GITHUB_API_SPEC` / `GITLAB_API_SPEC` for the same reason.

### 3. Reorder methods in `client/base.py` with section banners (`d7a5fc7`)
No functional change. `MacheteClient`'s 60+ methods are grouped by concern under `# === Section ===` banners (Initialization / Branch listing / Branch existence assertions / Branch layout file I/O / Branch navigation / Slide-out support / Fork-point computation / Fork-point overrides / Merge detection / Branch addition / Branch deletion / Rebase / Editor / Hooks / Sync-to-remote state handlers / Output formatting / User prompts / Cache management), mirroring the section-banner convention already used in `git_machete/git.py`. Method bodies are preserved byte-for-byte; only the order changes.

### 4. Extract `ListMacheteClient`; inline trivial traverse-fetch helper (`3773b8b`)
Six methods used solely by the `list` subcommand (`addable_branches`, `unmanaged_branches`, `childless_managed_branches`, `branches_with_overridden_fork_point`, `slidable_branches`, `get_slidable_after`) move from `MacheteClient` into a new `ListMacheteClient` in `git_machete/client/list.py`; `cli.py` instantiates it for `git machete list`. The trivial one-line wrapper `remote_enabled_for_traverse_fetch` is inlined into its sole caller in `traverse.py`.

### 5. Move single-client navigation/backup methods out of `base.py` (`7778ebb`)
- `back_up_branch_layout_file` (only used by `discover`) moves into `DiscoverMacheteClient`.
- The seven navigation primitives used solely by the `go-show` subcommand (`first_branch_for`, `last_branch_for`, `next_branch_for`, `prev_branch_for`, `first_root_branch`, `last_root_branch`, `get_or_pick_child_of`) move into `GoShowMacheteClient`.
- `MacheteClient.__raise_no_branches_error` is renamed to `_raise_no_branches_error` (single underscore) so subclasses can call it without name mangling.

Net effect: `client/base.py` shrinks from 1222 to ~1090 lines and is significantly easier to navigate.

## Test plan

- [x] `tox -e flake8-check,isort-check,mypy,vulture-check,cyclic-import-check` clean
- [x] `bash ci/checks/enforce-mocking-only-whitelisted-methods.sh` clean
- [x] `tox -e py` - 419 passed, 1 skipped (no regressions)
- [x] `python -m build --wheel --sdist` - includes new `git_machete/client/list.py`; no stale `git_operations.py`
- [x] CI on this PR