### PR TITLE
Introduce strict typing for paths

### DIFF
--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -43,7 +43,7 @@ from .utils.exceptions import (ExitCode, InteractionStopped, MacheteException,
                                UnexpectedMacheteException)
 from .utils.fs import does_directory_exist, get_current_directory_or_none
 from .utils.markup import green_ok, print_fmt, warn
-from .utils.paths import abspath_posix, join_paths_posix
+from .utils.paths import AbsPath, Path, abs_path, join_paths
 
 T = TypeVar('T')
 
@@ -684,7 +684,7 @@ def launch(orig_args: List[str]) -> None:
 
 
 def launch_internal(orig_args: List[str]) -> None:
-    initial_current_directory: Optional[str] = get_current_directory_or_none()
+    initial_current_directory: Optional[AbsPath] = get_current_directory_or_none()
 
     try:
         cli_opts = git_machete.options.CommandLineOptions()
@@ -818,7 +818,7 @@ def launch_internal(orig_args: List[str]) -> None:
         elif cmd == "file":
             # No need to read branch layout file.
             file_client = MacheteClient(git)
-            print(abspath_posix(file_client.branch_layout_file_path))
+            print(file_client.branch_layout_file_path)
         elif cmd == "fork-point":
             fork_point_client = ForkPointMacheteClient(git)
             fork_point_client.read_branch_layout_file()
@@ -1143,12 +1143,12 @@ def launch_internal(orig_args: List[str]) -> None:
         # has been fixed in git itself as of 2.35.0:
         # see https://github.com/git/git/blob/master/Documentation/RelNotes/2.35.0.txt#L81
         if initial_current_directory and not does_directory_exist(initial_current_directory):
-            nearest_existing_parent_directory = initial_current_directory
+            nearest_existing_parent_directory: Path = initial_current_directory
             while not does_directory_exist(nearest_existing_parent_directory):
-                nearest_existing_parent_directory = join_paths_posix(
+                nearest_existing_parent_directory = join_paths(
                     nearest_existing_parent_directory, os.path.pardir)
             warn(f"current directory {initial_current_directory} no longer exists, "
-                 f"the nearest existing parent directory is {abspath_posix(nearest_existing_parent_directory)}")
+                 f"the nearest existing parent directory is {abs_path(nearest_existing_parent_directory)}")
 
 
 def main() -> None:

--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -20,7 +20,7 @@ from git_machete.utils.debug_log import debug
 from git_machete.utils.exceptions import (InteractionStopped, MacheteException,
                                           UnexpectedMacheteException)
 from git_machete.utils.markup import input_fmt, pretty_choices, print_fmt, warn
-from git_machete.utils.paths import join_paths_posix, relpath_posix
+from git_machete.utils.paths import AbsPath, Path, rel_path
 
 from ..utils import fs
 
@@ -39,13 +39,13 @@ class MacheteClient:
         self._config: MacheteConfig = MacheteConfig(git)
         git.owner = self
 
-        self._branch_layout_file_path: str = self.__get_git_machete_branch_layout_file_path()
+        self._branch_layout_file_path: AbsPath = self.__get_git_machete_branch_layout_file_path()
         # Cwd-relative rendition of the layout path, captured at init time
         # for use in user-facing messages (compact, points at the file as
         # the user invoked us from). I/O always uses the absolute path so
         # it survives any mid-run `chdir` (e.g. into a linked worktree).
         try:
-            self._branch_layout_file_path_for_display: str = relpath_posix(self._branch_layout_file_path)
+            self._branch_layout_file_path_for_display: Path = rel_path(self._branch_layout_file_path)
         except Exception:  # pragma: no cover
             self._branch_layout_file_path_for_display = self._branch_layout_file_path
         if not os.path.exists(self._branch_layout_file_path):
@@ -65,7 +65,7 @@ class MacheteClient:
 
         self.__init_state()
 
-    def __get_git_machete_branch_layout_file_path(self) -> str:
+    def __get_git_machete_branch_layout_file_path(self) -> AbsPath:
         if self._config.worktree_use_top_level_machete_file():
             machete_file_directory = self._git.get_main_worktree_git_dir()
         else:
@@ -75,8 +75,8 @@ class MacheteClient:
         # resolve against the wrong directory - inside a linked worktree `.git`
         # is a gitdir-pointer file, so `.git/machete` no longer points at the
         # layout file. The underlying `get_SOMETHING_worktree_git_dir()` helpers already
-        # return absolute paths (via `git rev-parse` + `abspath_posix`).
-        return join_paths_posix(machete_file_directory, 'machete')
+        # return absolute paths (via `git rev-parse` + `abs_path`).
+        return machete_file_directory.join_fragments('machete')
 
     def __init_state(self) -> None:
         self._state = MacheteState()
@@ -124,7 +124,7 @@ class MacheteClient:
     # === Branch layout file I/O ===
 
     @property
-    def branch_layout_file_path(self) -> str:
+    def branch_layout_file_path(self) -> AbsPath:
         return self._branch_layout_file_path
 
     def read_branch_layout_file(self, *, interactively_slide_out_invalid_branches: bool = False, verify_branches: bool = True) -> None:
@@ -796,7 +796,7 @@ class MacheteClient:
 
     # === Hooks ===
 
-    def __run_hook(self, *args: str, cwd: str) -> int:
+    def __run_hook(self, *args: str, cwd: Path) -> int:
         self._git.flush_caches()
         if sys.platform == "win32":
             return run_cmd("sh", *args, cwd=cwd)

