### PR TITLE
fork-point: add `--explain` flag

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## New in git-machete 3.41.0
 
 - added: `git machete rename <new-name>` command to rename a branch both in git and in the branch layout file
+- added: `git machete fork-point --explain` flag explains which branches the fork point was inferred from
 - changed: `git machete github update-pr-descriptions` and `git machete gitlab update-mr-descriptions` now default to `--related` when no flag (`--all`/`--by`/`--mine`/`--related`) is provided
 - changed: `git machete status -l` now lists, for green and yellow edges, all commits between the parent branch and the branch tip (rather than just between the fork point and the branch tip), with the fork point commit annotated `-> fork point`; red edges still list only the unique commits of the branch (`fork-point..branch`, exclusive)
 - fixed: spurious yellow edge no longer appears in `status` when the parent branch is merely behind its remote counterpart and the child branch was forked from the remote tip

--- a/completion/git-machete.completion.bash
+++ b/completion/git-machete.completion.bash
@@ -66,7 +66,7 @@ _git_machete() {
   local delete_unmanaged_opts="-y --yes"
   local diff_opts="-s --stat"
   local discover_opts="-C --checked-out-since= -l --list-commits -r --roots= -y --yes"
-  local fork_point_opts="--inferred --override-to= --override-to-inferred --override-to-parent --unset-override"
+  local fork_point_opts="--explain --inferred --override-to= --override-to-inferred --override-to-parent --unset-override"
   local githublab_anno_opts="--with-urls"
   local githublab_create_opts="--draft --title= -U --update-related-descriptions -y --yes"
   local githublab_checkout_opts="--all --by= --mine"
@@ -114,7 +114,8 @@ _git_machete() {
         fork-point)
           local filtered_fork_point_opts
           filtered_fork_point_opts=$(_git_machete_filter_mutex_groups "$fork_point_opts" \
-            "--inferred --override-to= --override-to-inferred --override-to-parent --unset-override")
+            "--inferred --override-to= --override-to-inferred --override-to-parent --unset-override" \
+            "--explain --override-to= --override-to-inferred --override-to-parent --unset-override")
           __gitcomp "$common_opts $filtered_fork_point_opts"
           ;;
         github)

