### PR TITLE
default to `--related` in `github`/`gitlab` `update-{pr,mr}-descriptions`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## New in git-machete 3.41.0
 
 - added: `git machete rename <new-name>` command to rename a branch both in git and in the branch layout file
+- changed: `git machete github update-pr-descriptions` and `git machete gitlab update-mr-descriptions` now default to `--related` when no flag (`--all`/`--by`/`--mine`/`--related`) is provided
 - changed: `git machete status -l` now lists, for green and yellow edges, all commits between the parent branch and the branch tip (rather than just between the fork point and the branch tip), with the fork point commit annotated `-> fork point`; red edges still list only the unique commits of the branch (`fork-point..branch`, exclusive)
 - fixed: spurious yellow edge no longer appears in `status` when the parent branch is merely behind its remote counterpart and the child branch was forked from the remote tip
 - fixed: minor glitches in shell completions

--- a/docs/man/git-machete.1
+++ b/docs/man/git-machete.1
@@ -1116,6 +1116,8 @@ delete untracked managed branches that have no downstream branch.
 Update the generated sections (\(dqintros\(dq) of PR descriptions that list the upstream and/or downstream PRs
 (depending on \fBmachete.github.prDescriptionIntroStyle\fP git config key).
 .sp
+When no flag is provided, \fB\-\-related\fP is assumed.
+.sp
 \fBOptions:\fP
 .INDENT 7.0
 .TP
@@ -1129,7 +1131,7 @@ Update PR descriptions for all PRs authored by the given GitHub user, where \fB<
 Update PR descriptions for all PRs opened by the current user associated with the GitHub token.
 .TP
 .B  \-\-related
-Update PR descriptions for all PRs both upstream and downstream of the PR for the current branch (the entire stack).
+Update PR descriptions for all PRs both upstream and downstream of the PR for the current branch (the entire stack). This is the default if no flag is given.
 .UNINDENT
 .UNINDENT
 .sp
@@ -1382,6 +1384,8 @@ See help for \fBgit machete gitlab update\-mr\-descriptions \-\-related\fP for d
 Update the generated sections (\(dqintros\(dq) of MR descriptions that list the upstream and/or downstream MRs
 (depending on \fBmachete.gitlab.mrDescriptionIntroStyle\fP git config key).
 .sp
+When no flag is provided, \fB\-\-related\fP is assumed.
+.sp
 \fBOptions:\fP
 .INDENT 7.0
 .TP
@@ -1395,7 +1399,7 @@ Update MR descriptions for all MRs authored by the given GitLab user, where \fB<
 Update MR descriptions for all MRs opened by the current user associated with the GitLab token.
 .TP
 .B  \-\-related
-Update MR descriptions for all MRs both upstream and downstream of the MR for the current branch (the entire stack).
+Update MR descriptions for all MRs both upstream and downstream of the MR for the current branch (the entire stack). This is the default if no flag is given.
 .UNINDENT
 .UNINDENT
 .sp

--- a/docs/source/cli/github.rst
+++ b/docs/source/cli/github.rst
@@ -151,6 +151,8 @@ Create, check out and manage GitHub PRs while keeping them reflected in branch l
     Update the generated sections ("intros") of PR descriptions that list the upstream and/or downstream PRs
     (depending on ``machete.github.prDescriptionIntroStyle`` git config key).
 
+    When no flag is provided, ``--related`` is assumed.
+
     **Options:**
 
     --all                Update PR descriptions for all PRs in the repository.
@@ -159,7 +161,7 @@ Create, check out and manage GitHub PRs while keeping them reflected in branch l
 
     --mine               Update PR descriptions for all PRs opened by the current user associated with the GitHub token.
 
-    --related            Update PR descriptions for all PRs both upstream and downstream of the PR for the current branch (the entire stack).
+    --related            Update PR descriptions for all PRs both upstream and downstream of the PR for the current branch (the entire stack). This is the default if no flag is given.
 
 **Git config keys:**
 

--- a/docs/source/cli/gitlab.rst
+++ b/docs/source/cli/gitlab.rst
@@ -142,6 +142,8 @@ Create, check out and manage GitLab MRs while keeping them reflected in branch l
     Update the generated sections ("intros") of MR descriptions that list the upstream and/or downstream MRs
     (depending on ``machete.gitlab.mrDescriptionIntroStyle`` git config key).
 
+    When no flag is provided, ``--related`` is assumed.
+
     **Options:**
 
     --all                Update MR descriptions for all MRs in the project.
@@ -150,7 +152,7 @@ Create, check out and manage GitLab MRs while keeping them reflected in branch l
 
     --mine               Update MR descriptions for all MRs opened by the current user associated with the GitLab token.
 
-    --related            Update MR descriptions for all MRs both upstream and downstream of the MR for the current branch (the entire stack).
+    --related            Update MR descriptions for all MRs both upstream and downstream of the MR for the current branch (the entire stack). This is the default if no flag is given.
 
 **Git config keys:**
 

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -942,12 +942,15 @@ def launch_internal(orig_args: List[str]) -> None:
                 github_or_gitlab_client.delete_unmanaged(opt_squash_merge_detection=SquashMergeDetection.NONE, opt_yes=False)
                 github_or_gitlab_client.delete_untracked(opt_yes=cli_opts.opt_yes)
             elif subcommand == f"update-{pr_or_mr}-descriptions":
-                if len(set(parsed_cli_as_dict.keys()).intersection({'all', 'by', 'mine', 'related'})) != 1:
+                selectors = set(parsed_cli_as_dict.keys()).intersection({'all', 'by', 'mine', 'related'})
+                if len(selectors) > 1:
                     raise MacheteException(
-                        f"`update-{pr_or_mr}-descriptions` subcommand must take exactly one of the following options: "
-                        '`--all`, `--by=...`, `--mine`, `--related`')
+                        f"`update-{pr_or_mr}-descriptions` subcommand takes at most one of the following options: "
+                        '`--all`, `--by=...`, `--mine`, `--related`; '
+                        '`--related` is assumed if none of these is provided.')
+                related = cli_opts.opt_related or not selectors
                 github_or_gitlab_client.update_pull_request_descriptions(
-                    all=cli_opts.opt_all, by=cli_opts.opt_by, mine=cli_opts.opt_mine, related=cli_opts.opt_related)
+                    all=cli_opts.opt_all, by=cli_opts.opt_by, mine=cli_opts.opt_mine, related=related)
             else:  # an unknown subcommand is handled by argparse
                 raise UnexpectedMacheteException(f"Unknown subcommand: `{subcommand}`")
         elif cmd in {"go", alias_by_command["go"]}:

--- a/git_machete/generated_docs.py
+++ b/git_machete/generated_docs.py
@@ -746,6 +746,8 @@ long_docs: Dict[str, str] = {
               Update the generated sections ("intros") of PR descriptions that list the upstream and/or downstream PRs
               (depending on `machete.github.prDescriptionIntroStyle` git config key).
 
+              When no flag is provided, `--related` is assumed.
+
               <b>Options:</b>
 
               --all                Update PR descriptions for all PRs in the repository.
@@ -754,7 +756,7 @@ long_docs: Dict[str, str] = {
 
               --mine               Update PR descriptions for all PRs opened by the current user associated with the GitHub token.
 
-              --related            Update PR descriptions for all PRs both upstream and downstream of the PR for the current branch (the entire stack).
+              --related            Update PR descriptions for all PRs both upstream and downstream of the PR for the current branch (the entire stack). This is the default if no flag is given.
 
         <b>Git config keys:</b>
 
@@ -934,6 +936,8 @@ long_docs: Dict[str, str] = {
               Update the generated sections ("intros") of MR descriptions that list the upstream and/or downstream MRs
               (depending on `machete.gitlab.mrDescriptionIntroStyle` git config key).
 
+              When no flag is provided, `--related` is assumed.
+
               <b>Options:</b>
 
               --all                Update MR descriptions for all MRs in the project.
@@ -942,7 +946,7 @@ long_docs: Dict[str, str] = {
 
               --mine               Update MR descriptions for all MRs opened by the current user associated with the GitLab token.
 
-              --related            Update MR descriptions for all MRs both upstream and downstream of the MR for the current branch (the entire stack).
+              --related            Update MR descriptions for all MRs both upstream and downstream of the MR for the current branch (the entire stack). This is the default if no flag is given.
 
         <b>Git config keys:</b>
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -447,7 +447,8 @@ class TestGitHub(BaseTest):
         assert_failure(["github", "checkout-prs", "--related"],
                        "--related option is only valid with update-pr-descriptions subcommand.")
         assert_failure(["github", "update-pr-descriptions", "--all", "--related"],
-                       "update-pr-descriptions subcommand must take exactly one "
-                       "of the following options: --all, --by=..., --mine, --related")
+                       "update-pr-descriptions subcommand takes at most one "
+                       "of the following options: --all, --by=..., --mine, --related; "
+                       "--related is assumed if none of these is provided.")
         assert_failure(["github", "update-pr-descriptions", "--update-related-descriptions"],
                        "--update-related-descriptions option is only valid with create-pr, restack-pr and retarget-pr subcommands.")

--- a/tests/test_github_update_pr_descriptions.py
+++ b/tests/test_github_update_pr_descriptions.py
@@ -89,6 +89,56 @@ class TestGitHubUpdatePRDescriptions(BaseTest):
             """
         )
 
+    def test_github_update_pr_descriptions_no_flag_defaults_to_related(self, mocker: MockerFixture) -> None:
+        """
+        With no `--all`/`--by`/`--mine`/`--related` flag, `update-pr-descriptions` defaults to `--related`:
+        only PRs in the stack of the current branch are touched, unrelated PRs are left alone.
+        """
+        self.patch_symbol(mocker, 'git_machete.code_hosting.OrganizationAndRepository.from_url', mock_from_url)
+        self.patch_symbol(mocker, 'git_machete.github.GitHubToken.for_domain', mock_github_token_for_domain_fake)
+        prs = [
+            mock_pr_json(head='branch1', base='root', number=1, body='# Summary\n'),
+            mock_pr_json(head='branch2', base='branch1', number=2, body='# Summary\n'),
+            mock_pr_json(head='unrelated', base='root', number=99, body='# Summary\n'),
+        ]
+        self.patch_symbol(mocker, 'urllib.request.urlopen', mock_urlopen(MockGitHubAPIState.with_prs(*prs)))
+        self.patch_symbol(mocker, 'git_machete.utils.date.get_current_date', lambda: '2023-12-31')
+
+        create_repo_with_remote()
+        new_branch("root")
+        commit("initial commit")
+        push()
+        new_branch("branch1")
+        commit("branch1 commit")
+        push()
+        new_branch("branch2")
+        commit("branch2 commit")
+        push()
+        check_out("root")
+        new_branch("unrelated")
+        commit("unrelated commit")
+        push()
+
+        rewrite_branch_layout_file("""
+            root
+              branch1
+                branch2
+              unrelated
+            """)
+        check_out('branch2')
+        # `full` style ensures every PR in the stack (incl. the topmost) has an intro
+        # to add, so all three of the related PRs surface a "has been updated" line.
+        set_git_config_key("machete.github.prDescriptionIntroStyle", "full")
+
+        assert_success(
+            ['github', 'update-pr-descriptions'],
+            """
+            Checking for open GitHub PRs... OK
+            Description of PR #1 (branch1 -> root) has been updated
+            Description of PR #2 (branch2 -> branch1) has been updated
+            """
+        )
+
     @staticmethod
     def prs_for_test_update_pr_descriptions() -> List[Dict[str, Any]]:
         return [

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -380,7 +380,8 @@ class TestGitLab(BaseTest):
         assert_failure(["gitlab", "checkout-mrs", "--related"],
                        "--related option is only valid with update-mr-descriptions subcommand.")
         assert_failure(["gitlab", "update-mr-descriptions", "--all", "--related"],
-                       "update-mr-descriptions subcommand must take exactly one "
-                       "of the following options: --all, --by=..., --mine, --related")
+                       "update-mr-descriptions subcommand takes at most one "
+                       "of the following options: --all, --by=..., --mine, --related; "
+                       "--related is assumed if none of these is provided.")
         assert_failure(["gitlab", "update-mr-descriptions", "--update-related-descriptions"],
                        "--update-related-descriptions option is only valid with create-mr, restack-mr and retarget-mr subcommands.")

--- a/tests/test_gitlab_update_mr_descriptions.py
+++ b/tests/test_gitlab_update_mr_descriptions.py
@@ -89,6 +89,56 @@ class TestGitLabUpdateMRDescriptions(BaseTest):
             """
         )
 
+    def test_gitlab_update_mr_descriptions_no_flag_defaults_to_related(self, mocker: MockerFixture) -> None:
+        """
+        With no `--all`/`--by`/`--mine`/`--related` flag, `update-mr-descriptions` defaults to `--related`:
+        only MRs in the stack of the current branch are touched, unrelated MRs are left alone.
+        """
+        self.patch_symbol(mocker, 'git_machete.code_hosting.OrganizationAndRepository.from_url', mock_from_url)
+        self.patch_symbol(mocker, 'git_machete.gitlab.GitLabToken.for_domain', mock_gitlab_token_for_domain_fake)
+        mrs = [
+            mock_mr_json(head='branch1', base='root', number=1, body='# Summary\n'),
+            mock_mr_json(head='branch2', base='branch1', number=2, body='# Summary\n'),
+            mock_mr_json(head='unrelated', base='root', number=99, body='# Summary\n'),
+        ]
+        self.patch_symbol(mocker, 'urllib.request.urlopen', mock_urlopen(MockGitLabAPIState.with_mrs(*mrs)))
+        self.patch_symbol(mocker, 'git_machete.utils.date.get_current_date', lambda: '2023-12-31')
+
+        create_repo_with_remote()
+        new_branch("root")
+        commit("initial commit")
+        push()
+        new_branch("branch1")
+        commit("branch1 commit")
+        push()
+        new_branch("branch2")
+        commit("branch2 commit")
+        push()
+        check_out("root")
+        new_branch("unrelated")
+        commit("unrelated commit")
+        push()
+
+        rewrite_branch_layout_file("""
+            root
+              branch1
+                branch2
+              unrelated
+            """)
+        check_out('branch2')
+        # `full` style ensures every MR in the stack (incl. the topmost) has an intro
+        # to add, so all three of the related MRs surface a "has been updated" line.
+        set_git_config_key("machete.gitlab.mrDescriptionIntroStyle", "full")
+
+        assert_success(
+            ['gitlab', 'update-mr-descriptions'],
+            """
+            Checking for open GitLab MRs... OK
+            Description of MR !1 (branch1 -> root) has been updated
+            Description of MR !2 (branch2 -> branch1) has been updated
+            """
+        )
+
     @staticmethod
     def mrs_for_test_update_mr_descriptions() -> List[Dict[str, Any]]:
         return [


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1667

## Chain of upstream PRs as of 2026-05-08

* PR #1670:
  `develop` ← `refactor/rename-git-and-code-hosting`

  * PR #1667:
    `refactor/rename-git-and-code-hosting` ← `fix/fork-point-unpulled-parent`

    * **PR #1671 (THIS ONE)**:
      `fix/fork-point-unpulled-parent` ← `feature/default-related-for-update-descriptions`

<!-- end git-machete generated -->

`git machete github update-pr-descriptions` and `git machete gitlab
update-mr-descriptions` previously required exactly one of `--all`,
`--by`, `--mine`, or `--related`; running without any selector printed
an error. Since `--related` is the most common usage, make it the
default when no selector is provided. Passing >1 selector still errors
out, but with an updated message that mentions the new default.

Add a sibling test for each platform asserting that running with no
flag from a stack-internal branch updates only the related PRs/MRs and
leaves unrelated ones alone (with `prDescriptionIntroStyle=full` so all
three related PRs/MRs surface a "has been updated" line).

Update help text in `generated_docs.py` and the rst docs, and add a
release-notes entry under 3.41.0.