--- a/git_machete/client/branch_layout.py
+++ b/git_machete/client/branch_layout.py
@@ -5,9 +5,10 @@ from git_machete.annotation import Annotation
 from git_machete.client.state import MacheteState
 from git_machete.git import LocalBranchShortName
 from git_machete.utils.exceptions import MacheteException
+from git_machete.utils.paths import AbsPath, Path
 
 
-def parse(path: str, *, display_path: Optional[str] = None) -> Tuple[MacheteState, Optional[str]]:
+def parse(path: AbsPath, *, display_path: Optional[Path] = None) -> Tuple[MacheteState, Optional[str]]:
     """Parse the branch layout file at *path*.
 
     Returns a new `MacheteState` populated from the file together with
@@ -20,7 +21,7 @@ def parse(path: str, *, display_path: Optional[str] = None) -> Tuple[MacheteStat
     an absolute internal location and the caller wants a more compact
     cwd-relative form shown to the user.
     """
-    msg_path: str = display_path if display_path is not None else path
+    msg_path: Path = display_path if display_path is not None else path
     with open(path) as f:
         lines: List[str] = [line.rstrip() for line in f.readlines()]
 
@@ -102,7 +103,7 @@ def render(state: MacheteState, indent: str) -> List[str]:
     return lines
 
 
-def save(path: str, state: MacheteState, *, indent: str) -> None:
+def save(path: AbsPath, state: MacheteState, *, indent: str) -> None:
     """Write *state* to the branch layout file at *path*."""
     with open(path, "w") as f:
         f.write("\n".join(render(state, indent)) + "\n")

--- a/git_machete/client/status.py
+++ b/git_machete/client/status.py
@@ -15,6 +15,7 @@ from git_machete.utils.cmd import popen_cmd
 from git_machete.utils.debug_log import debug
 from git_machete.utils.exceptions import MacheteException
 from git_machete.utils.markup import escape_markup, print_fmt, warn
+from git_machete.utils.paths import Path
 
 from ..utils import markup
 from .base import MacheteClient
@@ -432,7 +433,7 @@ class StatusMacheteClient(MacheteClient):
                 warn(warning_msg)
 
     @staticmethod
-    def _popen_hook(*args: str, cwd: str, env: Dict[str, str]) -> PopenResult:
+    def _popen_hook(*args: str, cwd: Path, env: Dict[str, str]) -> PopenResult:
         if sys.platform == "win32":
             return popen_cmd("sh", *args, cwd=cwd, env=env)
         else:

--- a/git_machete/client/traverse.py
+++ b/git_machete/client/traverse.py
@@ -13,7 +13,7 @@ from git_machete.git import Git, LocalBranchShortName, SyncToRemoteStatus
 from git_machete.utils.exceptions import (MacheteException, ParsableEnum,
                                           UnexpectedMacheteException)
 from git_machete.utils.markup import green_ok, pretty_choices, print_fmt, warn
-from git_machete.utils.paths import abspath_posix
+from git_machete.utils.paths import AbsPath, abs_path
 
 
 class TraverseReturnTo(ParsableEnum):
@@ -51,9 +51,9 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
 
     def __init__(self, git: Git, spec: CodeHostingSpec):
         super().__init__(git, spec)
