### PR TITLE
Introduce `ManagedBranchName` as a subtype of `LocalBranchShortName`

### DIFF
--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -922,7 +922,7 @@ def launch_internal(orig_args: List[str]) -> None:
                 raise MacheteException(f"`git machete list {category}` does not expect extra arguments")
 
             list_client = ListMacheteClient()
-            res = []
+            res: Sequence[LocalBranchShortName] = []
             if category == "addable":
                 res = list_client.addable_branches()
             elif category == "childless":

--- a/git_machete/client/advance.py
+++ b/git_machete/client/advance.py
@@ -9,8 +9,7 @@ class AdvanceMacheteClient(MacheteClient):
     def advance(self, *, opt_yes: bool) -> None:
         self._git.expect_no_operation_in_progress()
 
-        branch = self._git.get_current_branch()
-        self.expect_in_managed_branches(branch)
+        branch = self.expect_in_managed_branches(self._git.get_current_branch())
 
         children = self.children_of(branch)
         if not children:

--- a/git_machete/client/anno.py
+++ b/git_machete/client/anno.py
@@ -7,8 +7,7 @@ from git_machete.git import LocalBranchShortName
 
 class AnnoMacheteClient(MacheteClientWithCodeHosting):
     def annotate(self, *, opt_branch: Optional[LocalBranchShortName], words: List[str]) -> None:
-        branch = opt_branch or self._git.get_current_branch()
-        self.expect_in_managed_branches(branch)
+        branch = self.expect_in_managed_branches(opt_branch or self._git.get_current_branch())
         if self._state.has_annotation(branch) and words == ['']:
             self._state.delete_annotation(branch)
         else:
@@ -16,8 +15,7 @@ class AnnoMacheteClient(MacheteClientWithCodeHosting):
         self.save_branch_layout_file()
 
     def print_annotation(self, *, opt_branch: Optional[LocalBranchShortName]) -> None:
-        branch = opt_branch or self._git.get_current_branch()
-        self.expect_in_managed_branches(branch)
+        branch = self.expect_in_managed_branches(opt_branch or self._git.get_current_branch())
         anno = self._state.get_annotation(branch)
         if anno is not None:
             print(anno.text_without_qualifiers)

--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -3,10 +3,11 @@ import shlex
 import sys
 import textwrap
 from enum import Enum, auto
-from typing import Callable, Dict, Iterator, List, NoReturn, Optional, Tuple
+from typing import (Callable, Dict, Iterator, List, NoReturn, Optional,
+                    Sequence, Tuple, TypeVar)
 
 from git_machete.client import branch_layout
-from git_machete.client.state import MacheteState
+from git_machete.client.state import MacheteState, ManagedBranchName
 from git_machete.config import MacheteConfig, SquashMergeDetection
 from git_machete.constants import (INITIAL_COMMIT_COUNT_FOR_LOG,
                                    TOTAL_COMMIT_COUNT_FOR_LOG)
@@ -23,6 +24,8 @@ from git_machete.utils.markup import input_fmt, pretty_choices, print_fmt, warn
 from git_machete.utils.paths import AbsPath, Path
 
 from ..utils import fs
+
+_BranchT = TypeVar("_BranchT", bound=LocalBranchShortName)
 
 
 class PickRoot(Enum):
@@ -103,13 +106,13 @@ class MacheteClient:
     # === Branch listing ===
 
     @property
-    def managed_branches(self) -> List[LocalBranchShortName]:
+    def managed_branches(self) -> List[ManagedBranchName]:
         return self._state.managed_branches  # returns a copy
 
-    def parent_of(self, branch: LocalBranchShortName) -> Optional[LocalBranchShortName]:
+    def parent_of(self, branch: LocalBranchShortName) -> Optional[ManagedBranchName]:
         return self._state.get_parent(branch)
 
-    def children_of(self, branch: LocalBranchShortName) -> Optional[List[LocalBranchShortName]]:
+    def children_of(self, branch: LocalBranchShortName) -> Optional[List[ManagedBranchName]]:
         return self._state.get_children(branch)
 
     def is_managed(self, *, opt_branch: Optional[LocalBranchShortName]) -> bool:
@@ -118,11 +121,16 @@ class MacheteClient:
 
     # === Branch existence assertions ===
 
-    def expect_in_managed_branches(self, branch: LocalBranchShortName) -> None:
-        if branch not in self.managed_branches:
+    def expect_in_managed_branches(self, branch: LocalBranchShortName) -> ManagedBranchName:
+        """Verify `branch` lives in the layout file; on success, narrow its
+        type to `ManagedBranchName` so the caller can pass it to layout-
+        mutating APIs without a re-check."""
+        managed = self._state.as_managed(branch)
+        if managed is None:
             raise MacheteException(
                 f"Branch <b>{branch}</b> not found in the tree of branch dependencies.\n"
                 f"Use `git machete add {branch}` or `git machete edit`.")
+        return managed
 
     def expect_in_local_branches(self, branch: LocalBranchShortName) -> None:
         if branch not in self._git.get_local_branches():
@@ -193,7 +201,7 @@ class MacheteClient:
     def save_branch_layout_file(self) -> None:
         branch_layout.save(self._branch_layout_file_path, self._state, indent=self.__indent or "  ")
 
