### PR TITLE
Fix `NotADirectoryError: .git/machete` when auto-slide-out fires inside a worktree

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@
 - changed: `git machete github update-pr-descriptions` and `git machete gitlab update-mr-descriptions` now default to `--related` when no flag (`--all`/`--by`/`--mine`/`--related`) is provided
 - changed: `git machete status -l` now lists, for green and yellow edges, all commits between the parent branch and the branch tip (rather than just between the fork point and the branch tip), with the fork point commit annotated `-> fork point`; red edges still list only the unique commits of the branch (`fork-point..branch`, exclusive)
 - fixed: spurious yellow edge no longer appears in `status` when the parent branch is merely behind its remote counterpart and the child branch was forked from the remote tip
+- fixed: `git machete traverse` no longer crashes with `NotADirectoryError: '.git/machete'` when auto-slide-out fires inside a linked worktree (reported by @BertPluymersTR)
 - fixed: minor glitches in shell completions
 - fixed: parsing of `gh --version` output for custom/devel `gh` builds (e.g. `gh version 2.92.0-7-ga3efb25a`)
 - improved: CLI error messages now suggest close matches for typo'd subcommands, flags and choices

--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -40,6 +40,14 @@ class MacheteClient:
         git.owner = self
 
         self._branch_layout_file_path: str = self.__get_git_machete_branch_layout_file_path()
+        # Cwd-relative rendition of the layout path, captured at init time
+        # for use in user-facing messages (compact, points at the file as
+        # the user invoked us from). I/O always uses the absolute path so
+        # it survives any mid-run `chdir` (e.g. into a linked worktree).
+        try:
+            self._branch_layout_file_path_for_display: str = relpath_posix(self._branch_layout_file_path)
+        except Exception:  # pragma: no cover
+            self._branch_layout_file_path_for_display = self._branch_layout_file_path
         if not os.path.exists(self._branch_layout_file_path):
             # We're opening in "append" and not "write" mode to avoid a race condition:
             # if other process writes to the file between we check the
@@ -52,7 +60,7 @@ class MacheteClient:
             # Extremely unlikely case, basically checking if anybody
             # tampered with the repository.
             raise MacheteException(
-                f"{self._branch_layout_file_path} is a directory "
+                f"{self._branch_layout_file_path_for_display} is a directory "
                 "rather than a regular file, aborting")
 
         self.__init_state()
@@ -62,15 +70,13 @@ class MacheteClient:
             machete_file_directory = self._git.get_main_worktree_git_dir()
         else:
             machete_file_directory = self._git.get_current_worktree_git_dir()
-        abs_path = join_paths_posix(machete_file_directory, 'machete')
-        # Make the path relative to the current working directory, if possible.
-        # This is more convenient for display purposes, and shouldn't introduce any problems in traverse
-        # (since machete file path is only retrieved at the start, before any potential CWD changes)
-        try:
-            return relpath_posix(abs_path)
-        except Exception:  # pragma: no cover
-            # If for some reason relpath fails, fall back to absolute path.
-            return abs_path
+        # Keep the path absolute: `traverse` and other commands may `chdir` into
+        # linked worktrees mid-run, and a stored cwd-relative path would then
+        # resolve against the wrong directory - inside a linked worktree `.git`
+        # is a gitdir-pointer file, so `.git/machete` no longer points at the
+        # layout file. The underlying `get_SOMETHING_worktree_git_dir()` helpers already
+        # return absolute paths (via `git rev-parse` + `abspath_posix`).
+        return join_paths_posix(machete_file_directory, 'machete')
 
     def __init_state(self) -> None:
         self._state = MacheteState()
@@ -109,9 +115,9 @@ class MacheteClient:
     def _raise_no_branches_error(self) -> NoReturn:
         raise MacheteException(
             textwrap.dedent(f"""
-                No branches listed in {self._branch_layout_file_path}. Consider one of:
+                No branches listed in {self._branch_layout_file_path_for_display}. Consider one of:
                 * `git machete discover`
-                * `git machete edit` or edit {self._branch_layout_file_path} manually
+                * `git machete edit` or edit {self._branch_layout_file_path_for_display} manually
                 * `git machete github checkout-prs --mine`
                 * `git machete gitlab checkout-mrs --mine`"""[1:]))
 