-        self.__temporary_worktree_path: Optional[str] = None
-        self.__dir_before_temporary_worktree: Optional[str] = None
-        self.__worktree_root_dir_for_branch: Dict[LocalBranchShortName, str] = {}
+        self.__temporary_worktree_path: Optional[AbsPath] = None
+        self.__dir_before_temporary_worktree: Optional[AbsPath] = None
+        self.__worktree_root_dir_for_branch: Dict[LocalBranchShortName, AbsPath] = {}
 
     def _update_worktrees_cache_after_checkout(self, checked_out_branch: LocalBranchShortName) -> None:
         """
@@ -111,7 +111,7 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
             config_value = self._config.traverse_when_branch_not_checked_out_in_any_worktree()
 
             if config_value == TraverseWhenBranchNotCheckedOutInAnyWorktree.CD_INTO_TEMPORARY_WORKTREE:
-                temp_worktree_path = tempfile.mkdtemp(prefix="git-machete-worktree-")
+                temp_worktree_path = abs_path(tempfile.mkdtemp(prefix="git-machete-worktree-"))
                 print_fmt(f"Creating a temporary worktree to check out <b>{target_branch}</b>... ",
                           newline=False)
                 self._git.worktree_add(temp_worktree_path, target_branch)
@@ -561,7 +561,7 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
             final_worktree_path = self.__worktree_root_dir_for_branch.get(final_branch)
             if final_worktree_path and initial_worktree_root != final_worktree_path:
                 # Final branch is checked out in a worktree different from where we started
-                normalized_path = abspath_posix(final_worktree_path)
+                normalized_path = abs_path(final_worktree_path)
                 warn(
                     f"branch <b>{final_branch}</b> is checked out in worktree at <b>{normalized_path}</b>\n"
                     f"You may want to change directory with:\n"

--- a/git_machete/client/with_code_hosting.py
+++ b/git_machete/client/with_code_hosting.py
@@ -19,7 +19,7 @@ from git_machete.utils.exceptions import (MacheteException,
 from git_machete.utils.fs import slurp_file
 from git_machete.utils.markup import (colored_yes_no, green_ok, pretty_choices,
                                       print_fmt, warn)
-from git_machete.utils.paths import join_paths_posix
+from git_machete.utils.paths import AbsPath, Path, join_paths
 
 from ..utils import date
 
@@ -351,12 +351,14 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
         if self._config.code_hosting_force_description_from_commit_message(spec.git_config_keys):
             description = self._git.get_commit_data(commits[0].hash, GitFormatPatterns.MESSAGE_BODY) if commits else ''
         else:
-            machete_description_path = self._git.get_main_worktree_git_subpath('info', 'description')
+            machete_description_path: AbsPath = self._git.get_main_worktree_git_subpath('info', 'description')
             if os.path.isfile(machete_description_path):
                 description = slurp_file(machete_description_path)
             else:
-                code_hosting_description_paths = [join_paths_posix(self._git.get_current_worktree_root_dir(), *path)
-                                                  for path in spec.pr_description_paths]
+                code_hosting_description_paths: List[Path] = [
+                    join_paths(self._git.get_current_worktree_root_dir(), *path)
+                    for path in spec.pr_description_paths
+                ]
                 existing = find_or_none(os.path.isfile, code_hosting_description_paths)
                 if existing:
                     description = slurp_file(existing)
@@ -388,7 +390,7 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
                 self.code_hosting_client.set_description_of_pull_request(pr.number, new_description)
                 print_fmt(green_ok())
 
-        milestone_path: str = self._git.get_main_worktree_git_subpath('info', 'milestone')
+        milestone_path: AbsPath = self._git.get_main_worktree_git_subpath('info', 'milestone')
         if os.path.isfile(milestone_path):
             milestone = slurp_file(milestone_path).strip()
         else:

--- a/git_machete/git.py
+++ b/git_machete/git.py
@@ -4,7 +4,7 @@ import re
 import string
 import sys
 from enum import Enum, auto
-from pathlib import Path
+from pathlib import Path as PyPath
 from typing import (Any, Dict, Iterator, List, Match, NamedTuple, Optional,
                     Set, Tuple)
 
@@ -17,7 +17,7 @@ from .utils.exceptions import (UnderlyingGitException,
                                UnexpectedMacheteException)
 from .utils.fs import is_executable, slurp_file
 from .utils.markup import escape_markup, print_fmt
-from .utils.paths import abspath_posix, join_paths_posix
+from .utils.paths import AbsPath, Path, abs_path, join_paths
 
 
 class AnyRevision(str):
@@ -232,10 +232,10 @@ class Git:
         self.owner: Optional[Any] = None
 
         self.__git_version: Optional[Tuple[int, int, int]] = None
-        self.__main_worktree_root_dir: Optional[str] = None
-        self.__main_worktree_git_dir: Optional[str] = None
-        self.__current_worktree_root_dir: Optional[str] = None
-        self.__current_worktree_git_dir: Optional[str] = None
+        self.__main_worktree_root_dir: Optional[AbsPath] = None
+        self.__main_worktree_git_dir: Optional[AbsPath] = None
+        self.__current_worktree_root_dir: Optional[AbsPath] = None
+        self.__current_worktree_git_dir: Optional[AbsPath] = None
 
         self.__commit_hash_by_revision_cached: Optional[Dict[AnyRevision, Optional[FullCommitHash]]] = None
         self.__committer_unix_timestamp_by_revision_cached: Optional[Dict[AnyRevision, int]] = None
@@ -270,7 +270,7 @@ class Git:
         self.__short_commit_hash_by_revision_cached = {}
         self.__flush_current_worktree_caches()
 
-    def chdir(self, path: str) -> None:
+    def chdir(self, path: Path) -> None:
         os.chdir(path)
         self.__flush_current_worktree_caches()
 
@@ -312,13 +312,17 @@ class Git:
         return self.__git_version
 
     # === Worktree & repository paths ===
+    #
+    # All path-returning helpers in this section return `AbsPath`: relative
+    # paths can lead to subtle bugs when CWD changes between worktrees
+    # mid-run (e.g. `traverse` chdir-ing into a linked worktree - the latent
+    # source of issue #1681 and similar). The conversion happens once here,
+    # in `__rev_parse_path`, via `abs_path`.
 
-    def __rev_parse_path(self, flag: str) -> str:
-        # Let's use absolute paths for main/git directories.
-        # Relative paths can lead to subtle bugs when CWD changes between worktrees in traverse.
-        return abspath_posix(self._popen_git("rev-parse", flag).stdout.strip())
+    def __rev_parse_path(self, flag: str) -> AbsPath:
+        return abs_path(self._popen_git("rev-parse", flag).stdout.strip())
 
-    def get_current_worktree_root_dir(self) -> str:
+    def get_current_worktree_root_dir(self) -> AbsPath:
         if not self.__current_worktree_root_dir:
             try:
                 self.__current_worktree_root_dir = self.__rev_parse_path("--show-toplevel")
@@ -326,7 +330,7 @@ class Git:
                 raise UnderlyingGitException("Not a git repository")
         return self.__current_worktree_root_dir
 
-    def get_current_worktree_git_dir(self) -> str:
+    def get_current_worktree_git_dir(self) -> AbsPath:
         if not self.__current_worktree_git_dir:
             try:
                 self.__current_worktree_git_dir = self.__rev_parse_path("--git-dir")
@@ -334,10 +338,10 @@ class Git:
                 raise UnderlyingGitException("Not a git repository")
         return self.__current_worktree_git_dir
 
-    def get_current_worktree_git_subpath(self, *fragments: str) -> str:
-        return join_paths_posix(self.get_current_worktree_git_dir(), *fragments)
+    def get_current_worktree_git_subpath(self, *fragments: str) -> AbsPath:
+        return self.get_current_worktree_git_dir().join_fragments(*fragments)
 
-    def get_main_worktree_root_dir(self) -> str:
+    def get_main_worktree_root_dir(self) -> AbsPath:
         """
         Returns the path to the main worktree (not a linked worktree).
         """
@@ -356,19 +360,19 @@ class Git:
                 # The first worktree in the list is always the main worktree
                 first_entry = result.stdout.splitlines()[0]
                 if first_entry.startswith('worktree '):
-                    self.__main_worktree_root_dir = first_entry[len('worktree '):]
+                    self.__main_worktree_root_dir = AbsPath.of(first_entry[len('worktree '):])
                 else:
                     raise UnexpectedMacheteException("Could not obtain the main worktree path from "
                                                      f"`git worktree list --porcelain` output (first line: `{first_entry}`)")
         return self.__main_worktree_root_dir
 
-    def get_main_worktree_git_dir(self) -> str:
+    def get_main_worktree_git_dir(self) -> AbsPath:
         if not self.__main_worktree_git_dir:
             try:
-                git_dir: str = self.__rev_parse_path("--git-dir")
-                git_dir_parts = Path(git_dir).parts
+                git_dir: AbsPath = self.__rev_parse_path("--git-dir")
+                git_dir_parts = PyPath(git_dir).parts
                 if len(git_dir_parts) >= 3 and git_dir_parts[-3] == '.git' and git_dir_parts[-2] == 'worktrees':
-                    self.__main_worktree_git_dir = join_paths_posix(*git_dir_parts[:-2])
+                    self.__main_worktree_git_dir = AbsPath.of(join_paths(*git_dir_parts[:-2]))
                     debug(f'git dir pointing to {git_dir} - we are in a worktree; '
                           f'using {self.__main_worktree_git_dir} as the effective git dir instead')
                 else:
@@ -377,11 +381,11 @@ class Git:
                 raise UnderlyingGitException("Not a git repository")
         return self.__main_worktree_git_dir
 
-    def get_main_worktree_git_subpath(self, *fragments: str) -> str:
+    def get_main_worktree_git_subpath(self, *fragments: str) -> AbsPath:
         # Let's use /-style paths even on Windows, for consistency with what git itself returns.
-        return join_paths_posix(self.get_main_worktree_git_dir(), *fragments)
+        return self.get_main_worktree_git_dir().join_fragments(*fragments)
 
-    def get_worktree_root_dirs_by_branch(self) -> Dict[LocalBranchShortName, str]:
+    def get_worktree_root_dirs_by_branch(self) -> Dict[LocalBranchShortName, AbsPath]:
         """
         Returns a dict mapping branch names to their worktree paths.
         The main worktree's current branch is included if it's on a branch.