-    def _remove_branches_from_layout(self, branches_to_delete: List[LocalBranchShortName]) -> None:
+    def _remove_branches_from_layout(self, branches_to_delete: List[ManagedBranchName]) -> None:
         for branch in branches_to_delete:
             self._state.remove_leaf(branch)
         self.save_branch_layout_file()
@@ -227,9 +235,9 @@ class MacheteClient:
                                prompt_if_inferred_msg: Optional[str],
                                prompt_if_inferred_yes_opt_msg: Optional[str]) -> LocalBranchShortName:
         if branch in self.managed_branches:
-            parent = self.parent_of(branch)
-            if parent:
-                return parent
+            managed_parent = self.parent_of(branch)
+            if managed_parent:
+                return managed_parent
             else:
                 raise MacheteException(f"Branch <b>{branch}</b> has no upstream branch")
         else:
@@ -576,8 +584,11 @@ class MacheteClient:
         if branch in self.managed_branches:
             raise MacheteException(f"Branch <b>{branch}</b> already exists in the tree of branch dependencies")
 
-        if opt_onto:
-            self.expect_in_managed_branches(opt_onto)
+        # `onto` is tracked as a `ManagedBranchName` from this point on so
+        # that the final `add_as_child(parent=...)` call type-checks; every
+        # path that assigns to it (explicit `--onto`, current branch, inferred
+        # parent) is gated on the branch being in the layout.
+        onto: Optional[ManagedBranchName] = self.expect_in_managed_branches(opt_onto) if opt_onto else None
 
         if branch not in self._git.get_local_branches():
             remote_branch: Optional[RemoteBranchShortName] = self._git.get_sole_remote_branch(branch)
@@ -594,8 +605,8 @@ class MacheteClient:
                 # Not dealing with `onto` here. If it hasn't been explicitly
                 # specified via `--onto`, we'll try to infer it now.
             else:
-                out_of = LocalBranchShortName.of(opt_onto).full_name() if opt_onto else HEAD
-                out_of_str = f"<b>{opt_onto}</b>" if opt_onto else "the current HEAD"
+                out_of = LocalBranchShortName.of(onto).full_name() if onto else HEAD
+                out_of_str = f"<b>{onto}</b>" if onto else "the current HEAD"
                 msg = (f"A local branch <b>{branch}</b> does not exist. Create out "
                        f"of {out_of_str}?" + pretty_choices('y', 'N'))
                 opt_yes_msg = (f"A local branch <b>{branch}</b> does not exist. "
@@ -603,11 +614,11 @@ class MacheteClient:
                 if self.ask_if(msg, opt_yes_msg, opt_yes=opt_yes, verbose=verbose) in ('y', 'yes'):
                     # If `--onto` hasn't been explicitly specified, let's try to
                     # assess if the current branch would be a good `onto`.
-                    if not opt_onto:
+                    if not onto:
                         current_branch = self._git.get_current_branch_or_none()
                         if self._state.roots:
                             if current_branch and current_branch in self.managed_branches:
-                                opt_onto = current_branch
+                                onto = ManagedBranchName(current_branch)
                         else:
                             if current_branch:
                                 # In this case (empty .git/machete, creating a new branch with `git machete add`)
@@ -617,7 +628,7 @@ class MacheteClient:
                                 # This section of code is only ever executed in verbose mode, but let's leave the `if` for consistency
                                 if verbose:  # pragma: no branch
                                     print_fmt(f"Added branch <b>{current_branch}</b> as a new root")
-                                opt_onto = current_branch
+                                onto = ManagedBranchName(current_branch)
                     self._git.create_branch(branch, out_of, switch_head=switch_head_if_new_branch)
                 else:
                     return
@@ -627,7 +638,7 @@ class MacheteClient:
             if verbose:
                 print_fmt(f"Added branch <b>{branch}</b> as a new root")
         else:
-            if not opt_onto:
+            if not onto:
                 parent = self._infer_parent(
                     branch,
                     condition=lambda x: x in self.managed_branches,
@@ -645,13 +656,16 @@ class MacheteClient:
                     opt_yes_msg = (f"Adding <b>{branch}</b> onto the inferred upstream"
                                    f" (parent) branch <b>{parent}</b>")
                     if self.ask_if(msg, opt_yes_msg, opt_yes=opt_yes, verbose=verbose) in ('y', 'yes'):
-                        opt_onto = parent
+                        # `_infer_parent` was filtered by `x in self.managed_branches`
+                        # above, so we can safely narrow here.
+                        onto = ManagedBranchName(parent)
                     else:
                         return
 
-            self._state.add_as_child(branch=branch, parent=opt_onto, as_first_child=opt_as_first_child)
+            assert onto is not None  # established by the `if not onto: ...` block above
+            self._state.add_as_child(branch=branch, parent=onto, as_first_child=opt_as_first_child)
             if verbose:
-                print_fmt(f"Added branch <b>{branch}</b> onto <b>{opt_onto}</b>")
+                print_fmt(f"Added branch <b>{branch}</b> onto <b>{onto}</b>")
 
         self.save_branch_layout_file()
 
@@ -665,7 +679,7 @@ class MacheteClient:
 
     def delete_untracked(self, *, opt_yes: bool) -> None:
         print_fmt("<b>Checking for untracked managed branches with no downstream...</b>")
-        branches_to_delete: List[LocalBranchShortName] = []
+        branches_to_delete: List[ManagedBranchName] = []
         for branch in self.managed_branches.copy():
             status, _ = self._git.get_combined_remote_sync_status(branch)
             if status == SyncToRemoteStatus.UNTRACKED and not self.children_of(branch):
@@ -676,7 +690,7 @@ class MacheteClient:
 
     def _delete_branches(
         self,
-        branches_to_delete: List[LocalBranchShortName],
+        branches_to_delete: Sequence[LocalBranchShortName],
         *,
         opt_squash_merge_detection: SquashMergeDetection,
         opt_yes: bool
@@ -829,7 +843,7 @@ class MacheteClient:
         *,
         new_parent: Optional[LocalBranchShortName],
         slid_out_branch: LocalBranchShortName,
-        new_children: List[LocalBranchShortName]
+        new_children: List[ManagedBranchName]
     ) -> None:
         hook_path = self._git.get_hook_path("machete-post-slide-out")
         if self._git.check_hook_executable(hook_path):
@@ -1166,7 +1180,10 @@ class MacheteClient:
         return ans
 
     @staticmethod
-    def pick(choices: List[LocalBranchShortName], name: str) -> LocalBranchShortName:
+    def pick(choices: Sequence[_BranchT], name: str) -> _BranchT:
+        # Generic in the branch type: when the caller hands us `List[ManagedBranchName]`
+        # the returned element is also a `ManagedBranchName` (not just any `LocalBranchShortName`),
+        # which matters when the result is then fed back into layout-mutating APIs.
         xs: str = "".join(f"[{index + 1}] {x}\n" for index, x in enumerate(choices))
         msg: str = xs + f"Specify {name} or hit <return> to skip: "
         try:

--- a/git_machete/client/branch_layout.py
+++ b/git_machete/client/branch_layout.py
@@ -2,7 +2,7 @@ import itertools
 from typing import Dict, List, Optional, Tuple
 
 from git_machete.annotation import Annotation
-from git_machete.client.state import MacheteState
+from git_machete.client.state import MacheteState, ManagedBranchName
 from git_machete.git import LocalBranchShortName
 from git_machete.utils.exceptions import MacheteException
 from git_machete.utils.paths import AbsPath, Path
@@ -27,7 +27,10 @@ def parse(path: AbsPath, *, display_path: Optional[Path] = None) -> Tuple[Machet
 
     state = MacheteState()
     indent: Optional[str] = None
-    at_depth: Dict[int, LocalBranchShortName] = {}
+    # Every entry has by now been handed to `state.add_branch(...)`, so a
+    # `ManagedBranchName` is the natural type for "branch at depth N-1
+    # that the next line's parent will point at".
+    at_depth: Dict[int, ManagedBranchName] = {}
     last_depth = -1
     hint = "Edit the branch layout file manually with `git machete edit`"
 
@@ -80,9 +83,9 @@ def parse(path: AbsPath, *, display_path: Optional[Path] = None) -> Tuple[Machet
                 f"for the branch <b>{branch}</b>. {hint}")
         last_depth = depth
 
-        at_depth[depth] = branch
         parent = at_depth[depth - 1] if depth else None
         state.add_branch(branch, parent=parent, annotation=annotation)
+        at_depth[depth] = ManagedBranchName(branch)
 
     return state, indent
 

--- a/git_machete/client/discover.py
+++ b/git_machete/client/discover.py
@@ -4,6 +4,7 @@ import os
 import shutil
 from typing import List, Optional, Tuple
 
+from git_machete.client.state import ManagedBranchName
 from git_machete.client.status import StatusMacheteClient
 from git_machete.config import SquashMergeDetection
 from git_machete.constants import DISCOVER_DEFAULT_FRESH_BRANCH_COUNT
@@ -43,10 +44,10 @@ class DiscoverMacheteClient(StatusMacheteClient):
                 initial_roots.append(LocalBranchShortName.of("main"))
             if "develop" in self._git.get_local_branches():
                 initial_roots.append(LocalBranchShortName.of("develop"))
-        for branch in self._state.managed_branches:
-            anno = self._state.get_annotation(branch)
+        for managed in self._state.managed_branches:
+            anno = self._state.get_annotation(managed)
             if anno is not None:
-                self._state.set_annotation(branch, anno._replace(text_without_qualifiers=''))
+                self._state.set_annotation(managed, anno._replace(text_without_qualifiers=''))
         self._state.reset_tree(initial_roots)
 
         root_of = dict((branch, branch) for branch in all_local_branches)
@@ -119,7 +120,9 @@ class DiscoverMacheteClient(StatusMacheteClient):
                 % (", ".join(f"<b>{branch}</b>" for branch in merged_branches_to_skip),
                    "it's" if len(merged_branches_to_skip) == 1 else "they're"))
             for branch in merged_branches_to_skip:
-                self._state.detach_leaf(branch)
+                # Every fresh branch was wired into state above (`wire_as_child`/`wire_as_root`)
+                # before being collected here, so narrowing to `ManagedBranchName` is safe.
+                self._state.detach_leaf(ManagedBranchName(branch))
             # We're NOT applying the removal process recursively,
             # so it's theoretically possible that some merged branches became childless
             # after removing the outer layer of childless merged branches.

--- a/git_machete/client/go_show.py
+++ b/git_machete/client/go_show.py
@@ -1,6 +1,7 @@
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 from git_machete.client.base import MacheteClient, PickRoot
+from git_machete.client.state import ManagedBranchName
 from git_machete.git import LocalBranchShortName
 from git_machete.utils.exceptions import (MacheteException,
                                           UnexpectedMacheteException)
@@ -23,15 +24,15 @@ class GoShowMacheteClient(MacheteClient):
         return destination
 
     def next_branch_for(self, branch: LocalBranchShortName) -> LocalBranchShortName:
-        self.expect_in_managed_branches(branch)
-        index: int = self.managed_branches.index(branch) + 1
+        managed = self.expect_in_managed_branches(branch)
+        index: int = self.managed_branches.index(managed) + 1
         if index == len(self.managed_branches):
             raise MacheteException(f"Branch <b>{branch}</b> has no successor")
         return self.managed_branches[index]
 
     def prev_branch_for(self, branch: LocalBranchShortName) -> LocalBranchShortName:
-        self.expect_in_managed_branches(branch)
-        index: int = self.managed_branches.index(branch) - 1
+        managed = self.expect_in_managed_branches(branch)
+        index: int = self.managed_branches.index(managed) - 1
         if index == -1:
             raise MacheteException(f"Branch <b>{branch}</b> has no predecessor")
         return self.managed_branches[index]
@@ -50,7 +51,7 @@ class GoShowMacheteClient(MacheteClient):
         else:
             self._raise_no_branches_error()  # pragma: no cover; this case should never happen
 
-    def get_or_pick_child_of(self, branch: LocalBranchShortName, *, pick_if_multiple: bool) -> List[LocalBranchShortName]:
+    def get_or_pick_child_of(self, branch: LocalBranchShortName, *, pick_if_multiple: bool) -> List[ManagedBranchName]:
         self.expect_in_managed_branches(branch)
         children = self.children_of(branch)
         if not children:
@@ -83,7 +84,7 @@ class GoShowMacheteClient(MacheteClient):
         branch: Optional[LocalBranchShortName],
         allow_current: bool,
         pick_if_multiple: bool
-    ) -> List[LocalBranchShortName]:
+    ) -> Sequence[LocalBranchShortName]:
         if param in ("c", "current") and allow_current:
             return [self._git.get_current_branch()]  # throws in case of detached HEAD, as in the spec
         elif param in ("d", "down"):

