### PR TITLE
cli: enforce CLI options mutual exclusivity via argparse rather than at runtime

### DIFF
--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -353,8 +353,9 @@ def create_cli_parser() -> argparse.ArgumentParser:
     # possible values of 'annotation_text' include: [], [''], ['some_val'], ['text_1', 'text_2']
     anno_parser.add_argument('annotation_text', nargs='*')
     anno_parser.add_argument('-b', '--branch')
-    anno_parser.add_argument('-H', '--sync-github-prs', action='store_true')
-    anno_parser.add_argument('-L', '--sync-gitlab-mrs', action='store_true')
+    anno_sync_group = anno_parser.add_mutually_exclusive_group()
+    anno_sync_group.add_argument('-H', '--sync-github-prs', action='store_true')
+    anno_sync_group.add_argument('-L', '--sync-gitlab-mrs', action='store_true')
 
     clean_parser = create_subparser('clean')
     clean_parser.add_argument('-H', '--checkout-my-github-prs', action='store_true')
@@ -488,9 +489,10 @@ def create_cli_parser() -> argparse.ArgumentParser:
 
     traverse_parser = create_subparser('traverse', alias='t')
     traverse_parser.add_argument('-F', '--fetch', action='store_true')
-    traverse_parser.add_argument('-H', '--sync-github-prs', action='store_true')
+    traverse_sync_group = traverse_parser.add_mutually_exclusive_group()
+    traverse_sync_group.add_argument('-H', '--sync-github-prs', action='store_true')
+    traverse_sync_group.add_argument('-L', '--sync-gitlab-mrs', action='store_true')
     traverse_parser.add_argument('-l', '--list-commits', action='store_true')
-    traverse_parser.add_argument('-L', '--sync-gitlab-mrs', action='store_true')
     traverse_parser.add_argument('-M', '--merge', action='store_true')
     traverse_parser.add_argument('-n', action='store_true')
     traverse_parser.add_argument('--no-detect-squash-merges', action='store_true')
@@ -707,9 +709,6 @@ def launch_internal(orig_args: List[str]) -> None:
             raise MacheteException(
                 "Option `-f/--fork-point` only makes sense when using rebase and"
                 " cannot be specified together with `-M/--merge`.")
-        if cli_opts.opt_sync_github_prs and cli_opts.opt_sync_gitlab_mrs:
-            raise MacheteException(
-                "Option `-H/--sync-github-prs` cannot be specified together with `-L/--sync-gitlab-mrs`.")
 
         cmd = parsed_cli.command
         if not cmd:

--- a/tests/cli_runner.py
+++ b/tests/cli_runner.py
@@ -5,7 +5,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from typing import Iterable, Optional, Tuple, Type
 
 from git_machete import cli
-from git_machete.utils.exceptions import MacheteException
+from git_machete.utils.exceptions import ExitCode, MacheteException
 
 
 def launch_command_capturing_output_and_exception(*cmd_and_args: str) -> Tuple[Optional[str], Optional[BaseException]]:
@@ -64,6 +64,24 @@ def assert_failure(cmd_and_args: Iterable[str], expected_message: str, expected_
     if expected_output is not None:
         actual_output = strip_trailing_spaces(textwrap.dedent(output or ""))
         assert actual_output == expected_output
+
+
+def assert_argparse_failure(cmd_and_args: Iterable[str], expected_output: str) -> None:
+    """Run the CLI and assert it exits with `ARGUMENT_ERROR` after emitting
+    exactly `expected_output` (a literal multi-line string) on stdout/stderr.
+
+    `assert_failure` reads the failure text from `MacheteException.msg`, but
+    argparse failures bubble up as `SystemExit` (which carries only an exit
+    code) with the actual message written to stdout/stderr - hence this
+    dedicated helper for argparse-driven errors (mutex groups, invalid
+    choices, missing required, ...).
+    """
+    output, e = launch_command_capturing_output_and_exception(*cmd_and_args)
+    assert type(e) is SystemExit
+    assert e.code == ExitCode.ARGUMENT_ERROR
+    assert output is not None
+    expected = expected_output if expected_output.endswith("\n") else expected_output + "\n"
+    assert output == expected
 
 
 def read_branch_layout_file() -> str:

--- a/tests/test_anno.py
+++ b/tests/test_anno.py
@@ -2,8 +2,8 @@ from pytest_mock import MockerFixture
 
 from . import mockers_github, mockers_gitlab
 from .base_test import BaseTest
-from .cli_runner import (assert_failure, assert_success, launch_command,
-                         rewrite_branch_layout_file)
+from .cli_runner import (assert_argparse_failure, assert_success,
+                         launch_command, rewrite_branch_layout_file)
 from .git_repository import (add_remote, check_out, commit, create_repo,
                              create_repo_with_remote, new_branch)
 from .mockers_github import (MockGitHubAPIState,
@@ -160,9 +160,9 @@ class TestAnno(BaseTest):
         )
 
     def test_anno_sync_both_github_and_gitlab(self) -> None:
-        assert_failure(
+        assert_argparse_failure(
             ['anno', '--sync-github-prs', '--sync-gitlab-mrs'],
-            "Option -H/--sync-github-prs cannot be specified together with -L/--sync-gitlab-mrs."
+            "argument -L/--sync-gitlab-mrs: not allowed with argument -H/--sync-github-prs"
         )
 
     @staticmethod

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,5 @@
 import os
 from tempfile import mkdtemp
-from typing import List
 
 import pytest
 from pytest_mock import MockerFixture
@@ -9,25 +8,9 @@ from git_machete.cli import main
 from git_machete.utils.exceptions import ExitCode
 
 from .base_test import BaseTest
-from .cli_runner import launch_command_capturing_output_and_exception
+from .cli_runner import (assert_argparse_failure,
+                         launch_command_capturing_output_and_exception)
 from .git_repository import create_repo
-
-
-def assert_argparse_failure(cmd_and_args: List[str], expected_output: str) -> None:
-    """Run the CLI and assert it exits with `ARGUMENT_ERROR` after emitting
-    exactly `expected_output` (a literal multi-line string) on stdout/stderr.
-
-    The shared `assert_failure` helper from `tests.cli_runner` reads the failure
-    text from `MacheteException.msg`, but argparse failures bubble up as
-    `SystemExit` (which carries only an exit code) with the actual message
-    written to stdout/stderr - hence this dedicated helper for `test_cli`.
-    """
-    output, e = launch_command_capturing_output_and_exception(*cmd_and_args)
-    assert type(e) is SystemExit
-    assert e.code == ExitCode.ARGUMENT_ERROR
-    assert output is not None
-    expected = expected_output if expected_output.endswith("\n") else expected_output + "\n"
-    assert output == expected
 
 
 class TestCLI(BaseTest):

--- a/tests/test_traverse.py
+++ b/tests/test_traverse.py
@@ -9,7 +9,8 @@ from git_machete.utils.exceptions import UnderlyingGitException
 from git_machete.utils.terminal import FullTerminalAnsiOutputCodes
 
 from .base_test import BaseTest
-from .cli_runner import (assert_failure, assert_success, launch_command,
+from .cli_runner import (assert_argparse_failure, assert_failure,
+                         assert_success, launch_command,
                          rewrite_branch_layout_file)
 from .git_repository import (add_file_and_commit, add_remote, amend_commit,
                              check_out, commit, create_repo,
@@ -150,6 +151,15 @@ class TestTraverse(BaseTest):
 
             No successor of {E.BOLD}feature{E.ENDC_BOLD_DIM} needs to be slid out or synced with upstream branch or remote; nothing left to update
             """)
+        )
+
+    def test_traverse_sync_both_github_and_gitlab(self) -> None:
+        # `-H/--sync-github-prs` and `-L/--sync-gitlab-mrs` are pairwise
+        # mutually exclusive on `traverse` - enforced via an argparse
+        # mutex group, so the failure carries argparse's standard wording.
+        assert_argparse_failure(
+            ["traverse", "--sync-github-prs", "--sync-gitlab-mrs"],
+            "argument -L/--sync-gitlab-mrs: not allowed with argument -H/--sync-github-prs"
         )
 
     def test_traverse_no_remotes(self) -> None:


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1672

## Chain of upstream PRs as of 2026-05-13

* PR #1672:
  `develop` ← `feature/fork-point-list-branches`

  * **PR #1673 (THIS ONE)**:
    `feature/fork-point-list-branches` ← `refactor/argparse-mutex-groups`

<!-- end git-machete generated -->

The `-H/--sync-github-prs` and `-L/--sync-gitlab-mrs` constraint is the
only runtime mutex check in `cli.py` that fits cleanly into an argparse
`add_mutually_exclusive_group`: both flags live in just two parsers
(`anno`, `traverse`), they're pairwise exclusive with each other, and
neither participates in any other mutex relationship. Dropping the
global runtime check (which redundantly covered both parsers) in favour
of per-parser mutex groups gives us argparse-standard error wording at
parse time and trims a few lines of dispatch code.

The other runtime mutex checks in the file are NOT migrated:
- `add` (-R vs -o, -R vs -f), `fork-point` (--explain vs override-*),
  `update`/`slide-out` (-f vs -M, --no-int-rebase vs -M, etc.) -
  asymmetric: a single Action would need to be in two mutex groups,
  which argparse forbids without poking at private internals.
- `slide-out` rebase/merge cluster - partially expressible as a 3-way
  group `{-d, -M, --no-rebase}`, but the existing runtime messages
  carry useful "only makes sense when using rebase" diagnostic context
  that argparse's standard `argument X: not allowed with argument Y`
  wording would erase. Net negative for users.
- code-hosting `--all/--by/--mine/--related` constraints, per-subcommand
  flag-validity checks - subcommand is itself an argument, not a
  sub-subparser; argparse can't model these without a structural rewrite.

Also moves `assert_argparse_failure` from `tests/test_cli.py` to
`tests/cli_runner.py` so other test modules (here, `test_anno.py` and
`test_traverse.py`) can use it for argparse-driven `SystemExit`
failures instead of `assert_failure` which assumes a `MacheteException`.