@@ -393,15 +397,15 @@ class Git:
             return {}
 
         result = self._popen_git("worktree", "list", "--porcelain")
-        worktrees: Dict[LocalBranchShortName, str] = {}
+        worktrees: Dict[LocalBranchShortName, AbsPath] = {}
 
-        latest_worktree_path: Optional[str] = None
+        latest_worktree_path: Optional[AbsPath] = None
         latest_branch: Optional[LocalBranchShortName] = None
         is_detached: bool = False
 
         for line in result.stdout.strip().splitlines():
             if line.startswith('worktree '):
-                latest_worktree_path = line[len('worktree '):]
+                latest_worktree_path = AbsPath.of(line[len('worktree '):])
             elif line.startswith('branch '):
                 # Format: "branch refs/heads/<branch-name>"
                 branch_ref = line[len('branch '):]
@@ -425,10 +429,10 @@ class Git:
 
         return worktrees
 
-    def worktree_add(self, path: str, branch: 'LocalBranchShortName') -> None:
+    def worktree_add(self, path: Path, branch: 'LocalBranchShortName') -> None:
         self._run_git("worktree", "add", path, branch, flush_caches=False)
 
-    def worktree_remove(self, path: str) -> None:
+    def worktree_remove(self, path: Path) -> None:
         if self.get_git_version() >= (2, 17):
             self._run_git("worktree", "remove", "-f", path, flush_caches=False)
         else:
@@ -954,8 +958,8 @@ class Git:
 
     # === Merge-base & ancestry ===
 
-    def __get_merge_base_cache_path(self) -> str:
-        return os.path.join(self.get_main_worktree_git_dir(), "machete-merge-base-cache")
+    def __get_merge_base_cache_path(self) -> AbsPath:
+        return self.get_main_worktree_git_dir().join_fragments("machete-merge-base-cache")
 
     def __load_merge_base_cache(self) -> None:
         """Load merge-base cache from file. Called lazily on first use."""
@@ -1192,11 +1196,15 @@ class Git:
 
     # === Hooks ===
 
-    def get_hook_path(self, hook_name: str) -> str:
-        hook_dir: str = self.get_config_attr_or_none("core.hooksPath") or self.get_main_worktree_git_subpath("hooks")
-        return join_paths_posix(hook_dir, hook_name)
+    def get_hook_path(self, hook_name: str) -> Path:
+        # `core.hooksPath` may be unset, relative, or absolute - so the
+        # combined result is only ever known to be a `Path`, not `AbsPath`.
+        # `core.hooksPath` may be unset, relative, or absolute - the joined
+        # `hook_dir` is therefore only ever known to be a `Path`.
+        hook_dir: Path = Path(self.get_config_attr_or_none("core.hooksPath") or self.get_main_worktree_git_subpath("hooks"))
+        return join_paths(hook_dir, hook_name)
 