--- a/git_machete/client/list.py
+++ b/git_machete/client/list.py
@@ -2,6 +2,7 @@ import re
 from typing import List
 
 from git_machete.client.base import MacheteClient
+from git_machete.client.state import ManagedBranchName
 from git_machete.git import LocalBranchShortName, RemoteBranchShortName
 from git_machete.utils.collections import excluding, map_truthy_only
 
@@ -22,17 +23,17 @@ class ListMacheteClient(MacheteClient):
     def unmanaged_branches(self) -> List[LocalBranchShortName]:
         return excluding(self._git.get_local_branches(), self.managed_branches)
 
-    def childless_managed_branches(self) -> List[LocalBranchShortName]:
+    def childless_managed_branches(self) -> List[ManagedBranchName]:
         return [b for b in self._state.managed_branches if not self._state.get_children(b)]
 
     def branches_with_overridden_fork_point(self) -> List[LocalBranchShortName]:
         return [branch for branch in self._git.get_local_branches() if self.has_any_fork_point_override_config(branch)]
 
-    def slidable_branches(self) -> List[LocalBranchShortName]:
+    def slidable_branches(self) -> List[ManagedBranchName]:
         # All managed branches can be slid out, including root branches
         return self.managed_branches
 
-    def get_slidable_after(self, branch: LocalBranchShortName) -> List[LocalBranchShortName]:
+    def get_slidable_after(self, branch: LocalBranchShortName) -> List[ManagedBranchName]:
         if self._state.has_parent(branch):
             children = self.children_of(branch)
             if children and len(children) == 1:

--- a/git_machete/client/rename.py
+++ b/git_machete/client/rename.py
@@ -13,8 +13,7 @@ class RenameMacheteClient(MacheteClient):
                opt_branch: Optional[LocalBranchShortName],
                new_name: LocalBranchShortName,
                opt_repoint_tracking: bool) -> None:
-        branch = opt_branch or self._git.get_current_branch()
-        self.expect_in_managed_branches(branch)
+        branch = self.expect_in_managed_branches(opt_branch or self._git.get_current_branch())
         if new_name == branch:
             raise MacheteException(f"Branch is already named <b>{branch}</b>")
         if new_name in self._git.get_local_branches():

--- a/git_machete/client/slide_out.py
+++ b/git_machete/client/slide_out.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 
 from git_machete.client.base import MacheteClient
+from git_machete.client.state import ManagedBranchName
 from git_machete.config import SquashMergeDetection
 from git_machete.git import AnyRevision, LocalBranchShortName
 from git_machete.utils.exceptions import MacheteException
@@ -19,14 +20,19 @@ class SlideOutMacheteClient(MacheteClient):
                   opt_no_rebase: bool
                   ) -> None:
         self._git.expect_no_operation_in_progress()