--- a/completion/git-machete.completion.zsh
+++ b/completion/git-machete.completion.zsh
@@ -67,11 +67,12 @@ _git-machete() {
           ;;
         (fork-point)
           _arguments '1:: :__git_machete_fork_point_branch_arg' \
+            '(--explain --override-to --override-to-inferred --override-to-parent --unset-override)'--explain'[Also list the branches the fork point was inferred from]' \
             '(--inferred --override-to --override-to-inferred --override-to-parent --unset-override)'--inferred'[Display the fork point ignoring any potential override]' \
-            '(--inferred --override-to --override-to-inferred --override-to-parent --unset-override)'--override-to='[Override fork point to the given revision]: :__git_references' \
-            '(--inferred --override-to --override-to-inferred --override-to-parent --unset-override)'--override-to-inferred'[Override fork point to the inferred location]' \
-            '(--inferred --override-to --override-to-inferred --override-to-parent --unset-override)'--override-to-parent'[Override fork point to the upstream (parent) branch]' \
-            '(--inferred --override-to --override-to-inferred --override-to-parent --unset-override)'--unset-override'[Unset fork point override by removing machete.overrideForkPoint.<branch>.* configs]' \
+            '(--explain --inferred --override-to --override-to-inferred --override-to-parent --unset-override)'--override-to='[Override fork point to the given revision]: :__git_references' \
+            '(--explain --inferred --override-to --override-to-inferred --override-to-parent --unset-override)'--override-to-inferred'[Override fork point to the inferred location]' \
+            '(--explain --inferred --override-to --override-to-inferred --override-to-parent --unset-override)'--override-to-parent'[Override fork point to the upstream (parent) branch]' \
+            '(--explain --inferred --override-to --override-to-inferred --override-to-parent --unset-override)'--unset-override'[Unset fork point override by removing machete.overrideForkPoint.<branch>.* configs]' \
             "${common_flags[@]}"
           ;;
         (g|go)

--- a/completion/git-machete.fish
+++ b/completion/git-machete.fish
@@ -88,14 +88,16 @@ complete -c git-machete -n "__fish_seen_subcommand_from fork-point; and not __fi
 complete -c git-machete -n "__fish_seen_subcommand_from fork-point; and __fish_seen_subcommand_from --unset-override"                                                                          -f                          -a '(__machete_with_overridden_fork_point_branches)'
 # form 1
 complete -c git-machete -n "__fish_seen_subcommand_from fork-point; and not __fish_seen_subcommand_from --inferred --unset-override --override-to --override-to-inferred --override-to-parent" -f -l inferred
+# --explain may be combined with --inferred but not with the override-* / --unset-override flags
+complete -c git-machete -n "__fish_seen_subcommand_from fork-point; and not __fish_seen_subcommand_from --explain --unset-override --override-to --override-to-inferred --override-to-parent" -f -l explain
 # form 2
-complete -c git-machete -n "__fish_seen_subcommand_from fork-point; and not __fish_seen_subcommand_from --inferred --unset-override               --override-to-inferred --override-to-parent" -x -l override-to           -a '(__fish_git_refs)'
-complete -c git-machete -n "__fish_seen_subcommand_from fork-point; and not __fish_seen_subcommand_from --inferred --unset-override --override-to --override-to-inferred --override-to-parent" -f -l override-to-inferred
-complete -c git-machete -n "__fish_seen_subcommand_from fork-point; and not __fish_seen_subcommand_from --inferred --unset-override --override-to --override-to-inferred --override-to-parent" -f -l override-to-parent
+complete -c git-machete -n "__fish_seen_subcommand_from fork-point; and not __fish_seen_subcommand_from --explain --inferred --unset-override               --override-to-inferred --override-to-parent" -x -l override-to           -a '(__fish_git_refs)'
+complete -c git-machete -n "__fish_seen_subcommand_from fork-point; and not __fish_seen_subcommand_from --explain --inferred --unset-override --override-to --override-to-inferred --override-to-parent" -f -l override-to-inferred
+complete -c git-machete -n "__fish_seen_subcommand_from fork-point; and not __fish_seen_subcommand_from --explain --inferred --unset-override --override-to --override-to-inferred --override-to-parent" -f -l override-to-parent
 # form 3
 # --unset-override is a boolean flag; the positional <branch> (handled above) is the
 # branch whose override gets unset, hence no -x and no value completer here.
-complete -c git-machete -n "__fish_seen_subcommand_from fork-point; and not __fish_seen_subcommand_from --inferred                  --override-to --override-to-inferred --override-to-parent" -f -l unset-override
+complete -c git-machete -n "__fish_seen_subcommand_from fork-point; and not __fish_seen_subcommand_from --explain --inferred                  --override-to --override-to-inferred --override-to-parent" -f -l unset-override
 
 # git machete github
 complete -c git-machete -n "not __fish_seen_subcommand_from $__machete_commands"                                                                                                           -f -a github                                               -d 'Create, check out and manage GitHub PRs while keeping them reflected in git machete'

--- a/docs/man/git-machete.1
+++ b/docs/man/git-machete.1
@@ -824,7 +824,7 @@ if \fBgit machete\fP is executed from a \fBsubmodule\fP, this file is located in
 .INDENT 3.5
 .sp
 .EX
-git machete fork\-point [\-\-inferred] [<branch>]
+git machete fork\-point [\-\-inferred] [\-\-explain] [<branch>]
 git machete fork\-point \-\-override\-to=<revision>|\-\-override\-to\-inferred|\-\-override\-to\-parent [<branch>]
 git machete fork\-point \-\-unset\-override [<branch>]
 .EE
@@ -873,6 +873,12 @@ With \fB\-\-inferred\fP, displays the commit that \fBgit machete fork\-point\fP 
 If there is \fBno\fP fork point override for \fB<branch>\fP, this is identical to the output of \fBgit machete fork\-point\fP\&.
 If there is a fork point override for \fB<branch>\fP, this is identical to the what the output of \fBgit machete fork\-point\fP would be if the override was \fBnot\fP present.
 Note: this piece of information is also displayed by \fBgit machete status \-\-list\-commits\fP in case a yellow edge occurs.
+.sp
+With \fB\-\-explain\fP, prints the fork point hash on stdout and, on stderr, an explanation of the form
+\fBthis commit seems to be a part of the unique history of <branch1> and <branch2>\fP \-\-\- mirroring the wording of the
+\fB\-> fork point ???\fP annotation that \fBgit machete status \-\-list\-commits\fP shows on a yellow edge.
+If a fork point override is active, the inference is short\-circuited and the stderr line falls back to \fBfork point of <branch> is overridden\fP\&.
+This flag may be combined with \fB\-\-inferred\fP but not with the \fB\-\-override\-to\fP/\fB\-\-override\-to\-inferred\fP/\fB\-\-override\-to\-parent\fP/\fB\-\-unset\-override\fP flags.
 .sp
 With \fB\-\-override\-to\-inferred\fP option, overrides fork point of \fB<branch>\fP to the result of \fBgit machete fork\-point \-\-inferred\fP for \fB<branch>\fP\&.
 Note: similarly to \fB\-\-override\-to=<revision>\fP, this option is \fBdeprecated\fP\&.

--- a/docs/source/cli/fork-point.rst
+++ b/docs/source/cli/fork-point.rst
@@ -15,7 +15,7 @@ fork-point
 
 .. code-block:: shell
 
-    git machete fork-point [--inferred] [<branch>]
+    git machete fork-point [--inferred] [--explain] [<branch>]
     git machete fork-point --override-to=<revision>|--override-to-inferred|--override-to-parent [<branch>]
     git machete fork-point --unset-override [<branch>]
 
@@ -58,6 +58,12 @@ With ``--inferred``, displays the commit that ``git machete fork-point`` infers 
 If there is **no** fork point override for ``<branch>``, this is identical to the output of ``git machete fork-point``.
 If there is a fork point override for ``<branch>``, this is identical to the what the output of ``git machete fork-point`` would be if the override was **not** present.
 Note: this piece of information is also displayed by ``git machete status --list-commits`` in case a :yellow:`yellow` edge occurs.
+
+With ``--explain``, prints the fork point hash on stdout and, on stderr, an explanation of the form
+``this commit seems to be a part of the unique history of <branch1> and <branch2>`` --- mirroring the wording of the
+``-> fork point ???`` annotation that ``git machete status --list-commits`` shows on a :yellow:`yellow` edge.
+If a fork point override is active, the inference is short-circuited and the stderr line falls back to ``fork point of <branch> is overridden``.
+This flag may be combined with ``--inferred`` but not with the ``--override-to``/``--override-to-inferred``/``--override-to-parent``/``--unset-override`` flags.
 
 With ``--override-to-inferred`` option, overrides fork point of ``<branch>`` to the result of ``git machete fork-point --inferred`` for ``<branch>``.
 Note: similarly to ``--override-to=<revision>``, this option is **deprecated**.

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -382,6 +382,7 @@ def create_cli_parser() -> argparse.ArgumentParser:
 
     fork_point_parser = create_subparser('fork-point')
     fork_point_parser.add_argument('branch', nargs='?')
+    fork_point_parser.add_argument('--explain', action='store_true')
     fork_point_exclusive_optional_args = fork_point_parser.add_mutually_exclusive_group()
     fork_point_exclusive_optional_args.add_argument('--inferred', action='store_true')
     fork_point_exclusive_optional_args.add_argument('--override-to')
@@ -555,6 +556,8 @@ def update_cli_options_using_parsed_args(
             cli_opts.opt_down_fork_point = AnyRevision.of(arg) if arg else None
         elif opt == "draft":
             cli_opts.opt_draft = True
+        elif opt == "explain":
+            cli_opts.opt_explain = True
         elif opt == "fetch":
             cli_opts.opt_fetch = True
         elif opt == "fork_point":
@@ -841,8 +844,15 @@ def launch_internal(orig_args: List[str]) -> None:
                 # It's unlikely that anyone overrides fork point for a branch that doesn't have a parent,
                 # also it's unclear what the suggested action should even be - let's skip this case.
 
+            if cli_opts.opt_override_to or cli_opts.opt_override_to_inferred or \
+                    cli_opts.opt_override_to_parent or cli_opts.opt_unset_override:
+                if cli_opts.opt_explain:
+                    raise MacheteException(
+                        "`--explain` cannot be combined with "
+                        "`--override-to`/`--override-to-inferred`/`--override-to-parent`/`--unset-override`.")
+
             if cli_opts.opt_inferred:
-                print(fork_point_client.fork_point(branch=branch, use_overrides=False))
+                fork_point_client.print_fork_point(branch=branch, use_overrides=False, explain=cli_opts.opt_explain)
             elif cli_opts.opt_override_to:
                 override_to = AnyRevision.of(cli_opts.opt_override_to)
                 fork_point_client.set_fork_point_override(branch, override_to)
@@ -867,7 +877,7 @@ def launch_internal(orig_args: List[str]) -> None:
             elif cli_opts.opt_unset_override:
                 fork_point_client.unset_fork_point_override(branch)
             else:
-                print(fork_point_client.fork_point(branch=branch, use_overrides=True))
+                fork_point_client.print_fork_point(branch=branch, use_overrides=True, explain=cli_opts.opt_explain)
         elif cmd in {"github", "gitlab"}:
             subcommand = parsed_cli.subcommand
             spec = GITHUB_API_SPEC if cmd == "github" else GITLAB_API_SPEC

--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -227,7 +227,7 @@ class MacheteClient:
 
     # === Fork-point computation ===
 
-    def fork_point_and_containing_branch_pairs(
+    def fork_point_and_inferring_branch_pairs(
         self,
         branch: LocalBranchShortName,
         *,
@@ -260,7 +260,7 @@ class MacheteClient:
                     return overridden_fork_point, []
 
         try:
-            computed_fork_point, containing_branch_pairs = next(self.__match_log_to_filtered_reflogs(branch))
+            computed_fork_point, inferring_branch_pairs = next(self.__match_log_to_filtered_reflogs(branch))
         except StopIteration:
             if parent and upstream_hash:
                 if self._git.is_ancestor_or_equal(parent.full_name(), branch.full_name()):
@@ -280,7 +280,7 @@ class MacheteClient:
         else:
             debug(f"commit {computed_fork_point} is the most recent point in history of {branch} to occur on "
                   "filtered reflog of any other branch or its remote counterpart "
-                  f"(specifically: {' and '.join(map(get_second, containing_branch_pairs))})")
+                  f"(specifically: {' and '.join(map(get_second, inferring_branch_pairs))})")
 
             if parent and upstream_hash and \
                     self._git.is_ancestor_or_equal(parent.full_name(), branch.full_name()) and \
@@ -309,8 +309,8 @@ class MacheteClient:
                 return common_ancestor_hash, []
             else:
                 improved_fork_point = computed_fork_point
-                improved_containing_branch_pairs = containing_branch_pairs
-                for candidate_branch, original_matched_branch in containing_branch_pairs:
+                improved_inferring_branch_pairs = inferring_branch_pairs
+                for candidate_branch, original_matched_branch in inferring_branch_pairs:
                     merge_base = self._git.get_merge_base(original_matched_branch, branch)
                     debug(f"improving fork point {improved_fork_point} "
                           f"by checking for merge_base({original_matched_branch}, {branch}) = {merge_base}")
@@ -318,12 +318,12 @@ class MacheteClient:
                         if self._git.is_ancestor(improved_fork_point, merge_base):
                             debug(f"improving fork point {improved_fork_point} to {merge_base}")
                             improved_fork_point = merge_base
-                            improved_containing_branch_pairs = [BranchPair(candidate_branch, original_matched_branch)]
+                            improved_inferring_branch_pairs = [BranchPair(candidate_branch, original_matched_branch)]
                 debug(f"effective fork point of {branch} is {improved_fork_point}")
-                return improved_fork_point, improved_containing_branch_pairs
+                return improved_fork_point, improved_inferring_branch_pairs
 
     def fork_point(self, branch: LocalBranchShortName, *, use_overrides: bool) -> FullCommitHash:
-        hash, containing_branch_pairs = self.fork_point_and_containing_branch_pairs(branch, use_overrides=use_overrides)
+        hash, inferring_branch_pairs = self.fork_point_and_inferring_branch_pairs(branch, use_overrides=use_overrides)
         return FullCommitHash.of(hash)
 
     def fork_point_or_none(self, branch: LocalBranchShortName, *, use_overrides: bool) -> Optional[FullCommitHash]:
@@ -433,10 +433,10 @@ class MacheteClient:
                 def lb_is_not_b(lb: str, _lb_or_rb: str) -> bool:
                     return lb != branch
 
-                containing_branch_pairs = sorted(filter(tupled(lb_is_not_b), branch_pairs), key=get_second)
-                if containing_branch_pairs:
+                inferring_branch_pairs = sorted(filter(tupled(lb_is_not_b), branch_pairs), key=get_second)
+                if inferring_branch_pairs:
                     debug(f"commit {hash} found in filtered reflog of {' and '.join(map(get_second, branch_pairs))}")
-                    yield hash, containing_branch_pairs
+                    yield hash, inferring_branch_pairs
                 else:
                     debug(f"commit {hash} found only in filtered reflog of {' and '.join(map(get_second, branch_pairs))}; ignoring")
             else:
@@ -448,10 +448,10 @@ class MacheteClient:
                         *,
                         reject_reason_message: str = ""
                         ) -> Optional[LocalBranchShortName]:
-        for hash, containing_branch_pairs in self.__match_log_to_filtered_reflogs(branch):
-            debug(f"commit {hash} found in filtered reflog of {' and '.join(map(get_second, containing_branch_pairs))}")
+        for hash, inferring_branch_pairs in self.__match_log_to_filtered_reflogs(branch):
+            debug(f"commit {hash} found in filtered reflog of {' and '.join(map(get_second, inferring_branch_pairs))}")
 
-            for candidate, original_matched_branch in containing_branch_pairs:
+            for candidate, original_matched_branch in inferring_branch_pairs:
                 if candidate != original_matched_branch:
                     debug(f"upstream candidate is {candidate}, which is the local counterpart of {original_matched_branch}")
 

--- a/git_machete/client/fork_point.py
+++ b/git_machete/client/fork_point.py
@@ -1,3 +1,5 @@
+import sys
+
 from git_machete.client.base import MacheteClient
 from git_machete.git import AnyRevision, LocalBranchShortName
 from git_machete.utils.exceptions import MacheteException
@@ -5,6 +7,21 @@ from git_machete.utils.markup import print_fmt
 
 
 class ForkPointMacheteClient(MacheteClient):
+    def print_fork_point(self, branch: LocalBranchShortName, *, use_overrides: bool, explain: bool) -> None:
+        if explain:
+            fork_point, pairs = self.fork_point_and_inferring_branch_pairs(branch=branch, use_overrides=use_overrides)
+            print(fork_point)
+            if pairs:
+                # Same wording as the `-> fork point ???` annotation rendered by `status -l` on yellow edges.
+                formatted = " and ".join(sorted(f"<b>{lb_or_rb}</b>" for _, lb_or_rb in pairs))
+                print_fmt(f"this commit seems to be a part of the unique history of {formatted}", file=sys.stderr)
+            else:
+                # Empty `pairs` is only reachable when an override short-circuits the inference;
+                # otherwise `fork_point_and_inferring_branch_pairs` would have raised `MacheteException`.
+                print_fmt(f"fork point of <b>{branch}</b> is overridden", file=sys.stderr)
+        else:
+            print(self.fork_point(branch=branch, use_overrides=use_overrides))
+
     def unset_fork_point_override(self, branch: LocalBranchShortName) -> None:
         self._config.unset_fork_point_override_to(branch)
         # We still unset the now-deprecated `whileDescendantOf` key.

--- a/git_machete/client/status.py
+++ b/git_machete/client/status.py
@@ -271,7 +271,7 @@ class StatusMacheteClient(MacheteClient):
             if for_branch not in fork_point_hash_cached:
                 try:
                     fork_point_hash_cached[for_branch], fork_point_branches_cached[for_branch] = \
-                        self.fork_point_and_containing_branch_pairs(for_branch, use_overrides=True)
+                        self.fork_point_and_inferring_branch_pairs(for_branch, use_overrides=True)
                 except MacheteException:
                     fork_point_hash_cached[for_branch], fork_point_branches_cached[for_branch] = None, []
             return fork_point_hash_cached[for_branch]
@@ -291,7 +291,7 @@ class StatusMacheteClient(MacheteClient):
                 sync_to_parent_status[branch] = SyncToParentStatus.IN_SYNC
             else:
                 fp = fork_point_hash(branch)
-                # `fork_point_hash` only returns None when `fork_point_and_containing_branch_pairs` raises
+                # `fork_point_hash` only returns None when `fork_point_and_inferring_branch_pairs` raises
                 # `MacheteException`, which in turn requires reflog inference to fail AND one of:
                 # parent is missing, parent commit is unresolvable, or parent is not an ancestor of branch
                 # with no common merge-base (unrelated histories). All of these are ruled out by reaching

--- a/git_machete/generated_docs.py
+++ b/git_machete/generated_docs.py
@@ -523,7 +523,7 @@ long_docs: Dict[str, str] = {
    """,
     "fork-point": """
         <b>Usage:</b><b>
-           git machete fork-point [--inferred] [<branch>]
+           git machete fork-point [--inferred] [--explain] [<branch>]
            git machete fork-point --override-to=<revision>|--override-to-inferred|--override-to-parent [<branch>]
            git machete fork-point --unset-override [<branch>]</b>
 
@@ -565,6 +565,12 @@ long_docs: Dict[str, str] = {
         If there is <b>no</b> fork point override for `<branch>`, this is identical to the output of `git machete fork-point`.
         If there is a fork point override for `<branch>`, this is identical to the what the output of `git machete fork-point` would be if the override was <b>not</b> present.
         Note: this piece of information is also displayed by `git machete status --list-commits` in case a <yellow>yellow</yellow> edge occurs.
+
+        With `--explain`, prints the fork point hash on stdout and, on stderr, an explanation of the form
+        `this commit seems to be a part of the unique history of <branch1> and <branch2>` — mirroring the wording of the
+        `-> fork point ???` annotation that `git machete status --list-commits` shows on a <yellow>yellow</yellow> edge.
+        If a fork point override is active, the inference is short-circuited and the stderr line falls back to `fork point of <branch> is overridden`.
+        This flag may be combined with `--inferred` but not with the `--override-to`/`--override-to-inferred`/`--override-to-parent`/`--unset-override` flags.
 
         With `--override-to-inferred` option, overrides fork point of `<branch>` to the result of `git machete fork-point --inferred` for `<branch>`.
         Note: similarly to `--override-to=<revision>`, this option is <b>deprecated</b>.

--- a/git_machete/options.py
+++ b/git_machete/options.py
@@ -16,6 +16,7 @@ class CommandLineOptions:
         self.opt_delete: bool = False
         self.opt_down_fork_point: Optional[AnyRevision] = None
         self.opt_draft: bool = False
+        self.opt_explain: bool = False
         self.opt_fetch: bool = False
         self.opt_fork_point: Optional[AnyRevision] = None
         self.opt_ignore_if_missing: bool = False

--- a/tests/completion_e2e/test_completion_e2e.py
+++ b/tests/completion_e2e/test_completion_e2e.py
@@ -75,22 +75,29 @@ test_cases: Dict[str, str] = {
     "git machete fork-point ":
         "develop feature master",
     "git machete fork-point -":
-        "--debug -h --help --inferred --override-to --override-to-inferred --override-to-parent --unset-override -v --verbose",
+        "--debug --explain -h --help --inferred --override-to "
+        "--override-to-inferred --override-to-parent --unset-override -v --verbose",
     "git machete fork-point --inferred ":
         "develop feature master",
     # Mutex: with --inferred on the cmdline,
     # `--override-to=`, `--override-to-parent`, `--override-to-inferred`,
     # `--unset-override` MUST NOT be suggested.
+    # `--explain` IS allowed alongside `--inferred`.
     "git machete fork-point --inferred -":
-        "--debug -h --help -v --verbose",
-    # Mutex: with --override-to-parent on the cmdline,
-    # `--inferred`, `--override-to=`, `--override-to-inferred`,
+        "--debug --explain -h --help -v --verbose",
+    # Mutex: with --explain on the cmdline,
+    # `--override-to=`, `--override-to-parent`, `--override-to-inferred`,
     # `--unset-override` MUST NOT be suggested.
+    "git machete fork-point --explain -":
+        "--debug -h --help --inferred -v --verbose",
+    # Mutex: with --override-to-parent on the cmdline,
+    # `--explain`, `--inferred`, `--override-to=`,
+    # `--override-to-inferred`, `--unset-override` MUST NOT be suggested.
     "git machete fork-point --override-to-parent -":
         "--debug -h --help -v --verbose",
     # Mutex: with --override-to-inferred on the cmdline,
-    # `--inferred`, `--override-to=`, `--override-to-parent`,
-    # `--unset-override` MUST NOT be suggested.
+    # `--explain`, `--inferred`, `--override-to=`,
+    # `--override-to-parent`, `--unset-override` MUST NOT be suggested.
     "git machete fork-point --override-to-inferred -":
         "--debug -h --help -v --verbose",
     "git machete fork-point --override-to=":

--- a/tests/test_fork_point.py
+++ b/tests/test_fork_point.py
@@ -46,6 +46,77 @@ class TestForkPoint(BaseTest):
 
         assert_success(["fork-point", 'refs/heads/develop'], "3ce566089cda4d3303309cf93883ab75f531c855\n")
 
+    def test_fork_point_explain(self) -> None:
+        with fixed_author_and_committer_date_in_past():
+            create_repo()
+            new_branch("master")
+            commit(message="master commit.")
+            new_branch("develop")
+            commit(message="develop commit.")
+            new_branch("feature")
+            commit('feature commit.')
+
+        rewrite_branch_layout_file("""
+            master
+            develop
+                feature
+            """)
+
+        # The fork point of `feature` is the tip of `develop`; `--explain`
+        # mirrors the `-> fork point ???` wording from `status -l` to spell
+        # out which branches the algorithm inferred the fork point from.
+        # The hash goes to stdout, the explanation to stderr (the test
+        # helper merges both streams in order).
+        assert_success(
+            ["fork-point", "feature", "--explain"],
+            "22a73eb0478439391949c6d544938a8aeee684c5\n"
+            "this commit seems to be a part of the unique history of develop\n"
+        )
+
+        # Fork point of `develop` is the tip of `master`.
+        assert_success(
+            ["fork-point", "develop", "--explain"],
+            "3ce566089cda4d3303309cf93883ab75f531c855\n"
+            "this commit seems to be a part of the unique history of master\n"
+        )
+
+        # `--inferred --explain` combination is allowed.
+        assert_success(
+            ["fork-point", "feature", "--inferred", "--explain"],
+            "22a73eb0478439391949c6d544938a8aeee684c5\n"
+            "this commit seems to be a part of the unique history of develop\n"
+        )
+
+        # When an override is active, `--explain` (without `--inferred`)
+        # surfaces the override rather than running the inference: the user
+        # gets a clear "this came from the override" signal instead of being
+        # silently shown reflog-derived branches that don't actually drive
+        # the answer.
+        launch_command("fork-point", "feature", "--override-to-parent")
+        assert_success(
+            ["fork-point", "feature", "--explain"],
+            "22a73eb0478439391949c6d544938a8aeee684c5\n"
+            "fork point of feature is overridden\n"
+        )
+
+        # `--inferred --explain` ignores the override and explains the
+        # inferred fork point regardless. Here the override happens to point
+        # at the same commit (parent's tip) that inference would land on, so
+        # the hash is unchanged - but the explanation now reports the
+        # branches the inference ran against, not the override.
+        assert_success(
+            ["fork-point", "feature", "--inferred", "--explain"],
+            "22a73eb0478439391949c6d544938a8aeee684c5\n"
+            "this commit seems to be a part of the unique history of develop\n"
+        )
+
+        # Combining with override-* / --unset-override is rejected.
+        assert_failure(
+            ["fork-point", "feature", "--override-to-parent", "--explain"],
+            "--explain cannot be combined with "
+            "--override-to/--override-to-inferred/--override-to-parent/--unset-override."
+        )
+
     def test_fork_point_override_for_invalid_branch(self) -> None:
         create_repo()
         new_branch("master")


### PR DESCRIPTION
Prints, alongside the fork point hash, the branches whose filtered reflog
the algorithm matched the commit against - the same set that
`status --list-commits` reports next to a `-> fork point ???` annotation
on a yellow edge.

When a fork point override is active the override short-circuits the
reflog scan, so the list is empty and `(none)` is printed.

The flag composes with `--inferred` but is mutually exclusive with the
override-* / --unset-override flags.