@@ -122,7 +128,9 @@ class MacheteClient:
         return self._branch_layout_file_path
 
     def read_branch_layout_file(self, *, interactively_slide_out_invalid_branches: bool = False, verify_branches: bool = True) -> None:
-        self._state, self.__indent = branch_layout.parse(self._branch_layout_file_path)
+        self._state, self.__indent = branch_layout.parse(
+            self._branch_layout_file_path,
+            display_path=self._branch_layout_file_path_for_display)
 
         if not verify_branches:
             return
@@ -732,10 +740,10 @@ class MacheteClient:
         if not default_editor_with_args:
             raise MacheteException(
                 f"Cannot determine editor. Set `GIT_MACHETE_EDITOR` environment "
-                f"variable or edit {self._branch_layout_file_path} directly.")
+                f"variable or edit {self._branch_layout_file_path_for_display} directly.")
 
         command = default_editor_with_args[0]
-        args = default_editor_with_args[1:] + [self._branch_layout_file_path]
+        args = default_editor_with_args[1:] + [self._branch_layout_file_path_for_display]
         return run_cmd(command, *args)
 
     def __get_editor_with_args(self) -> List[str]:

--- a/git_machete/client/branch_layout.py
+++ b/git_machete/client/branch_layout.py
@@ -7,7 +7,7 @@ from git_machete.git import LocalBranchShortName
 from git_machete.utils.exceptions import MacheteException
 
 
-def parse(path: str) -> Tuple[MacheteState, Optional[str]]:
+def parse(path: str, *, display_path: Optional[str] = None) -> Tuple[MacheteState, Optional[str]]:
     """Parse the branch layout file at *path*.
 
     Returns a new `MacheteState` populated from the file together with
@@ -15,8 +15,12 @@ def parse(path: str) -> Tuple[MacheteState, Optional[str]]:
     line was found, e.g. a single-root flat layout).
 
     Raises `MacheteException` for structural errors (duplicate branch,
-    bad indent, excess depth).
+    bad indent, excess depth). The `display_path` argument, if provided,
+    is used in error messages in place of `path` - useful when `path` is
+    an absolute internal location and the caller wants a more compact
+    cwd-relative form shown to the user.
     """
+    msg_path: str = display_path if display_path is not None else path
     with open(path) as f:
         lines: List[str] = [line.rstrip() for line in f.readlines()]
 
@@ -51,7 +55,7 @@ def parse(path: str) -> Tuple[MacheteState, Optional[str]]:
 
         if state.is_managed(branch):
             raise MacheteException(
-                f"{path}, line {index + 1}: branch "
+                f"{msg_path}, line {index + 1}: branch "
                 f"<b>{branch}</b> re-appears in the branch layout. {hint}")
 
         if prefix:
@@ -62,7 +66,7 @@ def parse(path: str) -> Tuple[MacheteState, Optional[str]]:
                 prefix_expanded = "".join(mapping[c] for c in prefix)
                 indent_expanded = "".join(mapping[c] for c in indent)
                 raise MacheteException(
-                    f"{path}, line {index + 1}: "
+                    f"{msg_path}, line {index + 1}: "
                     f"invalid indent <b>{prefix_expanded}</b>, expected a multiply"
                     f" of <b>{indent_expanded}</b>. {hint}")
         else:
@@ -70,7 +74,7 @@ def parse(path: str) -> Tuple[MacheteState, Optional[str]]:
 
         if depth > last_depth + 1:
             raise MacheteException(
-                f"{path}, line {index + 1}: too much "
+                f"{msg_path}, line {index + 1}: too much "
                 f"indent (level {depth}, expected at most {last_depth + 1}) "
                 f"for the branch <b>{branch}</b>. {hint}")
         last_depth = depth

