### PR TITLE
Move Git interactions out of cli.py into clients

### DIFF
--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -25,15 +25,14 @@ from git_machete.client.rename import RenameMacheteClient
 from git_machete.client.slide_out import SlideOutMacheteClient
 from git_machete.client.squash import SquashMacheteClient
 from git_machete.client.status import StatusMacheteClient
-from git_machete.client.traverse import (TraverseMacheteClient,
-                                         TraverseReturnTo, TraverseStartFrom)
+from git_machete.client.traverse import TraverseMacheteClient, TraverseReturnTo
 from git_machete.client.update import UpdateMacheteClient
 from git_machete.client.with_code_hosting import MacheteClientWithCodeHosting
 from git_machete.config import MacheteConfig, SquashMergeDetection
 from git_machete.github import GITHUB_API_SPEC
 from git_machete.gitlab import GITLAB_API_SPEC
 
-from .git import AnyRevision, Git, LocalBranchShortName
+from .git import AnyRevision, LocalBranchShortName
 from .help import (MacheteHelpAction, alias_by_command, commands_and_aliases,
                    get_help_description, version)
 from .utils import cmd, debug_log, markup, terminal
@@ -41,7 +40,7 @@ from .utils.exceptions import (ExitCode, InteractionStopped, MacheteException,
                                UnderlyingGitException,
                                UnexpectedMacheteException)
 from .utils.fs import does_directory_exist, get_current_directory_or_none
-from .utils.markup import green_ok, print_fmt, warn
+from .utils.markup import print_fmt, warn
 from .utils.paths import AbsPath
 
 T = TypeVar('T')
@@ -657,11 +656,8 @@ def update_cli_options_using_parsed_args(
             cli_opts.opt_no_interactive_rebase = True
 
 
-def update_cli_options_using_config_keys(
-        cli_opts: git_machete.options.CommandLineOptions,
-        git: Git
-) -> None:
-    traverse_push = MacheteConfig(git).traverse_push()
+def update_cli_options_using_config_keys(cli_opts: git_machete.options.CommandLineOptions) -> None:
+    traverse_push = MacheteConfig().traverse_push()
     if traverse_push is not None:
         cli_opts.opt_push_tracked = cli_opts.opt_push_untracked = traverse_push
 
@@ -687,7 +683,6 @@ def launch_internal(orig_args: List[str]) -> None:
 
     try:
         cli_opts = git_machete.options.CommandLineOptions()
-        git = Git()
 
         direct_args = list(itertools.takewhile(lambda arg: arg != "--", orig_args))
         pass_through_args = list(itertools.dropwhile(lambda arg: arg != "--", orig_args))
@@ -697,7 +692,7 @@ def launch_internal(orig_args: List[str]) -> None:
 
         # Let's set up options like debug/verbose before we first start reading `git config`.
         set_utils_global_variables(parsed_cli)
-        update_cli_options_using_config_keys(cli_opts, git)
+        update_cli_options_using_config_keys(cli_opts)
         update_cli_options_using_parsed_args(cli_opts, parsed_cli)
 
         if cli_opts.opt_no_interactive_rebase and cli_opts.opt_merge:
@@ -724,7 +719,7 @@ def launch_internal(orig_args: List[str]) -> None:
             if cli_opts.opt_squash_merge_detection_origin is not None:
                 return SquashMergeDetection.from_string(
                     cli_opts.opt_squash_merge_detection_string, cli_opts.opt_squash_merge_detection_origin)
-            return MacheteConfig(git).squash_merge_detection()
+            return MacheteConfig().squash_merge_detection()
 
         if cmd == "completion":
             completion_shell = parsed_cli.shell
@@ -757,11 +752,9 @@ def launch_internal(orig_args: List[str]) -> None:
                 raise MacheteException("Option `-R/--as-root` cannot be specified together with `-o/--onto`.")
             if cli_opts.opt_as_root and cli_opts.opt_as_first_child:
                 raise MacheteException("Option `-R/--as-root` cannot be specified together with `-f/--as-first-child`.")
-            add_client = MacheteClient(git)
-            add_client.read_branch_layout_file()
-            branch = cli_opts.opt_branch or git.get_current_branch()
+            add_client = MacheteClient()
             add_client.add(
-                branch=branch,
+                opt_branch=cli_opts.opt_branch,
                 opt_onto=cli_opts.opt_onto,
                 opt_as_first_child=cli_opts.opt_as_first_child,
                 opt_as_root=cli_opts.opt_as_root,
@@ -769,78 +762,44 @@ def launch_internal(orig_args: List[str]) -> None:
                 verbose=True,
                 switch_head_if_new_branch=True)
         elif cmd == "advance":
-            advance_client = AdvanceMacheteClient(git)
-            advance_client.read_branch_layout_file()
+            advance_client = AdvanceMacheteClient()
             advance_client.advance(opt_yes=cli_opts.opt_yes)
         elif cmd == "anno":
             spec = GITHUB_API_SPEC if cli_opts.opt_sync_github_prs else GITLAB_API_SPEC
-            anno_client = AnnoMacheteClient(git, spec)
-            anno_client.read_branch_layout_file(verify_branches=False)
+            anno_client = AnnoMacheteClient(spec, verify_branches=False)
             if cli_opts.opt_sync_github_prs or cli_opts.opt_sync_gitlab_mrs:
                 anno_client.sync_annotations_to_prs(include_urls=False)
+            elif 'annotation_text' in parsed_cli:
+                anno_client.annotate(opt_branch=cli_opts.opt_branch, words=parsed_cli.annotation_text)
             else:
-                branch = cli_opts.opt_branch or git.get_current_branch()
-                anno_client.expect_in_managed_branches(branch)
-                if 'annotation_text' in parsed_cli:
-                    anno_client.annotate(branch, parsed_cli.annotation_text)
-                else:
-                    anno_client.print_annotation(branch)
+                anno_client.print_annotation(opt_branch=cli_opts.opt_branch)
         elif cmd == "clean":
-            clean_client = MacheteClientWithCodeHosting(git, GITHUB_API_SPEC)
-            clean_client.read_branch_layout_file()
+            clean_client = MacheteClientWithCodeHosting(GITHUB_API_SPEC)
             if 'checkout_my_github_prs' in parsed_cli:
                 clean_client.checkout_pull_requests(pr_numbers=[], mine=True)
             clean_client.delete_unmanaged(opt_squash_merge_detection=SquashMergeDetection.NONE, opt_yes=cli_opts.opt_yes)
             clean_client.delete_untracked(opt_yes=cli_opts.opt_yes)
         elif cmd == "delete-unmanaged":
-            delete_unmanaged_client = MacheteClient(git)
-            delete_unmanaged_client.read_branch_layout_file()
+            delete_unmanaged_client = MacheteClient()
             delete_unmanaged_client.delete_unmanaged(
-                opt_squash_merge_detection=MacheteConfig(git).squash_merge_detection(),
+                opt_squash_merge_detection=MacheteConfig().squash_merge_detection(),
                 opt_yes=cli_opts.opt_yes)
         elif cmd in {"diff", alias_by_command["diff"]}:
-            diff_client = DiffMacheteClient(git)
-            diff_client.read_branch_layout_file()
+            diff_client = DiffMacheteClient()
             diff_client.display_diff(branch=cli_opts.opt_branch, opt_stat=cli_opts.opt_stat, extra_git_diff_args=pass_through_args)
         elif cmd == "discover":
-            discover_client = DiscoverMacheteClient(git)
-            discover_client.read_branch_layout_file()
+            discover_client = DiscoverMacheteClient()
             discover_client.discover(
                 opt_checked_out_since=cli_opts.opt_checked_out_since,
                 opt_list_commits=cli_opts.opt_list_commits,
                 opt_roots=cli_opts.opt_roots,
                 opt_yes=cli_opts.opt_yes)
         elif cmd in {"edit", alias_by_command["edit"]}:
-            # No need to read branch layout file.
-            edit_client = MacheteClient(git)
-            edit_client.edit()
+            MacheteClient(read_layout_file=False).edit()
         elif cmd == "file":
-            # No need to read branch layout file.
-            file_client = MacheteClient(git)
-            print(file_client.branch_layout_file_path)
+            print(MacheteClient(read_layout_file=False).branch_layout_file_path)
         elif cmd == "fork-point":
-            fork_point_client = ForkPointMacheteClient(git)
-            fork_point_client.read_branch_layout_file()
-            branch = cli_opts.opt_branch or git.get_current_branch()
-            parent = fork_point_client.parent_of(branch)
-            fork_point_client.expect_in_local_branches(branch)
-
-            def warn_on_deprecation(*, flag: str, revision: AnyRevision, revision_str: str) -> None:
-                if parent:
-                    print()
-                    warn(
-                        f"`git machete fork-point {flag}` may lead to a confusing user experience and is deprecated.\n\n"
-                        f"If the commits between <b>{parent}</b> (parent of <b>{branch}</b>) "
-                        f"and {revision_str} <b>{git.get_short_commit_hash_by_revision_or_none(revision) or ''}</b> "
-                        f"do NOT belong to <b>{branch}</b>, consider using:\n"
-                        f"    `git checkout {branch}`\n"
-                        f"    `git machete update --fork-point=\"{revision}\"`\n\n"
-                        "Otherwise, if you're okay with treating these commits "
-                        f"as a part of <b>{branch}</b>'s unique history, use instead:\n"
-                        f"    `git machete fork-point {branch} --override-to-parent`"
-                    )
-                # It's unlikely that anyone overrides fork point for a branch that doesn't have a parent,
-                # also it's unclear what the suggested action should even be - let's skip this case.
+            fork_point_client = ForkPointMacheteClient()
 
             if cli_opts.opt_override_to or cli_opts.opt_override_to_inferred or \
                     cli_opts.opt_override_to_parent or cli_opts.opt_unset_override:
@@ -850,32 +809,23 @@ def launch_internal(orig_args: List[str]) -> None:
                         "`--override-to`/`--override-to-inferred`/`--override-to-parent`/`--unset-override`.")
 
             if cli_opts.opt_inferred:
-                fork_point_client.print_fork_point(branch=branch, use_overrides=False, explain=cli_opts.opt_explain)
+                fork_point_client.print_fork_point(
+                    opt_branch=cli_opts.opt_branch, use_overrides=False, explain=cli_opts.opt_explain)
             elif cli_opts.opt_override_to:
-                override_to = AnyRevision.of(cli_opts.opt_override_to)
-                fork_point_client.set_fork_point_override(branch, override_to)
-                # Let's issue the warning only if there are no errors from set_fork_point_override.
-                warn_on_deprecation(
-                    flag="--override-to=...",
-                    revision=override_to,
-                    revision_str="selected commit")
+                fork_point_client.override_fork_point_to(
+                    opt_branch=cli_opts.opt_branch,
+                    to_revision=AnyRevision.of(cli_opts.opt_override_to),
+                    deprecated_flag_label="--override-to=...",
+                    revision_label="selected commit")
             elif cli_opts.opt_override_to_inferred:
-                fork_point = fork_point_client.fork_point(branch=branch, use_overrides=False)
-                fork_point_client.set_fork_point_override(branch, fork_point)
-                warn_on_deprecation(
-                    flag="--override-to-inferred",
-                    revision=fork_point,
-                    revision_str="inferred commit")
+                fork_point_client.override_fork_point_to_inferred(opt_branch=cli_opts.opt_branch)
             elif cli_opts.opt_override_to_parent:
-                if parent:
-                    fork_point_client.set_fork_point_override(branch, parent)
-                else:
-                    raise MacheteException(
-                        f"Branch <b>{branch}</b> does not have upstream (parent) branch")
+                fork_point_client.override_fork_point_to_parent(opt_branch=cli_opts.opt_branch)
             elif cli_opts.opt_unset_override:
-                fork_point_client.unset_fork_point_override(branch)
+                fork_point_client.unset_fork_point_override(opt_branch=cli_opts.opt_branch)
             else:
-                fork_point_client.print_fork_point(branch=branch, use_overrides=True, explain=cli_opts.opt_explain)
+                fork_point_client.print_fork_point(
+                    opt_branch=cli_opts.opt_branch, use_overrides=True, explain=cli_opts.opt_explain)
         elif cmd in {"github", "gitlab"}:
             subcommand = parsed_cli.subcommand
             spec = GITHUB_API_SPEC if cmd == "github" else GITLAB_API_SPEC
@@ -909,8 +859,7 @@ def launch_internal(orig_args: List[str]) -> None:
             if cli_opts.opt_yes and subcommand != f"create-{pr_or_mr}":
                 raise MacheteException(f"`--yes` option is only valid with `create-{pr_or_mr}` subcommand.")
 
-            github_or_gitlab_client = MacheteClientWithCodeHosting(git, spec)
-            github_or_gitlab_client.read_branch_layout_file()
+            github_or_gitlab_client = MacheteClientWithCodeHosting(spec)
 
             if subcommand == f"anno-{pr_or_mr}s":
                 github_or_gitlab_client.sync_annotations_to_prs(include_urls=cli_opts.opt_with_urls)
@@ -926,10 +875,8 @@ def launch_internal(orig_args: List[str]) -> None:
                     by=cli_opts.opt_by,
                     fail_on_missing_current_user_for_my_open_prs=True)
             elif subcommand == f"create-{pr_or_mr}":