-        branches_to_slide_out: List[LocalBranchShortName] = opt_branches or [self._git.get_current_branch()]
+        raw_branches: List[LocalBranchShortName] = opt_branches or [self._git.get_current_branch()]
 
         # Verify that all branches exist, are managed and are NOT annotated with slide-out=no qualifier.
-        for branch in branches_to_slide_out:
-            self.expect_in_managed_branches(branch)
-            anno = self._state.get_annotation(branch)
+        # `expect_in_managed_branches` narrows to `ManagedBranchName`, which we keep
+        # for the rest of the method so we can hand the values to layout mutators
+        # (`splice_out`, `_remove_branches_from_layout`) without re-checking.
+        branches_to_slide_out: List[ManagedBranchName] = []
+        for branch in raw_branches:
+            managed = self.expect_in_managed_branches(branch)
+            branches_to_slide_out.append(managed)
+            anno = self._state.get_annotation(managed)
             if anno and not anno.qualifiers.slide_out:
-                raise MacheteException(f"Branch <b>{branch}</b> is annotated with `slide-out=no` qualifier, aborting.\n"
+                raise MacheteException(f"Branch <b>{managed}</b> is annotated with `slide-out=no` qualifier, aborting.\n"
                                        f"Remove the qualifier using `git machete anno` or edit branch layout file directly.")
 
         if opt_down_fork_point:
@@ -116,7 +122,7 @@ class SlideOutMacheteClient(MacheteClient):
     def slide_out_removed_from_remote(self, *, opt_delete: bool) -> None:
         self._git.expect_no_operation_in_progress()
 
-        slid_out_branches: List[LocalBranchShortName] = []
+        slid_out_branches: List[ManagedBranchName] = []
         for branch in self.managed_branches.copy():
             if self._git.is_removed_from_remote(branch) and not self.children_of(branch):
                 anno = self._state.get_annotation(branch)

--- a/git_machete/client/state.py
+++ b/git_machete/client/state.py
@@ -5,6 +5,23 @@ from git_machete.git import LocalBranchShortName
 from git_machete.utils.collections import flat_map
 
 
+class ManagedBranchName(LocalBranchShortName):
+    """A `LocalBranchShortName` known to live in the `.git/machete` branch
+    layout file.
+
+    The type is a marker - it carries no extra behaviour - and exists so that
+    mypy can distinguish "any local branch the user typed" from "a branch
+    that has already been verified against the layout file". Every read
+    accessor on `MacheteState` (and the corresponding `MacheteClient`
+    helpers, including `expect_in_managed_branches`) hands back an instance
+    of this type; every mutation method that operates on a presumed-managed
+    branch (`splice_out`, `remove_leaf`, `add_as_child`'s `parent`, etc.)
+    accepts only this type. The "promote raw -> managed" conversion lives
+    in those methods alone, so accidentally feeding an unverified branch
+    into the layout-file mutators becomes a type error.
+    """
+
+
 class MacheteState:
     """
     In-memory representation of the branch layout (.git/machete file).
@@ -23,92 +40,107 @@ class MacheteState:
     """
 
     def __init__(self) -> None:
-        self._managed_branches: List[LocalBranchShortName] = []
-        self._roots: List[LocalBranchShortName] = []
-        self._parent_of: Dict[LocalBranchShortName, LocalBranchShortName] = {}
-        self._children_of: Dict[LocalBranchShortName, List[LocalBranchShortName]] = {}
-        self._annotations: Dict[LocalBranchShortName, Annotation] = {}
+        self._managed_branches: List[ManagedBranchName] = []
+        self._roots: List[ManagedBranchName] = []
+        self._parent_of: Dict[ManagedBranchName, ManagedBranchName] = {}
+        self._children_of: Dict[ManagedBranchName, List[ManagedBranchName]] = {}
+        self._annotations: Dict[ManagedBranchName, Annotation] = {}
 
     # ── Read-only accessors ─────────────────────────────────────────────────
 
     @property
-    def managed_branches(self) -> List[LocalBranchShortName]:
+    def managed_branches(self) -> List[ManagedBranchName]:
         """DFS-ordered flat list of all managed branches. Returns a copy."""
         return list(self._managed_branches)
 
     @property
-    def roots(self) -> List[LocalBranchShortName]:
+    def roots(self) -> List[ManagedBranchName]:
         """Root branches (those with no parent). Returns a copy."""
         return list(self._roots)
 
     def is_managed(self, branch: LocalBranchShortName) -> bool:
         return branch in self._managed_branches
 
-    def get_parent(self, branch: LocalBranchShortName) -> Optional[LocalBranchShortName]:
-        return self._parent_of.get(branch)
+    def as_managed(self, branch: LocalBranchShortName) -> Optional[ManagedBranchName]:
+        """Promote `branch` to `ManagedBranchName` if it's in the layout file, else `None`."""
+        if branch in self._managed_branches:
+            return ManagedBranchName(branch)
+        return None
+
+    def get_parent(self, branch: LocalBranchShortName) -> Optional[ManagedBranchName]:
+        return self._parent_of.get(ManagedBranchName(branch))
 
     def has_parent(self, branch: LocalBranchShortName) -> bool:
-        return branch in self._parent_of
+        return ManagedBranchName(branch) in self._parent_of
 
-    def get_children(self, branch: LocalBranchShortName) -> Optional[List[LocalBranchShortName]]:
+    def get_children(self, branch: LocalBranchShortName) -> Optional[List[ManagedBranchName]]:
         """Returns a copy of the children list, or None if branch has no children entry."""
-        children = self._children_of.get(branch)
+        children = self._children_of.get(ManagedBranchName(branch))
         return list(children) if children is not None else None
 
     def get_annotation(self, branch: LocalBranchShortName) -> Optional[Annotation]:
-        return self._annotations.get(branch)
+        return self._annotations.get(ManagedBranchName(branch))
 
     def has_annotation(self, branch: LocalBranchShortName) -> bool:
-        return branch in self._annotations
+        return ManagedBranchName(branch) in self._annotations
 
     # ── Adding branches ─────────────────────────────────────────────────────
+    #
+    # The methods in this section are the gateway from `LocalBranchShortName`
+    # to `ManagedBranchName`: the branch passed in is *becoming* managed by
+    # virtue of the call itself, so the input type is the broader one and
+    # the value is stored internally as the narrower `ManagedBranchName`.
 
     def add_branch(
         self,
         branch: LocalBranchShortName,
         *,
-        parent: Optional[LocalBranchShortName],
+        parent: Optional[ManagedBranchName],
         annotation: Optional[Annotation],
     ) -> None:
         """Add a branch to the layout, wiring it under parent (or as a root if parent is None)."""
-        self._managed_branches.append(branch)
+        managed = ManagedBranchName(branch)
+        self._managed_branches.append(managed)
         if parent is not None:
-            self._parent_of[branch] = parent
+            self._parent_of[managed] = parent
             if parent in self._children_of:
-                self._children_of[parent].append(branch)
+                self._children_of[parent].append(managed)
             else:
-                self._children_of[parent] = [branch]
+                self._children_of[parent] = [managed]
         else:
-            self._roots.append(branch)
+            self._roots.append(managed)
         if annotation is not None:
-            self._annotations[branch] = annotation
+            self._annotations[managed] = annotation
 
     def bootstrap_as_single_managed(self, branch: LocalBranchShortName) -> None:
         """Bootstrap an empty layout with branch as the sole root and managed branch."""
-        self._roots = [branch]
-        self._managed_branches = [branch]
+        managed = ManagedBranchName(branch)
+        self._roots = [managed]
+        self._managed_branches = [managed]
 
     def add_as_root(self, branch: LocalBranchShortName) -> None:
         """Add branch as a new root, appending it to managed_branches."""
-        self._roots.append(branch)
-        self._managed_branches.append(branch)
+        managed = ManagedBranchName(branch)
+        self._roots.append(managed)
+        self._managed_branches.append(managed)
 
     def add_as_child(
         self,
         *,
         branch: LocalBranchShortName,
-        parent: LocalBranchShortName,
+        parent: ManagedBranchName,
         as_first_child: bool,
     ) -> None:
         """Add branch as a child of parent, appending it to managed_branches."""
-        self._parent_of[branch] = parent
+        managed = ManagedBranchName(branch)
+        self._parent_of[managed] = parent
         existing = self._children_of.get(parent, [])
-        self._children_of[parent] = ([branch] + existing) if as_first_child else (existing + [branch])
-        self._managed_branches.append(branch)
+        self._children_of[parent] = ([managed] + existing) if as_first_child else (existing + [managed])
+        self._managed_branches.append(managed)
 
     # ── Removing / rewiring branches ────────────────────────────────────────
 
-    def splice_out(self, branch: LocalBranchShortName) -> None:
+    def splice_out(self, branch: ManagedBranchName) -> None:
         """Remove a branch from the tree, wiring its children to its parent.
 
         If branch is a root, its children become new roots in its place.
@@ -135,7 +167,7 @@ class MacheteState:
         self._annotations.pop(branch, None)
         self._managed_branches.remove(branch)
 
-    def remove_leaf(self, branch: LocalBranchShortName) -> None:
+    def remove_leaf(self, branch: ManagedBranchName) -> None:
         """Remove a childless branch from the layout.
 
         Detaches it from its parent (or roots), removes it from managed_branches,
@@ -159,7 +191,7 @@ class MacheteState:
         Clears managed_branches, parent/children mappings, and sets roots to initial_roots.
         Annotations are preserved so they can be selectively updated afterwards.
         """
-        self._roots = list(initial_roots)
+        self._roots = [ManagedBranchName(b) for b in initial_roots]
         self._parent_of = {}
         self._children_of = {}
         self._managed_branches = []
@@ -172,11 +204,13 @@ class MacheteState:
         Intended for incremental tree building when managed_branches will be
         set in bulk afterwards via set_managed().
         """
-        self._parent_of[child] = parent
-        if parent in self._children_of:
-            self._children_of[parent].append(child)
+        managed_parent = ManagedBranchName(parent)
+        managed_child = ManagedBranchName(child)
+        self._parent_of[managed_child] = managed_parent
+        if managed_parent in self._children_of:
+            self._children_of[managed_parent].append(managed_child)
         else:
-            self._children_of[parent] = [child]
+            self._children_of[managed_parent] = [managed_child]
 
     def wire_as_root(self, branch: LocalBranchShortName) -> None:
         """Append branch to roots without touching managed_branches.
@@ -184,9 +218,9 @@ class MacheteState:
         Intended for incremental tree building when managed_branches will be
         set in bulk afterwards via set_managed().
         """
-        self._roots.append(branch)
+        self._roots.append(ManagedBranchName(branch))
 
-    def detach_leaf(self, branch: LocalBranchShortName) -> None:
+    def detach_leaf(self, branch: ManagedBranchName) -> None:
         """Detach a childless branch from the tree without touching managed_branches.
 
         Intended for pruning during tree building before managed_branches is set.
@@ -198,47 +232,48 @@ class MacheteState:
 
     def set_managed(self, branches: List[LocalBranchShortName]) -> None:
         """Overwrite managed_branches with the given DFS-ordered list."""
-        self._managed_branches = list(branches)
+        self._managed_branches = [ManagedBranchName(b) for b in branches]
 
     # ── Rename ──────────────────────────────────────────────────────────────
 
     def rename_branch(
         self,
         *,
-        old_name: LocalBranchShortName,
+        old_name: ManagedBranchName,
         new_name: LocalBranchShortName,
     ) -> None:
         """Rename a branch across all state fields."""
+        new_managed = ManagedBranchName(new_name)
         idx = self._managed_branches.index(old_name)
-        self._managed_branches[idx] = new_name
+        self._managed_branches[idx] = new_managed
 
         if old_name in self._roots:
             ridx = self._roots.index(old_name)
-            self._roots[ridx] = new_name
+            self._roots[ridx] = new_managed
 
         if old_name in self._parent_of:
             parent = self._parent_of.pop(old_name)
-            self._parent_of[new_name] = parent
+            self._parent_of[new_managed] = parent
 
         for k in list(self._parent_of):
             if self._parent_of[k] == old_name:
-                self._parent_of[k] = new_name
+                self._parent_of[k] = new_managed
 
         if old_name in self._children_of:
             children = self._children_of.pop(old_name)
-            self._children_of[new_name] = children
+            self._children_of[new_managed] = children
 
         for children_list in self._children_of.values():
             if old_name in children_list:
-                children_list[children_list.index(old_name)] = new_name
+                children_list[children_list.index(old_name)] = new_managed
 
         if old_name in self._annotations:
-            self._annotations[new_name] = self._annotations.pop(old_name)
+            self._annotations[new_managed] = self._annotations.pop(old_name)
 
     # ── Annotations ─────────────────────────────────────────────────────────
 
-    def set_annotation(self, branch: LocalBranchShortName, annotation: Annotation) -> None:
+    def set_annotation(self, branch: ManagedBranchName, annotation: Annotation) -> None:
         self._annotations[branch] = annotation
 
-    def delete_annotation(self, branch: LocalBranchShortName) -> None:
+    def delete_annotation(self, branch: ManagedBranchName) -> None:
         self._annotations.pop(branch, None)

--- a/git_machete/client/status.py
+++ b/git_machete/client/status.py
@@ -19,6 +19,7 @@ from git_machete.utils.paths import Path
 
 from ..utils import markup
 from .base import MacheteClient
+from .state import ManagedBranchName
 
 
 class SyncToParentStatus(Enum):
@@ -52,8 +53,8 @@ class StatusOngoingOperation(NamedTuple):
 class StatusBranch(NamedTuple):
     """Per-branch data for status output (tree structure, sync state, commits, annotations)."""
 
-    parent: Optional[LocalBranchShortName]
-    children: List[LocalBranchShortName]
+    parent: Optional[ManagedBranchName]
+    children: List[ManagedBranchName]
     sync_to_parent_status: SyncToParentStatus
     commits: List[Tuple[GitLogEntry, str]]
     sync_status: str
@@ -65,9 +66,12 @@ class StatusData(NamedTuple):
     """All precomputed data needed to render status output (tree and optional warning)."""
 
     flags: StatusFlags
+    # Keep the dict keyed on the broader `LocalBranchShortName` to spare every
+    # downstream helper from `ManagedBranchName`-narrowing dance when indexing
+    # via a parent/sibling-of-ancestor (which mypy tracks as the broader type).
     branches: Dict[LocalBranchShortName, StatusBranch]
-    branches_in_display_order: List[LocalBranchShortName]
-    roots: List[LocalBranchShortName]
+    branches_in_display_order: List[ManagedBranchName]
+    roots: List[ManagedBranchName]
     ongoing_operation: StatusOngoingOperation
 
 
@@ -262,7 +266,7 @@ class StatusMacheteClient(MacheteClient):
             self._git.is_ancestor_or_equal(fork_point, parent_remote.full_name())
 
     def compute_status_data(self, *, flags: StatusFlags) -> StatusData:
-        managed_branches: List[LocalBranchShortName] = self._state.managed_branches  # already returns a copy
+        managed_branches: List[ManagedBranchName] = self._state.managed_branches  # already returns a copy
 
         sync_to_parent_status: Dict[LocalBranchShortName, SyncToParentStatus] = {}
         fork_point_hash_cached: Dict[LocalBranchShortName, Optional[FullCommitHash]] = {}

--- a/git_machete/client/with_code_hosting.py
+++ b/git_machete/client/with_code_hosting.py
@@ -3,6 +3,7 @@ import os
 from typing import Dict, Iterator, List, Optional, Set, Tuple
 
 from git_machete.annotation import Annotation, Qualifiers
+from git_machete.client.state import ManagedBranchName
 from git_machete.client.status import StatusMacheteClient
 from git_machete.code_hosting import (CodeHostingApi, CodeHostingSpec,
                                       OrganizationAndRepository,
@@ -70,10 +71,11 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
                                                  *, include_urls: bool, verbose: bool) -> None:
         spec = self.code_hosting_spec
         for pr in prs:
-            if LocalBranchShortName.of(pr.head) in self.managed_branches:
+            head_branch_managed = self._state.as_managed(LocalBranchShortName.of(pr.head))
+            if head_branch_managed is not None:
                 debug(f'{pr} corresponds to a managed branch')
                 anno: str = self._pull_request_annotation(pr, current_user, include_url=include_urls)
-                parent: Optional[LocalBranchShortName] = self.parent_of(LocalBranchShortName.of(pr.head))
+                parent: Optional[LocalBranchShortName] = self.parent_of(head_branch_managed)
                 if parent is not None:
                     counterpart = self._git.get_combined_counterpart_for_fetching_of_branch(parent)
                 else:
@@ -88,8 +90,7 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
                              f"{spec.pr_short_name} has {pr.base}")
                 old_annotation_text = ''
                 old_annotation_qualifiers = Qualifiers()
-                head_branch = LocalBranchShortName.of(pr.head)
-                old_annotation = self._state.get_annotation(head_branch)
+                old_annotation = self._state.get_annotation(head_branch_managed)
                 if old_annotation is not None:
                     old_annotation_text = old_annotation.text_without_qualifiers
                     old_annotation_qualifiers = old_annotation.qualifiers
@@ -97,11 +98,11 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
                 if pr.user != current_user and old_annotation_qualifiers.is_default():
                     if verbose:
                         print_fmt(f'Annotating <b>{pr.head}</b> as `{anno} rebase=no push=no`')
-                    self._state.set_annotation(head_branch, Annotation(anno, Qualifiers(rebase=False, push=False)))
+                    self._state.set_annotation(head_branch_managed, Annotation(anno, Qualifiers(rebase=False, push=False)))
                 elif old_annotation_text != anno:
                     if verbose:
                         print_fmt(f'Annotating <b>{pr.head}</b> as `{anno}`')
-                    self._state.set_annotation(head_branch, Annotation(anno, old_annotation_qualifiers))
+                    self._state.set_annotation(head_branch_managed, Annotation(anno, old_annotation_qualifiers))
             else:
                 debug(f'{pr} does NOT correspond to a managed branch')
         self.save_branch_layout_file()
@@ -240,9 +241,12 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             opt_update_related_descriptions: bool,
             opt_yes: bool
     ) -> None:
-        head: LocalBranchShortName = self._git.get_current_branch()
+        # `sync_before_creating_pull_request` (invoked from the CLI just before this call)
+        # ensures the head branch is in the layout file, so narrowing to `ManagedBranchName`
+        # is safe.
+        head: ManagedBranchName = self.expect_in_managed_branches(self._git.get_current_branch())
         # Use provided base branch if --base flag is specified (undocumented), otherwise use parent branch from .git/machete
-        base: Optional[LocalBranchShortName] = opt_base or self.parent_of(LocalBranchShortName.of(head))
+        base: Optional[LocalBranchShortName] = opt_base or self.parent_of(head)
         spec = self.code_hosting_spec
         if not base:
             raise UnexpectedMacheteException(f'could not determine {spec.base_branch_name} branch for {spec.pr_short_name}. '
@@ -539,8 +543,7 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
 
     def retarget_pull_request(self, *, opt_branch: Optional[LocalBranchShortName],
                               opt_ignore_if_missing: bool, opt_update_related_descriptions: bool) -> None:
-        head: LocalBranchShortName = opt_branch or self._git.get_current_branch()
-        self.expect_in_managed_branches(head)
+        head: ManagedBranchName = self.expect_in_managed_branches(opt_branch or self._git.get_current_branch())
         spec = self.code_hosting_spec
         if self.__code_hosting_client is None:
             self._init_code_hosting_client(branch_used_for_tracking_data=head)
@@ -550,7 +553,7 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
         if pr is None:
             return
 
-        new_base: Optional[LocalBranchShortName] = self.parent_of(LocalBranchShortName.of(head))
+        new_base: Optional[LocalBranchShortName] = self.parent_of(head)
         if not new_base:
             raise MacheteException(
                 f'Branch <b>{head}</b> does not have a parent branch (it is a root) '


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1687

## Chain of upstream PRs as of 2026-05-14

* PR #1678:
  `master` ← `develop`

  * PR #1687:
    `develop` ← `refactor/git-out-of-cli`

    * **PR #1688 (THIS ONE)**:
      `refactor/git-out-of-cli` ← `refactor/managed-branch-name-type`

<!-- end git-machete generated -->

`ManagedBranchName` marks a branch that has been verified against the
`.git/machete` layout file. Read accessors on `MacheteState` (and
`MacheteClient` helpers like `expect_in_managed_branches`) hand back
`ManagedBranchName`; layout-mutating APIs (`splice_out`, `remove_leaf`,
`add_as_child.parent`, `set_annotation`, ...) only accept it. The
"promote raw -> managed" conversion is concentrated in a few gateway
methods, so feeding an unverified branch into the layout mutators is now
a type error rather than a silent runtime hazard.