### PR TITLE
Fix poor UX of `slide-out <branch>` when the branch is already deleted from git

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@
 - changed: `git machete github update-pr-descriptions` and `git machete gitlab update-mr-descriptions` now default to `--related` when no flag (`--all`/`--by`/`--mine`/`--related`) is provided
 - changed: `git machete status -l` now lists, for green and yellow edges, all commits between the parent branch and the branch tip (rather than just between the fork point and the branch tip), with the fork point commit annotated `-> fork point`; red edges still list only the unique commits of the branch (`fork-point..branch`, exclusive)
 - fixed: spurious yellow edge no longer appears in `status` when the parent branch is merely behind its remote counterpart and the child branch was forked from the remote tip
+- fixed: `git machete slide-out <branch>` no longer prints a confusing "Warning: sliding invalid branch ... out" followed by "Branch ... not found in the tree" when the branch was already deleted from git; the explicit slide-out is now honored cleanly
 - fixed: `git machete traverse` no longer crashes with `NotADirectoryError: '.git/machete'` when auto-slide-out fires inside a linked worktree (reported by @BertPluymersTR)
 - fixed: minor glitches in shell completions
 - fixed: parsing of `gh --version` output for custom/devel `gh` builds (e.g. `gh version 2.92.0-7-ga3efb25a`)

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -1071,7 +1071,13 @@ def launch_internal(orig_args: List[str]) -> None:
                     "merge and cannot be specified together with `--no-rebase`.")
 
             slide_out_client = SlideOutMacheteClient(git)
-            slide_out_client.read_branch_layout_file()
+            # `verify_branches=False` so that a branch the user is *explicitly* asking
+            # to slide out doesn't first trigger the "Warning: sliding invalid branch ..."
+            # auto-prune (which then makes the explicit slide-out fail with
+            # "not found in the tree of branch dependencies"). The auto-prune is useful
+            # for commands that just *read* the layout (e.g. `status`, `traverse`); for
+            # `slide-out` it's redundant with the user's own intent.
+            slide_out_client.read_branch_layout_file(verify_branches=False)
             branches_to_slide_out: Optional[List[str]] = parsed_cli_as_dict.get('branches')
             if cli_opts.opt_removed_from_remote:
                 if (branches_to_slide_out or cli_opts.opt_down_fork_point or cli_opts.opt_merge or

--- a/tests/test_slide_out.py
+++ b/tests/test_slide_out.py
@@ -6,9 +6,10 @@ from .base_test import BaseTest
 from .cli_runner import (assert_failure, assert_success, launch_command,
                          read_branch_layout_file, rewrite_branch_layout_file)
 from .git_repository import (amend_commit, check_out, commit, create_repo,
-                             create_repo_with_remote, delete_remote_branch,
-                             get_current_branch, get_current_commit_hash,
-                             get_local_branches, new_branch, push)
+                             create_repo_with_remote, delete_branch,
+                             delete_remote_branch, get_current_branch,
+                             get_current_commit_hash, get_local_branches,
+                             new_branch, push)
 from .mockers import (fixed_author_and_committer_date_in_past,
                       mock_input_returning_y)
 from .shell import read_file, set_file_executable, write_to_file
@@ -756,3 +757,35 @@ class TestSlideOut(BaseTest):
 
         # Verify we're still on root-2 (the slid-out branch, since it has no downstreams to check out)
         assert get_current_branch() == "root-2"
+
+    def test_slide_out_branch_already_deleted_from_git(self) -> None:
+        """Regression test: `slide-out <branch>` for a branch that has already been
+        deleted from git must succeed cleanly, without first auto-pruning the branch
+        with a `Warning: sliding invalid branch ... out` message and then failing
+        with `Branch ... not found in the tree of branch dependencies`.
+        """
+        create_repo()
+        new_branch('branch-0')
+        commit()
+        new_branch('branch-1')
+        commit()
+        check_out('branch-0')
+        new_branch('branch-2')
+        commit()
+
+        body: str = \
+            """
+            branch-0
+                branch-1
+                branch-2
+            """
+        rewrite_branch_layout_file(body)
+
+        delete_branch('branch-1')
+
+        # The explicit slide-out should produce no output (no warning, no error)
+        # and remove the (now-orphaned-in-git) branch from the layout.
+        assert_success(["slide-out", "branch-1"], "")
+
+        expected_layout = ["branch-0", "    branch-2"]
+        assert read_branch_layout_file().splitlines() == expected_layout


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1684

## Chain of upstream PRs as of 2026-05-13

* PR #1678:
  `master` ← `develop`

  * PR #1682:
    `develop` ← `fix/1681-relative-path-worktree`

    * PR #1684:
      `fix/1681-relative-path-worktree` ← `cross-platform/refactor/path-typing`

      * **PR #1685 (THIS ONE)**:
        `cross-platform/refactor/path-typing` ← `fix/slide-out-removed-branch`

<!-- end git-machete generated -->

Previously, explicitly sliding out a branch that had already been deleted
locally produced a confusing pair of messages:

    Warning: sliding invalid branch <branch> out of the branch layout file
    Branch <branch> not found in the tree of branch dependencies.
    Use git machete add <branch> or git machete edit.

The warning came from `read_branch_layout_file`'s auto-prune of invalid
branches, which silently removed the branch from the in-memory layout;
the error then followed from the explicit `slide_out` lookup, since the
branch was no longer there. The end state was correct, but the messaging
made it look like the operation had failed.

Call `read_branch_layout_file(verify_branches=False)` from the slide-out
command (mirroring what `anno` and `show` already do): for commands that
themselves mutate the layout, the auto-prune is redundant with the
user's explicit intent.