-    def check_hook_executable(self, hook_path: str) -> bool:
+    def check_hook_executable(self, hook_path: Path) -> bool:
         if not os.path.isfile(hook_path):
             return False
         elif not is_executable(hook_path):

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -6,7 +6,6 @@ import shutil
 import urllib.error
 # Deliberately NOT using much more convenient `requests` to avoid external dependencies in production code
 import urllib.request
-from pathlib import Path
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 from git_machete.code_hosting import (CodeHostingApi, CodeHostingGitConfigKeys,
@@ -20,7 +19,7 @@ from git_machete.utils.debug_log import compact_dict, debug
 from git_machete.utils.exceptions import (MacheteException,
                                           UnexpectedMacheteException)
 from git_machete.utils.markup import warn
-from git_machete.utils.paths import join_paths_posix
+from git_machete.utils.paths import AbsPath
 
 from .utils.fs import slurp_file
 
@@ -52,7 +51,7 @@ class GitHubToken(NamedTuple):
         debug("2. Trying to find token in `~/.github-token`...")
         required_file_name = '.github-token'
         provider = f'auth token for {domain} from `~/.github-token`'
-        file_full_path = os.path.expanduser(f'~/{required_file_name}')
+        file_full_path: AbsPath = AbsPath.home().join_fragments(required_file_name)
 
         if os.path.isfile(file_full_path):
             debug(f"  File `{file_full_path}` exists")
@@ -132,8 +131,7 @@ class GitHubToken(NamedTuple):
     @classmethod
     def __get_token_from_hub(cls, domain: str) -> Optional["GitHubToken"]:
         debug("4. Trying to find token via `hub` GitHub CLI...")
-        home_path: str = str(Path.home())
-        config_hub_path: str = join_paths_posix(home_path, ".config", "hub")
+        config_hub_path: AbsPath = AbsPath.home().join_fragments(".config", "hub")
         if os.path.isfile(config_hub_path):
             # ~/.config/hub is a yaml file, with a structure similar to:
             #

--- a/git_machete/gitlab.py
+++ b/git_machete/gitlab.py
@@ -22,6 +22,7 @@ from git_machete.utils.exceptions import (MacheteException,
                                           UnexpectedMacheteException)
 
 from .utils.fs import slurp_file
+from .utils.paths import AbsPath
 
 GITLAB_TOKEN_ENV_VAR = 'GITLAB_TOKEN'
 
@@ -50,7 +51,7 @@ class GitLabToken(NamedTuple):
         debug("2. Trying to find token in `~/.gitlab-token`...")
         required_file_name = '.gitlab-token'
         provider = f'auth token for {domain} from `~/.gitlab-token`'
-        file_full_path = os.path.expanduser(f'~/{required_file_name}')
+        file_full_path: AbsPath = AbsPath.home().join_fragments(required_file_name)
 
         if os.path.isfile(file_full_path):
             debug(f"  File `{file_full_path}` exists")

--- a/git_machete/utils/_subproc.py
+++ b/git_machete/utils/_subproc.py
@@ -17,6 +17,11 @@ class PopenResult(NamedTuple):
     stderr: str
 
 
+# `cwd` is typed as plain `str` here (not `Path`) to keep this lowest-level
+# module free of internal dependencies - `utils.paths` transitively pulls in
+# `utils.markup`/`utils.terminal`, which in turn re-imports from this module,
+# creating a circular import. The outer wrappers in `utils.cmd` enforce the
+# `Path` discipline.
 def _run_cmd(cmd: str, *args: str, cwd: Optional[str] = None, env: Optional[Dict[str, str]] = None) -> int:
     return subprocess.run([cmd] + list(args), stdout=None, stderr=None, cwd=cwd, env=env).returncode
 

--- a/git_machete/utils/cmd.py
+++ b/git_machete/utils/cmd.py
@@ -23,6 +23,7 @@ from ._subproc import PopenResult, _popen_cmd
 from .debug_log import debug
 from .fs import get_current_directory_or_none
 from .markup import escape_markup, print_fmt
+from .paths import AbsPath, Path
 
 # === Mutable runtime flags ===
 #
@@ -35,7 +36,7 @@ measure_command_time: bool = os.environ.get('GIT_MACHETE_MEASURE_COMMAND_TIME') 
 verbose_mode: bool = False
 
 
-def run_cmd(cmd: str, *args: str, cwd: Optional[str] = None, env: Optional[Dict[str, str]] = None) -> int:
+def run_cmd(cmd: str, *args: str, cwd: Optional[Path] = None, env: Optional[Dict[str, str]] = None) -> int:
     chdir_upwards_until_current_directory_exists()
 
     flat_cmd: str = get_cmd_shell_repr(cmd, *args, env=env)
@@ -79,7 +80,7 @@ def mark_current_directory_as_possibly_non_existent() -> None:
 def chdir_upwards_until_current_directory_exists() -> None:
     global current_directory_confirmed_to_exist
     if not current_directory_confirmed_to_exist:
-        current_directory: Optional[str] = get_current_directory_or_none()
+        current_directory: Optional[AbsPath] = get_current_directory_or_none()
         if not current_directory:
             while not current_directory:
                 # Note: 'os.chdir' only affects the current process and its subprocesses;
@@ -90,7 +91,7 @@ def chdir_upwards_until_current_directory_exists() -> None:
         current_directory_confirmed_to_exist = True
 
 
-def popen_cmd(cmd: str, *args: str, cwd: Optional[str] = None,
+def popen_cmd(cmd: str, *args: str, cwd: Optional[Path] = None,
               env: Optional[Dict[str, str]] = None, hide_debug_output: bool = False, input: Optional[str] = None) -> PopenResult:
     chdir_upwards_until_current_directory_exists()
 

--- a/git_machete/utils/fs.py
+++ b/git_machete/utils/fs.py
@@ -10,9 +10,10 @@ import sys
 from typing import Optional
 
 from .debug_log import debug
+from .paths import AbsPath, Path, abs_path, join_paths
 
 
-def does_directory_exist(path: str) -> bool:
+def does_directory_exist(path: Path) -> bool:
     try:
         # Note that os.path.isdir itself (without os.path.abspath) isn't reliable
         # since it returns a false positive (True) for the current directory when it doesn't exist
@@ -21,37 +22,37 @@ def does_directory_exist(path: str) -> bool:
         return False
 
 
-def get_current_directory_or_none() -> Optional[str]:
+def get_current_directory_or_none() -> Optional[AbsPath]:
     try:
-        return os.getcwd()
+        return AbsPath.of(os.getcwd())
     except OSError:
         # This happens when current directory does not exist (typically: has been deleted)
         return None
 
 
-def is_executable(path: str) -> bool:
+def is_executable(path: Path) -> bool:
     return os.access(path, os.X_OK)
 
 
-def find_executable(executable: str) -> Optional[str]:
+def find_executable(executable: str) -> Optional[AbsPath]:
     base, ext = os.path.splitext(executable)
 
     if (sys.platform == 'win32' or os.name == 'os2') and (ext != '.exe'):
         executable += ".exe"  # pragma: no cover; we don't collect coverage on Windows due to poor performance
 
-    if os.path.isfile(executable) and is_executable(executable):
-        return executable
+    if os.path.isfile(executable) and is_executable(Path.of(executable)):
+        return abs_path(executable)
 
     path = os.environ.get('PATH', os.defpath)
     paths = path.split(os.pathsep)
     for p in paths:
-        f = os.path.join(p, executable)
+        f: Path = join_paths(p, executable)
         if os.path.isfile(f) and is_executable(f):
             debug(f"found {executable} at {f}")
-            return f
+            return abs_path(f)
     return None
 
 
-def slurp_file(path: str) -> str:
+def slurp_file(path: Path) -> str:
     with open(path, 'r') as file:
         return file.read()

--- a/git_machete/utils/paths.py
+++ b/git_machete/utils/paths.py
@@ -1,22 +1,93 @@
-"""POSIX-style path utilities.
+"""POSIX-style typed paths and helpers.
 
-Forward slashes are used consistently across platforms to match Git's own
-representation; this works in all Windows environments (Git Bash,
-PowerShell, CMD) as well as on Unix-like systems.
+Every `Path` / `AbsPath` instance is normalised to forward-slash form on
+construction (via `PurePath(value).as_posix()`), regardless of platform.
+This is load-bearing for:
+
+* path equality / dictionary membership (`current_worktree_root_dir ==
+  target_worktree_root_dir`, `worktrees_by_branch.get(branch)`, ...) -
+  mixing native and posix separators on Windows would silently miscompare
+  paths produced by Python helpers vs. paths returned by `git` itself,
+* user-facing output and test snapshots (one form across all platforms,
+  matching `git`'s own output style),
+* cross-platform consistency of any path stored long-term in
+  git-machete's state (caches, branch-layout-file path, ...).
+
+Pure I/O (`open`, `os.path.isfile`, `shutil.*`, `subprocess.run(cwd=...)`)
+accepts either form on Windows, so the normalisation is invisible there -
+the value lies in the type-system guarantee that downstream comparisons
+and renders are stable.
+
+The `Path` / `AbsPath` hierarchy mirrors the discipline used for branch
+names (`AnyBranchName` / `LocalBranchShortName` etc.): production code
+converts raw `str`s at the earliest boundary, so the type system enforces
+"absolute" semantics where a stored path must outlive a possible
+`os.chdir` (most notably `traverse` switching into linked worktrees -
+the latent source of issue #1681 and friends).
 """
 
 import os
-from pathlib import Path, PurePosixPath
+from pathlib import Path as PyPath
+from pathlib import PurePath, PurePosixPath
+
+from git_machete.utils.exceptions import UnexpectedMacheteException
 
 
-def join_paths_posix(*paths: str) -> str:
-    return str(PurePosixPath(*paths))
+class Path(str):
+    """A filesystem path (relative or absolute), always in posix form."""
+
+    def __new__(cls, value: str = "") -> "Path":
+        # Normalise once at the boundary so every typed path is guaranteed
+        # forward-slash. `PurePath` is platform-aware: on Windows it converts
+        # `\` to `/`, on POSIX it's a no-op for sane inputs. We still go
+        # through `as_posix()` so the invariant holds even if the input was
+        # already posix-form on Windows.
+        return super().__new__(cls, PurePath(value).as_posix() if value else "")
+
+    @staticmethod
+    def of(value: str) -> "Path":
+        if not value:
+            raise UnexpectedMacheteException(
+                f"Path.of should not accept {value!r} as a param.")
+        return Path(value)
 
 
-def abspath_posix(path: str) -> str:
-    return Path(path).resolve().as_posix()
+class AbsPath(Path):
+    """A path confirmed absolute at construction time, in posix form."""
+
+    @staticmethod
+    def of(value: str) -> "AbsPath":
+        if not value:
+            raise UnexpectedMacheteException(
+                f"AbsPath.of should not accept {value!r} as a param.")
+        if not os.path.isabs(value):
+            raise UnexpectedMacheteException(
+                f"AbsPath.of expects an absolute path, got {value!r}.")
+        return AbsPath(value)
+
+    @staticmethod
+    def home() -> "AbsPath":
+        """The current user's home directory, posix-form."""
+        return AbsPath.of(str(PyPath.home()))
+
+    def join_fragments(self, *fragments: str) -> "AbsPath":
+        """Append `fragments` (path segments, not absolute paths themselves)
+        under this absolute base; result is also absolute.
+
+        Named `join_fragments` rather than `join` (which `str` already
+        defines with unrelated semantics) or `join_paths` (the args are
+        plain segments like `"machete"`, not standalone paths).
+        """
+        return AbsPath(str(PurePosixPath(self, *fragments)))
 
 
-def relpath_posix(path: str) -> str:
-    rel = os.path.relpath(path)
-    return Path(rel).as_posix()
+def join_paths(*paths: str) -> Path:
+    return Path(str(PurePosixPath(*paths)))
+
+
+def abs_path(path: str) -> AbsPath:
+    return AbsPath(PyPath(path).resolve().as_posix())
+
+
+def rel_path(path: str) -> Path:
+    return Path(os.path.relpath(path))

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -5,7 +5,7 @@ import textwrap
 import pytest
 from pytest_mock import MockerFixture
 
-from git_machete.utils.paths import abspath_posix
+from git_machete.utils.paths import abs_path
 from git_machete.utils.terminal import FullTerminalAnsiOutputCodes
 
 from .base_test import BaseTest
@@ -183,7 +183,7 @@ class TestStatus(BaseTest):
 
     @pytest.mark.skipif(sys.platform == "win32", reason="Windows doesn't distinguish between executable and non-executable files")
     def test_status_advice_ignored_non_executable_hook(self) -> None:
-        repo_path = abspath_posix(create_repo())
+        repo_path = abs_path(create_repo())
         new_branch('master')
         commit()
         new_branch('develop')

--- a/tests/test_traverse_worktrees.py
+++ b/tests/test_traverse_worktrees.py
@@ -5,7 +5,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from git_machete.utils.exceptions import UnderlyingGitException
-from git_machete.utils.paths import abspath_posix
+from git_machete.utils.paths import abs_path
 
 from .base_test import BaseTest
 from .cli_runner import (assert_failure, assert_success, launch_command,
@@ -73,8 +73,8 @@ class TestTraverseWorktrees(BaseTest):
 
         # Now run traverse - it should cd into the worktrees automatically
         # Using -y flag so no need to mock input
-        normalized_feature_1_worktree = abspath_posix(feature_1_worktree)
-        normalized_feature_2_worktree = abspath_posix(feature_2_worktree)
+        normalized_feature_1_worktree = abs_path(feature_1_worktree)
+        normalized_feature_2_worktree = abs_path(feature_2_worktree)
 
         # Assert the full output to verify proper messaging:
         # - When branch is not checked out anywhere: "Checking out ... OK"
@@ -176,7 +176,7 @@ class TestTraverseWorktrees(BaseTest):
         # 1. Checkout root (not in any worktree) in main worktree - triggers cache update
         # 2. Visit branch-1 (already in linked worktree, but no action needed so don't cd)
         # 3. Checkout branch-2 (not in any worktree) in main worktree - triggers cache update
-        normalized_local_path = abspath_posix(local_path)
+        normalized_local_path = abs_path(local_path)
 
         # This test verifies the worktree cache update logic and cd'ing from linked to main worktree
         assert_success(
@@ -309,7 +309,7 @@ class TestTraverseWorktrees(BaseTest):
 
         # Verify the warning is emitted
         assert "branch branch-2 is checked out in worktree at" in output
-        normalized_branch_2_worktree = abspath_posix(branch_2_worktree)
+        normalized_branch_2_worktree = abs_path(branch_2_worktree)
         assert f"You may want to change directory with:\n  cd {normalized_branch_2_worktree}" in output
 
     def test_traverse_no_warn_when_final_branch_in_same_worktree(self) -> None:
@@ -369,7 +369,7 @@ class TestTraverseWorktrees(BaseTest):
         check_out("root")
         self.patch_symbol(mocker, 'builtins.input', mock_input_returning("q"))
 
-        normalized_branch_1_worktree = abspath_posix(branch_1_worktree)
+        normalized_branch_1_worktree = abs_path(branch_1_worktree)
 
         # This corner case tests that when user quits mid-traverse,
         # the final warning is shown if ended in a different worktree
@@ -425,8 +425,8 @@ class TestTraverseWorktrees(BaseTest):
         # cd into root linked worktree to start traverse from there
         os.chdir(root_worktree)
 
-        normalized_local_path = abspath_posix(local_path)
-        normalized_branch_2_worktree = abspath_posix(branch_2_worktree)
+        normalized_local_path = abs_path(local_path)
+        normalized_branch_2_worktree = abs_path(branch_2_worktree)
 
         # First test: default behavior (without config key set)
         # We're in root linked worktree
@@ -558,7 +558,7 @@ class TestTraverseWorktrees(BaseTest):
 
         set_git_config_key("machete.traverse.whenBranchNotCheckedOutInAnyWorktree", "cd-into-temporary-worktree")
 
-        normalized_root_worktree = abspath_posix(root_worktree)
+        normalized_root_worktree = abs_path(root_worktree)
 
         self.patch_symbol(mocker, 'builtins.input', mock_input_returning("n", "n", "n"))
         assert_success(
@@ -630,7 +630,7 @@ class TestTraverseWorktrees(BaseTest):
 
         set_git_config_key("machete.traverse.whenBranchNotCheckedOutInAnyWorktree", "cd-into-temporary-worktree")
 
-        normalized_local_path = abspath_posix(local_path)
+        normalized_local_path = abs_path(local_path)
 
         assert_success(
             ["traverse", "-y"],
@@ -693,7 +693,7 @@ class TestTraverseWorktrees(BaseTest):
         # Start traverse from the linked worktree (on `other`).
         os.chdir(other_worktree)
 
-        normalized_local_path = abspath_posix(local_path)
+        normalized_local_path = abs_path(local_path)
 
         # Traverse visits:
         # - root: already checked out in main worktree -> cd there
@@ -754,7 +754,7 @@ class TestTraverseWorktrees(BaseTest):
         # Create a worktree for feature
         check_out("base")
         feature_worktree = add_worktree("feature")
-        normalized_feature_worktree = abspath_posix(feature_worktree)
+        normalized_feature_worktree = abs_path(feature_worktree)
 
         # Make a conflicting change on base
         check_out("base")
@@ -824,7 +824,7 @@ class TestTraverseWorktrees(BaseTest):
         execute("git merge --ff-only main")
         os.chdir(initial_dir)
 
-        normalized_a_worktree = abspath_posix(a_worktree)
+        normalized_a_worktree = abs_path(a_worktree)
 
         assert_success(
             ["traverse", "-y"],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,7 +10,7 @@ from git_machete.utils import debug_log
 from git_machete.utils.date import get_current_date
 from git_machete.utils.debug_log import debug, hex_repr
 from git_machete.utils.markup import _fmt
-from git_machete.utils.paths import abspath_posix
+from git_machete.utils.paths import abs_path
 from git_machete.utils.terminal import (BasicTerminalAnsiOutputCodes,
                                         FullTerminalAnsiOutputCodes)
 
@@ -62,11 +62,11 @@ class TestUtils(BaseTest):
     def test_hex_repr(self) -> None:
         assert hex_repr("Hello, world!") == "48:65:6c:6c:6f:2c:20:77:6f:72:6c:64:21"
 
-    def test_abspath_posix_general(self) -> None:
-        """Test that abspath_posix returns an absolute path with forward slashes."""
+    def test_abs_path_general(self) -> None:
+        """Test that abs_path returns an absolute path with forward slashes."""
         # Create a temporary directory to ensure we're working with real paths
         with tempfile.TemporaryDirectory() as tmpdir:
-            normalized = abspath_posix(tmpdir)
+            normalized = abs_path(tmpdir)
             # Should be absolute
             assert os.path.isabs(normalized)
             # Should use forward slashes (no backslashes)
@@ -75,7 +75,7 @@ class TestUtils(BaseTest):
             assert os.path.exists(normalized)
 
     @pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific test for backslash conversion")
-    def test_abspath_posix_windows_backslashes(self) -> None:
+    def test_abs_path_windows_backslashes(self) -> None:
         """Test that backslashes are converted to forward slashes on Windows."""
         # On Windows, Path.resolve() returns paths with backslashes
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -83,7 +83,7 @@ class TestUtils(BaseTest):
             # Verify it contains backslashes before normalization
             assert '\\' in tmpdir or '/' in tmpdir  # Windows paths have one or the other
 
-            normalized = abspath_posix(tmpdir)
+            normalized = abs_path(tmpdir)
 
             # After normalization, should have forward slashes only
             assert '\\' not in normalized
@@ -92,7 +92,7 @@ class TestUtils(BaseTest):
             assert normalized[1:3] == ':/'
 
     @pytest.mark.skipif(sys.platform != "darwin", reason="macOS-specific test for /private prefix")
-    def test_abspath_posix_macos_private_prefix(self) -> None:
+    def test_abs_path_macos_private_prefix(self) -> None:
         """Test that /private prefix is consistently added on macOS for /tmp and /var paths."""
         # On macOS, /tmp and /var are symlinks to /private/tmp and /private/var
         # tempfile.mkdtemp() may return paths with or without /private prefix
@@ -100,7 +100,7 @@ class TestUtils(BaseTest):
             # tmpdir is in /tmp or /var on macOS
             # It might be returned as /var/folders/... or /private/var/folders/...
 
-            normalized = abspath_posix(tmpdir)
+            normalized = abs_path(tmpdir)
 
             # After normalization with resolve(), should have /private prefix if in /var or /tmp
             # (resolve resolves the symlink)
@@ -110,10 +110,10 @@ class TestUtils(BaseTest):
                     f"Expected path to start with /private/ or /nix/ (for Nix builds), got: {normalized}"
 
     @pytest.mark.skipif(sys.platform == "win32", reason="Unix-specific test for absolute paths")
-    def test_abspath_posix_unix_absolute_paths(self) -> None:
+    def test_abs_path_unix_absolute_paths(self) -> None:
         """Test that paths start with / on Unix systems."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            normalized = abspath_posix(tmpdir)
+            normalized = abs_path(tmpdir)
             # Should start with / on Unix
             assert normalized.startswith('/')
             # Should not contain backslashes


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1682

## Chain of upstream PRs as of 2026-05-13

* PR #1678:
  `master` ← `develop`

  * PR #1682:
    `develop` ← `fix/1681-relative-path-worktree`

    * **PR #1683 (THIS ONE)**:
      `fix/1681-relative-path-worktree` ← `refactor/path-typing`

<!-- end git-machete generated -->