-                current_branch = git.get_current_branch()
                 github_or_gitlab_client.sync_before_creating_pull_request(opt_yes=cli_opts.opt_yes)
                 github_or_gitlab_client.create_pull_request(
-                    head=current_branch,
                     opt_base=cli_opts.opt_base,
                     opt_draft=cli_opts.opt_draft,
                     opt_title=cli_opts.opt_title,
@@ -938,10 +885,8 @@ def launch_internal(orig_args: List[str]) -> None:
             elif subcommand == f"restack-{pr_or_mr}":
                 github_or_gitlab_client.restack_pull_request(opt_update_related_descriptions=cli_opts.opt_update_related_descriptions)
             elif subcommand == f"retarget-{pr_or_mr}":
-                branch = cli_opts.opt_branch or git.get_current_branch()
-                github_or_gitlab_client.expect_in_managed_branches(branch)
                 github_or_gitlab_client.retarget_pull_request(
-                    head=branch,
+                    opt_branch=cli_opts.opt_branch,
                     opt_ignore_if_missing=cli_opts.opt_ignore_if_missing,
                     opt_update_related_descriptions=cli_opts.opt_update_related_descriptions
                 )
@@ -962,35 +907,12 @@ def launch_internal(orig_args: List[str]) -> None:
             else:  # an unknown subcommand is handled by argparse
                 raise UnexpectedMacheteException(f"Unknown subcommand: `{subcommand}`")
         elif cmd in {"go", alias_by_command["go"]}:
-            git.expect_no_operation_in_progress()
-            current_branch_or_none = git.get_current_branch_or_none()
-
             if parsed_cli.direction is not None:
-                go_client = GoShowMacheteClient(git)
-                go_client.read_branch_layout_file()
-                # with pick_if_multiple=True, there returned list will have exactly one element
-                dest = go_client.parse_direction(
-                    parsed_cli.direction, branch=current_branch_or_none,
-                    allow_current=False, pick_if_multiple=True)[0]
-                if dest != current_branch_or_none:
-                    print_fmt(f"Checking out <b>{dest}</b>... ", newline=False)
-                    git.checkout(dest)
-                    print_fmt(green_ok())
+                GoShowMacheteClient().go(parsed_cli.direction)
             else:
-                interactive_client = GoInteractiveMacheteClient(git)
-                interactive_client.read_branch_layout_file()
-                interactive_client.expect_at_least_one_managed_branch()
-                selected_branch = interactive_client.go_interactive(current_branch=current_branch_or_none)
-                if selected_branch is not None and selected_branch != current_branch_or_none:
-                    print()
-                    print_fmt(f"Checking out <b>{selected_branch}</b>... ", newline=False)
-                    git.checkout(selected_branch)
-                    print_fmt(green_ok())
+                GoInteractiveMacheteClient().go_interactive()
         elif cmd == "is-managed":
-            is_managed_client = MacheteClient(git)
-            is_managed_client.read_branch_layout_file()
-            branch = cli_opts.opt_branch or git.get_current_branch()
-            if branch is None or branch not in is_managed_client.managed_branches:
+            if not MacheteClient().is_managed(opt_branch=cli_opts.opt_branch):
                 sys.exit(ExitCode.MACHETE_EXCEPTION)
         elif cmd == "list":
             category = parsed_cli.category
@@ -999,8 +921,7 @@ def launch_internal(orig_args: List[str]) -> None:
             elif category != 'slidable-after' and cli_opts.opt_branch:
                 raise MacheteException(f"`git machete list {category}` does not expect extra arguments")
 
-            list_client = ListMacheteClient(git)
-            list_client.read_branch_layout_file()
+            list_client = ListMacheteClient()
             res = []
             if category == "addable":
                 res = list_client.addable_branches()
@@ -1023,32 +944,21 @@ def launch_internal(orig_args: List[str]) -> None:
             if res:
                 print("\n".join(res))
         elif cmd in {"log", alias_by_command["log"]}:
-            log_client = LogMacheteClient(git)
-            log_client.read_branch_layout_file()
-            branch = cli_opts.opt_branch or git.get_current_branch()
-            log_client.display_log(branch, extra_git_log_args=pass_through_args)
+            LogMacheteClient().display_log(opt_branch=cli_opts.opt_branch, extra_git_log_args=pass_through_args)
         elif cmd == "reapply":
-            reapply_client = ReapplyMacheteClient(git)
-            reapply_client.read_branch_layout_file()
-            reapply_client.reapply(
+            ReapplyMacheteClient().reapply(
                 opt_fork_point=cli_opts.opt_fork_point,
                 opt_no_interactive_rebase=cli_opts.opt_no_interactive_rebase)
         elif cmd == "rename":
-            rename_client = RenameMacheteClient(git)
-            rename_client.read_branch_layout_file()
-            branch = cli_opts.opt_branch or git.get_current_branch()
-            rename_client.rename(
-                branch=branch,
+            RenameMacheteClient().rename(
+                opt_branch=cli_opts.opt_branch,
                 new_name=LocalBranchShortName.of(parsed_cli.new_name),
                 opt_repoint_tracking=cli_opts.opt_repoint_tracking)
         elif cmd == "show":
             direction = parsed_cli.direction
             if direction == "current" and cli_opts.opt_branch:
                 raise MacheteException('`show current` with a `<branch>` argument does not make sense')
-            branch = cli_opts.opt_branch or git.get_current_branch()
-            show_client = GoShowMacheteClient(git)
-            show_client.read_branch_layout_file(verify_branches=False)
-            print('\n'.join(show_client.parse_direction(direction, branch=branch, allow_current=True, pick_if_multiple=False)))
+            GoShowMacheteClient(verify_branches=False).show(direction, opt_branch=cli_opts.opt_branch)
         elif cmd == "slide-out":
             if cli_opts.opt_down_fork_point and cli_opts.opt_merge:
                 raise MacheteException(
@@ -1070,14 +980,13 @@ def launch_internal(orig_args: List[str]) -> None:
                     "Option `--no-edit-merge` only makes sense when using "
                     "merge and cannot be specified together with `--no-rebase`.")
 
-            slide_out_client = SlideOutMacheteClient(git)
             # `verify_branches=False` so that a branch the user is *explicitly* asking
             # to slide out doesn't first trigger the "Warning: sliding invalid branch ..."
             # auto-prune (which then makes the explicit slide-out fail with
             # "not found in the tree of branch dependencies"). The auto-prune is useful
             # for commands that just *read* the layout (e.g. `status`, `traverse`); for
             # `slide-out` it's redundant with the user's own intent.
-            slide_out_client.read_branch_layout_file(verify_branches=False)
+            slide_out_client = SlideOutMacheteClient(verify_branches=False)
             branches_to_slide_out: Optional[List[str]] = parsed_cli_as_dict.get('branches')
             if cli_opts.opt_removed_from_remote:
                 if (branches_to_slide_out or cli_opts.opt_down_fork_point or cli_opts.opt_merge or
@@ -1086,8 +995,8 @@ def launch_internal(orig_args: List[str]) -> None:
                 slide_out_client.slide_out_removed_from_remote(opt_delete=cli_opts.opt_delete)
             else:
                 slide_out_client.slide_out(
-                    branches_to_slide_out=[LocalBranchShortName.of(branch)
-                                           for branch in (branches_to_slide_out or [git.get_current_branch()])],
+                    opt_branches=([LocalBranchShortName.of(branch) for branch in branches_to_slide_out]
+                                  if branches_to_slide_out else None),
                     opt_delete=cli_opts.opt_delete,
                     opt_down_fork_point=cli_opts.opt_down_fork_point,
                     opt_merge=cli_opts.opt_merge,
@@ -1095,15 +1004,11 @@ def launch_internal(orig_args: List[str]) -> None:
                     opt_no_interactive_rebase=cli_opts.opt_no_interactive_rebase,
                     opt_no_rebase=cli_opts.opt_no_rebase)
         elif cmd == "squash":
-            squash_client = SquashMacheteClient(git)
-            squash_client.read_branch_layout_file()
-            squash_client.squash(
-                current_branch=git.get_current_branch(),
-                opt_fork_point=cli_opts.opt_fork_point)
+            SquashMacheteClient().squash(opt_fork_point=cli_opts.opt_fork_point)
         elif cmd in {"status", alias_by_command["status"]}:
             opt_squash_merge_detection = squash_merge_detection()
-            status_client = StatusMacheteClient(git)
-            status_client.read_branch_layout_file(interactively_slide_out_invalid_branches=terminal.is_stdout_a_tty())
+            status_client = StatusMacheteClient(
+                interactively_slide_out_invalid_branches=terminal.is_stdout_a_tty())
             status_client.expect_at_least_one_managed_branch()
             status_client.status(
                 warn_when_branch_in_sync_but_fork_point_off=True,
@@ -1113,11 +1018,10 @@ def launch_internal(orig_args: List[str]) -> None:
         elif cmd in {"traverse", alias_by_command["traverse"]}:
             opt_squash_merge_detection = squash_merge_detection()
             opt_return_to = TraverseReturnTo.from_string(cli_opts.opt_return_to, "`--return-to` flag")
-            opt_start_from = TraverseStartFrom.from_string_or_branch(cli_opts.opt_start_from, git)
 
             spec = GITHUB_API_SPEC if cli_opts.opt_sync_github_prs else GITLAB_API_SPEC
-            traverse_client = TraverseMacheteClient(git, spec)
-            traverse_client.read_branch_layout_file(interactively_slide_out_invalid_branches=terminal.is_stdout_a_tty())
+            traverse_client = TraverseMacheteClient(
+                spec, interactively_slide_out_invalid_branches=terminal.is_stdout_a_tty())
             traverse_client.traverse(
                 opt_fetch=cli_opts.opt_fetch,
                 opt_list_commits=cli_opts.opt_list_commits,
@@ -1128,15 +1032,13 @@ def launch_internal(orig_args: List[str]) -> None:
                 opt_push_untracked=cli_opts.opt_push_untracked,
                 opt_return_to=opt_return_to,
                 opt_squash_merge_detection=opt_squash_merge_detection,
-                opt_start_from=opt_start_from,
+                opt_start_from=cli_opts.opt_start_from,
                 opt_stop_after=cli_opts.opt_stop_after,
                 opt_sync_github_prs=cli_opts.opt_sync_github_prs,
                 opt_sync_gitlab_mrs=cli_opts.opt_sync_gitlab_mrs,
                 opt_yes=cli_opts.opt_yes)
         elif cmd == "update":
-            update_client = UpdateMacheteClient(git)
-            update_client.read_branch_layout_file()
-            update_client.update(
+            UpdateMacheteClient().update(
                 opt_merge=cli_opts.opt_merge,
                 opt_no_edit_merge=cli_opts.opt_no_edit_merge,
                 opt_no_interactive_rebase=cli_opts.opt_no_interactive_rebase,

--- a/git_machete/client/advance.py
+++ b/git_machete/client/advance.py
@@ -1,14 +1,11 @@
 from git_machete.client.base import MacheteClient
 from git_machete.config import SquashMergeDetection
-from git_machete.git import Git, LocalBranchShortName, SyncToRemoteStatus
+from git_machete.git import LocalBranchShortName, SyncToRemoteStatus
 from git_machete.utils.exceptions import MacheteException
 from git_machete.utils.markup import pretty_choices, warn
 
 
 class AdvanceMacheteClient(MacheteClient):
-    def __init__(self, git: Git) -> None:
-        super().__init__(git)
-
     def advance(self, *, opt_yes: bool) -> None:
         self._git.expect_no_operation_in_progress()
 

--- a/git_machete/client/anno.py
+++ b/git_machete/client/anno.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from git_machete.annotation import Annotation
 from git_machete.client.with_code_hosting import MacheteClientWithCodeHosting
@@ -6,14 +6,18 @@ from git_machete.git import LocalBranchShortName
 
 
 class AnnoMacheteClient(MacheteClientWithCodeHosting):
-    def annotate(self, branch: LocalBranchShortName, words: List[str]) -> None:
+    def annotate(self, *, opt_branch: Optional[LocalBranchShortName], words: List[str]) -> None:
+        branch = opt_branch or self._git.get_current_branch()
+        self.expect_in_managed_branches(branch)
         if self._state.has_annotation(branch) and words == ['']:
             self._state.delete_annotation(branch)
         else:
             self._state.set_annotation(branch, Annotation.parse(" ".join(words)))
         self.save_branch_layout_file()
 
-    def print_annotation(self, branch: LocalBranchShortName) -> None:
+    def print_annotation(self, *, opt_branch: Optional[LocalBranchShortName]) -> None:
+        branch = opt_branch or self._git.get_current_branch()
+        self.expect_in_managed_branches(branch)
         anno = self._state.get_annotation(branch)
         if anno is not None:
             print(anno.text_without_qualifiers)

--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -34,10 +34,14 @@ class MacheteClient:
 
     # === Initialization ===
 
-    def __init__(self, git: Git) -> None:
-        self._git: Git = git
-        self._config: MacheteConfig = MacheteConfig(git)
-        git.owner = self
+    def __init__(self, *, read_layout_file: bool = True, verify_branches: bool = True,
+                 interactively_slide_out_invalid_branches: bool = False) -> None:
+        # Clients own their `Git` plumbing instance - command-dispatch code
+        # (`cli.py`) and tests never touch it directly. Pass-throughs are
+        # avoided in favour of domain-specific methods on the client itself.
+        self._git: Git = Git()
+        self._config: MacheteConfig = MacheteConfig(self._git)
+        self._git.owner = self
 
         self._branch_layout_file_path: AbsPath = self.__get_git_machete_branch_layout_file_path()
         # Cwd-relative rendition of the layout path, captured at init time
@@ -64,6 +68,18 @@ class MacheteClient:
                 "rather than a regular file, aborting")
 
         self.__init_state()
+
+        # Load the layout file as part of construction so that callers
+        # consistently get a ready-to-use client; subclasses don't need
+        # to remember a separate `client.read_branch_layout_file(...)`
+        # step (and easily get its flags wrong for the command at hand).
+        # `read_layout_file=False` is for the few commands (`edit`, `file`)
+        # that must work even when the layout file is malformed - their
+        # whole point is to let the user inspect or fix it.
+        if read_layout_file:
+            self.read_branch_layout_file(
+                verify_branches=verify_branches,
+                interactively_slide_out_invalid_branches=interactively_slide_out_invalid_branches)
 
     def __get_git_machete_branch_layout_file_path(self) -> AbsPath:
         if self._config.worktree_use_top_level_machete_file():
@@ -95,6 +111,10 @@ class MacheteClient:
 
     def children_of(self, branch: LocalBranchShortName) -> Optional[List[LocalBranchShortName]]:
         return self._state.get_children(branch)
+
+    def is_managed(self, *, opt_branch: Optional[LocalBranchShortName]) -> bool:
+        branch = opt_branch or self._git.get_current_branch_or_none()
+        return branch is not None and branch in self.managed_branches
 
     # === Branch existence assertions ===
 
@@ -544,7 +564,7 @@ class MacheteClient:
 
     def add(self,
             *,
-            branch: LocalBranchShortName,
+            opt_branch: Optional[LocalBranchShortName],
             opt_onto: Optional[LocalBranchShortName],
             opt_as_first_child: bool,
             opt_as_root: bool,
@@ -552,6 +572,7 @@ class MacheteClient:
             verbose: bool,
             switch_head_if_new_branch: bool
             ) -> None:
+        branch = opt_branch or self._git.get_current_branch()
         if branch in self.managed_branches:
             raise MacheteException(f"Branch <b>{branch}</b> already exists in the tree of branch dependencies")
 

--- a/git_machete/client/fork_point.py
+++ b/git_machete/client/fork_point.py
@@ -1,13 +1,16 @@
 import sys
+from typing import Optional
 
 from git_machete.client.base import MacheteClient
 from git_machete.git import AnyRevision, LocalBranchShortName
 from git_machete.utils.exceptions import MacheteException
-from git_machete.utils.markup import print_fmt
+from git_machete.utils.markup import print_fmt, warn
 
 
 class ForkPointMacheteClient(MacheteClient):
-    def print_fork_point(self, branch: LocalBranchShortName, *, use_overrides: bool, explain: bool) -> None:
+    def print_fork_point(self, *, opt_branch: Optional[LocalBranchShortName],
+                         use_overrides: bool, explain: bool) -> None:
+        branch = self._resolve_branch(opt_branch=opt_branch)
         if explain:
             fork_point, pairs = self.fork_point_and_inferring_branch_pairs(branch=branch, use_overrides=use_overrides)
             print(fork_point)
@@ -22,12 +25,53 @@ class ForkPointMacheteClient(MacheteClient):
         else:
             print(self.fork_point(branch=branch, use_overrides=use_overrides))
 
-    def unset_fork_point_override(self, branch: LocalBranchShortName) -> None:
+    def unset_fork_point_override(self, *, opt_branch: Optional[LocalBranchShortName]) -> None:
+        branch = self._resolve_branch(opt_branch=opt_branch)
         self._config.unset_fork_point_override_to(branch)
         # We still unset the now-deprecated `whileDescendantOf` key.
         self._config.unset_fork_point_override_while_descendant_of(branch)
 
-    def set_fork_point_override(self, branch: LocalBranchShortName, to_revision: AnyRevision) -> None:  # noqa: KW
+    def override_fork_point_to(self, *, opt_branch: Optional[LocalBranchShortName],
+                               to_revision: AnyRevision, deprecated_flag_label: str,
+                               revision_label: str) -> None:
+        """Override the fork point of the chosen branch to `to_revision`,
+        then emit a deprecation warning nudging the user toward the
+        `update --fork-point=...` workflow.
+
+        `deprecated_flag_label` is the human-readable name of the
+        `fork-point` flag the user invoked, e.g. `"--override-to=..."`;
+        `revision_label` is the noun phrase used in the warning to
+        describe `to_revision` (e.g. `"selected commit"` or
+        `"inferred commit"`).
+        """
+        branch = self._resolve_branch(opt_branch=opt_branch)
+        self._set_fork_point_override(branch=branch, to_revision=to_revision)
+        self._warn_on_deprecated_override(
+            branch=branch, flag=deprecated_flag_label,
+            revision=to_revision, revision_label=revision_label)
+
+    def override_fork_point_to_inferred(self, *, opt_branch: Optional[LocalBranchShortName]) -> None:
+        branch = self._resolve_branch(opt_branch=opt_branch)
+        inferred = self.fork_point(branch=branch, use_overrides=False)
+        self._set_fork_point_override(branch=branch, to_revision=inferred)
+        self._warn_on_deprecated_override(
+            branch=branch, flag="--override-to-inferred",
+            revision=inferred, revision_label="inferred commit")
+
+    def override_fork_point_to_parent(self, *, opt_branch: Optional[LocalBranchShortName]) -> None:
+        branch = self._resolve_branch(opt_branch=opt_branch)
+        parent = self.parent_of(branch)
+        if parent is None:
+            raise MacheteException(
+                f"Branch <b>{branch}</b> does not have upstream (parent) branch")
+        self._set_fork_point_override(branch=branch, to_revision=parent)
+
+    def _resolve_branch(self, *, opt_branch: Optional[LocalBranchShortName]) -> LocalBranchShortName:
+        branch = opt_branch or self._git.get_current_branch()
+        self.expect_in_local_branches(branch)
+        return branch
+
+    def _set_fork_point_override(self, *, branch: LocalBranchShortName, to_revision: AnyRevision) -> None:
         to_hash = self._git.get_commit_hash_by_revision(to_revision)
         if not to_hash:
             raise MacheteException(f"Cannot find revision <b>{to_revision}</b>")
@@ -42,6 +86,28 @@ class ForkPointMacheteClient(MacheteClient):
         short_hash = self._git.get_short_commit_hash_by_revision(to_hash)
         print_fmt(f"Fork point for <b>{branch}</b> is overridden to {self._get_revision_repr(to_revision)}.\n"
                   f"This applies as long as <b>{branch}</b> points to commit <b>{short_hash}</b> or its descendant.")
+
+    def _warn_on_deprecated_override(
+            self, *, branch: LocalBranchShortName, flag: str,
+            revision: AnyRevision, revision_label: str) -> None:
+        parent = self.parent_of(branch)
+        # It's unlikely that anyone overrides fork point for a branch that doesn't have a parent,
+        # also it's unclear what the suggested action should even be - so we just skip the case.
+        if parent is None:
+            return
+        short_hash = self._git.get_short_commit_hash_by_revision_or_none(revision) or ''
+        print()
+        warn(
+            f"`git machete fork-point {flag}` may lead to a confusing user experience and is deprecated.\n\n"
+            f"If the commits between <b>{parent}</b> (parent of <b>{branch}</b>) "
+            f"and {revision_label} <b>{short_hash}</b> "
+            f"do NOT belong to <b>{branch}</b>, consider using:\n"
+            f"    `git checkout {branch}`\n"
+            f"    `git machete update --fork-point=\"{revision}\"`\n\n"
+            "Otherwise, if you're okay with treating these commits "
+            f"as a part of <b>{branch}</b>'s unique history, use instead:\n"
+            f"    `git machete fork-point {branch} --override-to-parent`"
+        )
 
     def _get_revision_repr(self, revision: AnyRevision) -> str:
         short_hash = self._git.get_short_commit_hash_by_revision_or_none(revision)

--- a/git_machete/client/go_interactive.py
+++ b/git_machete/client/go_interactive.py
@@ -15,7 +15,7 @@ from git_machete.git import LocalBranchShortName
 from git_machete.utils.collections import index_or_none
 from git_machete.utils.exceptions import (MacheteException,
                                           UnexpectedMacheteException)
-from git_machete.utils.markup import print_fmt, warn
+from git_machete.utils.markup import green_ok, print_fmt, warn
 from git_machete.utils.terminal import (AnsiInputCodes,
                                         BasicTerminalAnsiOutputCodes,
                                         FullTerminalAnsiOutputCodes,
@@ -120,12 +120,22 @@ class GoInteractiveMacheteClient(StatusMacheteClient):
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
 
-    def go_interactive(self, *, current_branch: Optional[LocalBranchShortName]) -> Optional[LocalBranchShortName]:
+    def go_interactive(self) -> None:
         """
-        Launch interactive branch selection interface.
-        Returns the selected branch or None if cancelled.
+        Launch interactive branch selection interface, then check out the chosen branch.
         Status data is computed once at start; only rendering (format_status_output) runs on each redraw.
         """
+        self._git.expect_no_operation_in_progress()
+        self.expect_at_least_one_managed_branch()
+        current_branch = self._git.get_current_branch_or_none()
+        selected_branch = self._pick_branch_interactively(current_branch=current_branch)
+        if selected_branch is not None and selected_branch != current_branch:
+            print()
+            print_fmt(f"Checking out <b>{selected_branch}</b>... ", newline=False)
+            self._git.checkout(selected_branch)
+            print_fmt(green_ok())
+
+    def _pick_branch_interactively(self, *, current_branch: Optional[LocalBranchShortName]) -> Optional[LocalBranchShortName]:
         if termios is None or tty is None:
             raise UnexpectedMacheteException("Interactive mode is not supported on Windows yet")
         if not terminal.is_stdout_a_tty():

--- a/git_machete/client/go_show.py
+++ b/git_machete/client/go_show.py
@@ -4,6 +4,7 @@ from git_machete.client.base import MacheteClient, PickRoot
 from git_machete.git import LocalBranchShortName
 from git_machete.utils.exceptions import (MacheteException,
                                           UnexpectedMacheteException)
+from git_machete.utils.markup import green_ok, print_fmt
 
 
 class GoShowMacheteClient(MacheteClient):
@@ -61,7 +62,21 @@ class GoShowMacheteClient(MacheteClient):
         else:
             return children
 
-    def parse_direction(
+    def go(self, direction: str) -> None:
+        self._git.expect_no_operation_in_progress()
+        current_branch = self._git.get_current_branch_or_none()
+        # with pick_if_multiple=True, the returned list will have exactly one element
+        dest = self._parse_direction(direction, branch=current_branch, allow_current=False, pick_if_multiple=True)[0]
+        if dest != current_branch:
+            print_fmt(f"Checking out <b>{dest}</b>... ", newline=False)
+            self._git.checkout(dest)
+            print_fmt(green_ok())
+
+    def show(self, direction: str, *, opt_branch: Optional[LocalBranchShortName]) -> None:
+        branch = opt_branch or self._git.get_current_branch_or_none()
+        print('\n'.join(self._parse_direction(direction, branch=branch, allow_current=True, pick_if_multiple=False)))
+
+    def _parse_direction(
         self,
         param: str,
         *,

--- a/git_machete/client/log.py
+++ b/git_machete/client/log.py
@@ -1,11 +1,12 @@
-from typing import List
+from typing import List, Optional
 
 from git_machete.client.base import MacheteClient
 from git_machete.git import LocalBranchShortName
 
 
 class LogMacheteClient(MacheteClient):
-    def display_log(self, branch: LocalBranchShortName, extra_git_log_args: List[str]) -> None:
+    def display_log(self, *, opt_branch: Optional[LocalBranchShortName], extra_git_log_args: List[str]) -> None:
+        branch = opt_branch or self._git.get_current_branch()
         fork_point = self.fork_point(branch, use_overrides=True)
         self._git.display_log_between(from_inclusive=branch.full_name(), until_exclusive=fork_point,
                                       extra_git_log_args=extra_git_log_args)

--- a/git_machete/client/rename.py
+++ b/git_machete/client/rename.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from git_machete.client.base import MacheteClient
 from git_machete.git import LocalBranchShortName, RemoteBranchShortName
 from git_machete.utils.exceptions import MacheteException
@@ -8,9 +10,10 @@ class RenameMacheteClient(MacheteClient):
 
     def rename(self,
                *,
-               branch: LocalBranchShortName,
+               opt_branch: Optional[LocalBranchShortName],
                new_name: LocalBranchShortName,
                opt_repoint_tracking: bool) -> None:
+        branch = opt_branch or self._git.get_current_branch()
         self.expect_in_managed_branches(branch)
         if new_name == branch:
             raise MacheteException(f"Branch is already named <b>{branch}</b>")

--- a/git_machete/client/slide_out.py
+++ b/git_machete/client/slide_out.py
@@ -10,7 +10,7 @@ from git_machete.utils.markup import green_ok, print_fmt
 class SlideOutMacheteClient(MacheteClient):
     def slide_out(self,
                   *,
-                  branches_to_slide_out: List[LocalBranchShortName],
+                  opt_branches: Optional[List[LocalBranchShortName]],
                   opt_delete: bool,
                   opt_down_fork_point: Optional[AnyRevision],
                   opt_merge: bool,
@@ -19,6 +19,7 @@ class SlideOutMacheteClient(MacheteClient):
                   opt_no_rebase: bool
                   ) -> None:
         self._git.expect_no_operation_in_progress()
+        branches_to_slide_out: List[LocalBranchShortName] = opt_branches or [self._git.get_current_branch()]
 
         # Verify that all branches exist, are managed and are NOT annotated with slide-out=no qualifier.
         for branch in branches_to_slide_out:

--- a/git_machete/client/squash.py
+++ b/git_machete/client/squash.py
@@ -3,14 +3,15 @@ from typing import List, Optional
 
 from git_machete.client.base import MacheteClient
 from git_machete.git import (AnyRevision, FullCommitHash, GitFormatPatterns,
-                             GitLogEntry, LocalBranchShortName)
+                             GitLogEntry)
 from git_machete.utils.exceptions import MacheteException
 from git_machete.utils.markup import print_fmt
 
 
 class SquashMacheteClient(MacheteClient):
-    def squash(self, *, current_branch: LocalBranchShortName, opt_fork_point: Optional[AnyRevision]) -> None:
+    def squash(self, *, opt_fork_point: Optional[AnyRevision]) -> None:
         self._git.expect_no_operation_in_progress()
+        current_branch = self._git.get_current_branch()
         if opt_fork_point is not None:
             self.check_that_fork_point_is_ancestor_or_equal_to_tip_of_branch(
                 fork_point=opt_fork_point, branch=current_branch)

--- a/git_machete/client/traverse.py
+++ b/git_machete/client/traverse.py
@@ -9,7 +9,7 @@ from git_machete.client.with_code_hosting import MacheteClientWithCodeHosting
 from git_machete.code_hosting import CodeHostingSpec, PullRequest
 from git_machete.config import (SquashMergeDetection,
                                 TraverseWhenBranchNotCheckedOutInAnyWorktree)
-from git_machete.git import Git, LocalBranchShortName, SyncToRemoteStatus
+from git_machete.git import LocalBranchShortName, SyncToRemoteStatus
 from git_machete.utils.exceptions import (MacheteException, ParsableEnum,
                                           UnexpectedMacheteException)
 from git_machete.utils.markup import green_ok, pretty_choices, print_fmt, warn
@@ -29,11 +29,9 @@ class TraverseStartFrom(ParsableEnum):
 
     @classmethod
     def from_string_or_branch(cls: Type['TraverseStartFrom'], value: str,
-                              git_context: Git) -> Union['TraverseStartFrom', LocalBranchShortName]:
+                              local_branches: List[LocalBranchShortName]) -> Union['TraverseStartFrom', LocalBranchShortName]:
         """Parse value as enum (case-insensitive) or as branch name.
         If value matches both a special value and an existing branch name, the branch takes priority."""
-        local_branches = git_context.get_local_branches()
-
         # Check if it's an existing branch name first (gives priority to actual branches)
         # This handles exact matches (case-sensitive)
         if value in local_branches:
@@ -49,8 +47,12 @@ class TraverseStartFrom(ParsableEnum):
 
 class TraverseMacheteClient(MacheteClientWithCodeHosting):
 
-    def __init__(self, git: Git, spec: CodeHostingSpec):
-        super().__init__(git, spec)
+    def __init__(self, spec: CodeHostingSpec, *, read_layout_file: bool = True,
+                 verify_branches: bool = True,
+                 interactively_slide_out_invalid_branches: bool = False):
+        super().__init__(spec, read_layout_file=read_layout_file,
+                         verify_branches=verify_branches,
+                         interactively_slide_out_invalid_branches=interactively_slide_out_invalid_branches)
         self.__temporary_worktree_path: Optional[AbsPath] = None
         self.__dir_before_temporary_worktree: Optional[AbsPath] = None
         self.__worktree_root_dir_for_branch: Dict[LocalBranchShortName, AbsPath] = {}
@@ -153,7 +155,7 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
             opt_push_untracked: bool,
             opt_return_to: TraverseReturnTo,
             opt_squash_merge_detection: SquashMergeDetection,
-            opt_start_from: Union[TraverseStartFrom, LocalBranchShortName],
+            opt_start_from: str,
             opt_stop_after: Optional[LocalBranchShortName],
             opt_sync_github_prs: bool,
             opt_sync_gitlab_mrs: bool,
@@ -161,6 +163,7 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
     ) -> None:
         self._git.expect_no_operation_in_progress()
         self.expect_at_least_one_managed_branch()
+        start_from = TraverseStartFrom.from_string_or_branch(opt_start_from, self._git.get_local_branches())
 
         if opt_stop_after is not None:
             self.expect_in_managed_branches(opt_stop_after)
@@ -191,29 +194,29 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
         self.__worktree_root_dir_for_branch = self._git.get_worktree_root_dirs_by_branch()
 
         try:
-            if opt_start_from == TraverseStartFrom.ROOT:
+            if start_from == TraverseStartFrom.ROOT:
                 dest = self.root_branch_for(self._git.get_current_branch(), if_unmanaged=PickRoot.FIRST)
                 self._ensure_blank_separator()
                 self._switch_branch(dest, custom_checkout_message=f"Checking out the root branch (<b>{dest}</b>)")
                 current_branch = dest
-            elif opt_start_from == TraverseStartFrom.FIRST_ROOT:
+            elif start_from == TraverseStartFrom.FIRST_ROOT:
                 # Note that we already ensured that there is at least one managed branch.
                 dest = self.managed_branches[0]
                 self._ensure_blank_separator()
                 root_qualifier = "first root" if len(self._state.roots) > 1 else "root"  # property returns a copy
                 self._switch_branch(dest, custom_checkout_message=f"Checking out the {root_qualifier} branch (<b>{dest}</b>)")
                 current_branch = dest
-            elif opt_start_from == TraverseStartFrom.HERE:
+            elif start_from == TraverseStartFrom.HERE:
                 current_branch = self._git.get_current_branch()
                 self.expect_in_managed_branches(current_branch)
-            elif isinstance(opt_start_from, LocalBranchShortName):
-                dest = opt_start_from
+            elif isinstance(start_from, LocalBranchShortName):
+                dest = start_from
                 self.expect_in_managed_branches(dest)
                 self._ensure_blank_separator()
                 self._switch_branch(dest)
                 current_branch = dest
             else:
-                raise UnexpectedMacheteException(f"Unexpected value for opt_start_from: {opt_start_from}")
+                raise UnexpectedMacheteException(f"Unexpected value for opt_start_from: {start_from}")
 
             branch: LocalBranchShortName
             for branch in itertools.dropwhile(lambda x: x != current_branch, self.managed_branches.copy()):
@@ -505,7 +508,6 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
                         opt_yes=opt_yes)
                     if ans in ('y', 'yes', 'yq', 'd', 'draft'):
                         self.create_pull_request(
-                            head=current_branch,
                             opt_base=None,
                             opt_draft=(ans in ('d', 'draft')),
                             opt_title=None,

--- a/git_machete/client/with_code_hosting.py
+++ b/git_machete/client/with_code_hosting.py
@@ -9,7 +9,7 @@ from git_machete.code_hosting import (CodeHostingApi, CodeHostingSpec,
                                       OrganizationAndRepositoryAndRemote,
                                       PullRequest, is_matching_remote_url)
 from git_machete.config import PRDescriptionIntroStyle, SquashMergeDetection
-from git_machete.git import (Git, GitFormatPatterns, GitLogEntry,
+from git_machete.git import (GitFormatPatterns, GitLogEntry,
                              LocalBranchShortName, RemoteBranchShortName,
                              SyncToRemoteStatus)
 from git_machete.utils.collections import find_or_none, get_non_empty_lines
@@ -25,8 +25,12 @@ from ..utils import date
 
 
 class MacheteClientWithCodeHosting(StatusMacheteClient):
-    def __init__(self, git: Git, spec: CodeHostingSpec):
-        super().__init__(git)
+    def __init__(self, spec: CodeHostingSpec, *, read_layout_file: bool = True,
+                 verify_branches: bool = True,
+                 interactively_slide_out_invalid_branches: bool = False):
+        super().__init__(read_layout_file=read_layout_file,
+                         verify_branches=verify_branches,
+                         interactively_slide_out_invalid_branches=interactively_slide_out_invalid_branches)
         self.__code_hosting_spec: CodeHostingSpec = spec
         self.__code_hosting_client: Optional[CodeHostingApi] = None
         self.__all_open_prs: Optional[List[PullRequest]] = None
@@ -127,7 +131,7 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
 
         current_branch = self._git.get_current_branch()
         if current_branch not in self.managed_branches:
-            self.add(branch=current_branch,
+            self.add(opt_branch=current_branch,
                      opt_onto=None,
                      opt_as_first_child=False,
                      opt_as_root=False,
@@ -230,13 +234,13 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
     def create_pull_request(
             self,
             *,
-            head: LocalBranchShortName,
             opt_base: Optional[LocalBranchShortName],
             opt_draft: bool,
             opt_title: Optional[str],
             opt_update_related_descriptions: bool,
             opt_yes: bool
     ) -> None:
+        head: LocalBranchShortName = self._git.get_current_branch()
         # Use provided base branch if --base flag is specified (undocumented), otherwise use parent branch from .git/machete
         base: Optional[LocalBranchShortName] = opt_base or self.parent_of(LocalBranchShortName.of(head))
         spec = self.code_hosting_spec
@@ -456,7 +460,7 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
                 print_fmt(f'{pr.display_text()} has been temporarily marked as draft')
 
             # Note that retarget should happen BEFORE push, see issue #1222
-            self.retarget_pull_request(head, opt_ignore_if_missing=False,
+            self.retarget_pull_request(opt_branch=head, opt_ignore_if_missing=False,
                                        opt_update_related_descriptions=opt_update_related_descriptions)
 
             if s == SyncToRemoteStatus.AHEAD_OF_REMOTE:
@@ -509,7 +513,7 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             else:  # case handled elsewhere
                 raise UnexpectedMacheteException(f"Could not retarget {spec.pr_full_name}: invalid sync-to-remote status `{s}`.")
 
-            self.retarget_pull_request(head, opt_ignore_if_missing=False,
+            self.retarget_pull_request(opt_branch=head, opt_ignore_if_missing=False,
                                        opt_update_related_descriptions=opt_update_related_descriptions)
 
     def _get_updated_pull_request_description(self, pr: PullRequest) -> str:
@@ -533,8 +537,10 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             lines = lines_to_prepend + ([''] if lines_to_prepend else []) + skip_leading_empty(lines)
         return '\n'.join(lines) + original_trailing_newlines
 
-    def retarget_pull_request(self, head: LocalBranchShortName, *,
+    def retarget_pull_request(self, *, opt_branch: Optional[LocalBranchShortName],
                               opt_ignore_if_missing: bool, opt_update_related_descriptions: bool) -> None:
+        head: LocalBranchShortName = opt_branch or self._git.get_current_branch()
+        self.expect_in_managed_branches(head)
         spec = self.code_hosting_spec
         if self.__code_hosting_client is None:
             self._init_code_hosting_client(branch_used_for_tracking_data=head)
@@ -884,7 +890,7 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             reversed_pr_path: List[PullRequest] = pr_path[::-1]  # need to add from root downwards
             if reversed_pr_path[0].base not in self.managed_branches:
                 self.add(
-                    branch=LocalBranchShortName.of(reversed_pr_path[0].base),
+                    opt_branch=LocalBranchShortName.of(reversed_pr_path[0].base),
                     opt_as_first_child=False,
                     opt_as_root=True,
                     opt_onto=None,
@@ -894,7 +900,7 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             for pr_on_path in reversed_pr_path:
                 if pr_on_path.head not in self.managed_branches:
                     self.add(
-                        branch=LocalBranchShortName.of(pr_on_path.head),
+                        opt_branch=LocalBranchShortName.of(pr_on_path.head),
                         opt_onto=LocalBranchShortName.of(pr_on_path.base),
                         opt_as_first_child=False,
                         opt_as_root=False,

--- a/git_machete/config.py
+++ b/git_machete/config.py
@@ -50,8 +50,13 @@ class MacheteConfig:
     _TRAVERSE_WHEN_BRANCH_NOT_CHECKED_OUT_IN_ANY_WORKTREE = 'machete.traverse.whenBranchNotCheckedOutInAnyWorktree'
     _WORKTREE_USE_TOP_LEVEL_MACHETE_FILE = 'machete.worktree.useTopLevelMacheteFile'
 
-    def __init__(self, git: Git) -> None:
-        self._git: Git = git
+    def __init__(self, git: Optional[Git] = None) -> None:
+        # Default-construct `Git` so that early-startup code in `cli.py` can
+        # read a config key (e.g. `machete.traverse.push`) without having to
+        # build a `Git` instance itself just to feed it here. Clients that
+        # already own a `Git` (i.e. `MacheteClient`) keep passing it in to
+        # share the underlying caches.
+        self._git: Git = git if git is not None else Git()
 
     def advice_machete_editor_selection(self) -> bool:
         return self._git.get_config_attr_or_none(self._ADVICE_MACHETE_EDITOR_SELECTION) != 'false'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,6 @@
 from git_machete.annotation import Annotation
 from git_machete.client.base import MacheteClient
-from git_machete.git import Git, LocalBranchShortName
+from git_machete.git import LocalBranchShortName
 
 from .base_test import BaseTest
 from .cli_runner import read_branch_layout_file, rewrite_branch_layout_file
@@ -54,8 +54,7 @@ class TestClient(BaseTest):
             feature8 annotation rebase=no push=no rebase=no push=no
             """
         rewrite_branch_layout_file(body)
-        machete_client = MacheteClient(Git())
-        machete_client.read_branch_layout_file(interactively_slide_out_invalid_branches=False)
+        machete_client = MacheteClient()
 
         def anno(branch_name: str) -> Annotation:
             result = machete_client._state.get_annotation(LocalBranchShortName.of(branch_name))
@@ -121,8 +120,7 @@ class TestClient(BaseTest):
             # develop
               feature
             """)
-        machete_client = MacheteClient(Git())
-        machete_client.read_branch_layout_file(interactively_slide_out_invalid_branches=False)
+        machete_client = MacheteClient()
 
         assert machete_client.managed_branches == [
             LocalBranchShortName.of('master'),
@@ -145,8 +143,7 @@ class TestClient(BaseTest):
             master
             feature  note #123
             """)
-        machete_client = MacheteClient(Git())
-        machete_client.read_branch_layout_file(interactively_slide_out_invalid_branches=False)
+        machete_client = MacheteClient()
 
         feature = LocalBranchShortName.of('feature')
         assert machete_client.managed_branches == [
@@ -170,8 +167,7 @@ class TestClient(BaseTest):
             master
             # feature
             """)
-        machete_client = MacheteClient(Git())
-        machete_client.read_branch_layout_file(interactively_slide_out_invalid_branches=False)
+        machete_client = MacheteClient()
         machete_client.save_branch_layout_file()
 
         assert '#' not in read_branch_layout_file()


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1678

## Chain of upstream PRs as of 2026-05-14

* PR #1678:
  `master` ← `develop`

  * **PR #1687 (THIS ONE)**:
    `develop` ← `refactor/git-out-of-cli`

<!-- end git-machete generated -->

`cli.py` no longer constructs a `Git` instance or calls `git.X()` /
`client.read_branch_layout_file(...)` directly. Each command branch
now reads as a one-/two-liner that delegates the whole flow (current-
branch resolution, no-op-in-progress checks, layout-file loading,
post-action checkout) to a domain-specific method on the appropriate
client subclass. `MacheteClient.__init__` constructs its own `Git`,
`MacheteConfig` default-constructs one too, and the layout file is
loaded as part of client construction (with per-command flags like
`verify_branches` / `interactively_slide_out_invalid_branches` /
`read_layout_file` set at the construction site rather than via a
separate follow-up call).