--- a/git_machete/client/discover.py
+++ b/git_machete/client/discover.py
@@ -146,10 +146,10 @@ class DiscoverMacheteClient(StatusMacheteClient):
         print("")
         do_backup = os.path.isfile(self._branch_layout_file_path) and slurp_file(self._branch_layout_file_path).strip()
         backup_msg = (
-            f"\nThe existing branch layout file will be backed up as {self._branch_layout_file_path}~"
+            f"\nThe existing branch layout file will be backed up as {self._branch_layout_file_path_for_display}~"
             if do_backup else "")
-        msg = f"Save the above tree to {self._branch_layout_file_path}?{backup_msg}" + pretty_choices('y', 'e[dit]', 'N')
-        opt_yes_msg = f"Saving the above tree to {self._branch_layout_file_path}...{backup_msg}"
+        msg = f"Save the above tree to {self._branch_layout_file_path_for_display}?{backup_msg}" + pretty_choices('y', 'e[dit]', 'N')
+        opt_yes_msg = f"Saving the above tree to {self._branch_layout_file_path_for_display}...{backup_msg}"
         ans = self.ask_if(msg, opt_yes_msg, opt_yes=opt_yes)
         if ans in ('y', 'yes'):
             if do_backup:

--- a/tests/test_traverse_worktrees.py
+++ b/tests/test_traverse_worktrees.py
@@ -780,3 +780,68 @@ class TestTraverseWorktrees(BaseTest):
               cd {normalized_feature_worktree}
             """
         )
+
+    # Regression test for https://github.com/VirtusLab/git-machete/issues/1681.
+    #
+    # When `traverse` auto-slides out a branch that's checked out in a
+    # linked worktree, it `os.chdir`s into that worktree first. Previously
+    # the layout file path was computed at client construction time as a
+    # cwd-relative path (e.g. `.git/machete`); inside a linked worktree
+    # `.git` is a gitdir-pointer file, so `save_branch_layout_file`'s
+    # subsequent `open(path, "w")` raised `NotADirectoryError`. The path is
+    # now stored as absolute, so it survives any mid-traverse `chdir`.
+    def test_traverse_auto_slide_out_in_worktree(self) -> None:
+        from .shell import execute
+
+        create_repo_with_remote()
+        new_branch("main")
+        commit("M1")
+        push()
+        # Create `a` as a plain branch ref at M1 (no checkout, so it doesn't
+        # diverge from `main`), then advance `main` to M2 and fast-forward
+        # `a` in its worktree to match. After this `a` is at M2 (== main),
+        # which makes traverse classify it as "merged into main" and
+        # auto-slide-out eligible.
+        execute("git branch a")
+        commit("M2")
+        push()
+
+        body: str = \
+            """
+            main
+                a
+            """
+        rewrite_branch_layout_file(body)
+
+        # Put `a` in a linked worktree so traverse `chdir`s into it on
+        # visit. Pre-fix, the subsequent layout-file save would have
+        # raised `NotADirectoryError` because the path was cached as
+        # `.git/machete` relative to the main-worktree cwd.
+        a_worktree = add_worktree("a")
+
+        initial_dir = os.getcwd()
+        os.chdir(a_worktree)
+        execute("git merge --ff-only main")
+        os.chdir(initial_dir)
+
+        normalized_a_worktree = abspath_posix(a_worktree)
+
+        assert_success(
+            ["traverse", "-y"],
+            f"""
+            Changing directory to {normalized_a_worktree} worktree where a is checked out
+
+              main
+              |
+              m-a * (untracked)
+
+            Branch a is merged into main. Sliding a out of the tree of branch dependencies...
+
+              main
+
+            No successor of a needs to be slid out or synced with upstream branch or remote; nothing left to update
+            Warn: branch a is checked out in worktree at {normalized_a_worktree}
+            You may want to change directory with:
+              cd {normalized_a_worktree}
+            """
+        )


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1678

## Chain of upstream PRs as of 2026-05-13

* PR #1678:
  `master` ← `develop`

  * **PR #1682 (THIS ONE)**:
    `develop` ← `fix/1681-relative-path-worktree`

<!-- end git-machete generated -->
