### PR TITLE
status -l: show inferring branches next to `-> fork point` on green edges

### DIFF
--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -430,14 +430,18 @@ class MacheteClient:
 
             self.__branch_pairs_by_hash_in_reflog = {}
             for hash, branch_pair in generate_entries():
-                if hash in self.__branch_pairs_by_hash_in_reflog:
-                    # The practice shows that it's rather unlikely for a given
-                    # commit to appear on filtered reflogs of two unrelated branches
-                    # ("unrelated" as in, not a local branch and its remote counterpart)
-                    # but we need to handle this case anyway.
-                    self.__branch_pairs_by_hash_in_reflog[hash] += [branch_pair]
-                else:
-                    self.__branch_pairs_by_hash_in_reflog[hash] = [branch_pair]
+                # We dedup `branch_pair`s per hash so that a commit which appears
+                # multiple times in a single branch's filtered reflog (e.g. via a
+                # `git reset --hard` back to it followed by an advance, then
+                # another reset back) doesn't end up listed twice in
+                # `inferring_branches`. Without this, `fork-point --explain` and
+                # `status -l` would print things like
+                # "...part of the unique history of master and master".
+                # The list-of-pairs shape is preserved (rather than a set) because
+                # downstream code relies on sorted ordering and indexed iteration.
+                existing = self.__branch_pairs_by_hash_in_reflog.setdefault(hash, [])
+                if branch_pair not in existing:
+                    existing.append(branch_pair)
 
             def log_result() -> Iterator[str]:
                 entry_branch_pairs: List[BranchPair]

--- a/git_machete/client/status.py
+++ b/git_machete/client/status.py
@@ -249,21 +249,22 @@ class StatusMacheteClient(MacheteClient):
             )
         return f"{first_part}.\n\n{second_part}."
 
-    def _is_fork_point_on_parent_remote_counterpart(
+    def _is_fork_point_inferred_by_parent_remote_counterpart(
             self,
             *,
             parent_branch: LocalBranchShortName,
-            fork_point: FullCommitHash) -> bool:
+            inferring_branches: List[BranchPair]) -> bool:
         # Suppresses the spurious yellow edge that appears when the parent branch is merely behind
-        # its remote counterpart and the child branch was forked from a commit on the remote
-        # that is ahead of parent's local HEAD. We require that the fork point lies strictly
-        # between parent's local HEAD and parent's remote counterpart, so that legitimate
-        # yellow edges (where the fork point is older than parent's local HEAD) are preserved.
+        # its remote counterpart and the child branch was forked from the remote tip. We only
+        # fire here for parents that have a remote counterpart at all (otherwise the "behind
+        # remote" situation cannot arise), and only if `parent_branch` appears among the inferring
+        # branches - either directly as `parent_remote`, or as the `local_branch` side of a
+        # `BranchPair(parent_branch, parent_branch)` entry produced when the inferred commit
+        # survives on `parent_branch`'s own filtered reflog after the push.
         parent_remote = self._git.get_combined_counterpart_for_fetching_of_branch(parent_branch)
         if parent_remote is None:
             return False
-        return self._git.is_ancestor(parent_branch.full_name(), fork_point) and \
-            self._git.is_ancestor_or_equal(fork_point, parent_remote.full_name())
+        return any(p.local_branch == parent_branch for p in inferring_branches)
 
     def compute_status_data(self, *, flags: StatusFlags) -> StatusData:
         managed_branches: List[ManagedBranchName] = self._state.managed_branches  # already returns a copy
@@ -305,7 +306,9 @@ class StatusMacheteClient(MacheteClient):
                 assert fp is not None
                 if self._git.get_commit_hash_by_revision(parent_branch) == fp:
                     sync_to_parent_status[branch] = SyncToParentStatus.IN_SYNC
-                elif self._is_fork_point_on_parent_remote_counterpart(parent_branch=parent_branch, fork_point=fp):
+                elif self._is_fork_point_inferred_by_parent_remote_counterpart(
+                        parent_branch=parent_branch,
+                        inferring_branches=fork_point_branches_cached[branch]):
                     sync_to_parent_status[branch] = SyncToParentStatus.IN_SYNC
                 else:
                     sync_to_parent_status[branch] = SyncToParentStatus.IN_SYNC_BUT_FORK_POINT_OFF
@@ -344,16 +347,26 @@ class StatusMacheteClient(MacheteClient):
                     for commit in raw_commits:
                         if commit.hash != fork_point:
                             fp_suffix = ''
-                        elif is_fork_point_off:
+                        else:
+                            marker = '<red><rarrow/> fork point ???</red>' if is_fork_point_off else '<red><rarrow/> fork point</red>'
                             fp_branches_formatted = " and ".join(
                                 sorted(f"<u>{lb_or_rb}</u>" for lb, lb_or_rb in fork_point_branches_cached[branch]))
-                            fp_suffix = (
-                                ' <red><rarrow/> fork point ???</red> ' +
-                                ("this commit" if flags.opt_list_commits_with_hashes else f"commit {commit.short_hash}") +
-                                f' seems to be a part of the unique history of {fp_branches_formatted}'
-                            )
-                        else:
-                            fp_suffix = ' <red><rarrow/> fork point</red>'
+                            if fp_branches_formatted:
+                                # `???` already separates the marker from the prose; a colon would be redundant.
+                                separator = '' if is_fork_point_off else ':'
+                                commit_label = (
+                                    "this commit" if flags.opt_list_commits_with_hashes
+                                    else f"commit {commit.short_hash}"
+                                )
+                                fp_suffix = (
+                                    f' {marker}{separator} {commit_label}'
+                                    f' seems to be a part of the unique history of {fp_branches_formatted}'
+                                )
+                            else:
+                                # Reaching the green-edge marker with no inferring branches means the
+                                # fork point comes from an active override (a fallback-to-parent fork
+                                # point equals the parent hash, so it never appears in `parent..branch`).
+                                fp_suffix = f' {marker}: overridden'
                         commits.append((commit, fp_suffix))
                 commits_by_branch[branch] = commits
 

--- a/tests/test_fork_point.py
+++ b/tests/test_fork_point.py
@@ -9,7 +9,7 @@ from .cli_runner import (assert_failure, assert_success, launch_command,
                          rewrite_branch_layout_file)
 from .git_repository import (add_remote, check_out, commit, create_repo,
                              create_repo_with_remote, delete_branch, fetch,
-                             get_commit_hash, get_current_commit_hash,
+                             get_commit_hash, get_current_commit_hash, merge,
                              new_branch, new_orphan_branch, pull, push,
                              reset_to, set_git_config_key)
 from .mockers import fixed_author_and_committer_date_in_past
@@ -115,6 +115,60 @@ class TestForkPoint(BaseTest):
             ["fork-point", "feature", "--override-to-parent", "--explain"],
             "--explain cannot be combined with "
             "--override-to/--override-to-inferred/--override-to-parent/--unset-override."
+        )
+
+    def test_fork_point_explain_dedups_inferring_branches(self) -> None:
+        # When a single commit appears multiple times in a branch's
+        # *filtered* reflog (e.g. after two consecutive ff-merges/pulls
+        # to the same upstream tip), `__match_log_to_filtered_reflogs`
+        # used to record `BranchPair(master, master)` once per
+        # occurrence. The explanation then read
+        # "...part of the unique history of master and master", which
+        # is meaningless to the user and misleading in the debug logs.
+        # The fix dedups branch pairs per hash at computation time, so
+        # `master` is listed exactly once regardless of how many reflog
+        # events on `master` happen to point at the fork point.
+        with fixed_author_and_committer_date_in_past():
+            create_repo()
+            new_branch("master")
+            commit("master initial")
+            new_branch("sidebranch")
+            commit("sidebranch commit")
+            sidebranch_tip = get_current_commit_hash()
+            check_out("master")
+            # First ff-merge: master moves to `sidebranch_tip`; reflog
+            # gets a "merge sidebranch: Fast-forward" entry whose new
+            # value is `sidebranch_tip`. This subject is not excluded
+            # by `filtered_reflog`.
+            merge("sidebranch")
+            # Branch develop off the new master tip so develop's fork
+            # point lands at `sidebranch_tip`.
+            new_branch("develop")
+            commit("develop commit")
+            check_out("master")
+            # Rewind master and ff-merge sidebranch again, so master's
+            # filtered reflog ends up with two non-excluded entries
+            # both pointing at `sidebranch_tip`.
+            reset_to("master~1")
+            merge("sidebranch")
+            # Drop `sidebranch` so it doesn't contribute its own
+            # `BranchPair(sidebranch, sidebranch)` to the inferring set
+            # - the case under test is specifically about a single
+            # branch (`master`) being listed multiple times.
+            delete_branch("sidebranch")
+
+        rewrite_branch_layout_file("""
+            master
+                develop
+            """)
+
+        # Without the dedup the explanation read
+        #   "...part of the unique history of master and master"
+        # because `BranchPair(master, master)` was appended twice.
+        assert_success(
+            ["fork-point", "develop", "--explain"],
+            f"{sidebranch_tip}\n"
+            "this commit seems to be a part of the unique history of master\n"
         )
 
     def test_fork_point_override_for_invalid_branch(self) -> None:
@@ -277,21 +331,22 @@ class TestForkPoint(BaseTest):
             """
               master (untracked)
               |
-              | ad97c34  in-between commit -> fork point
+              | ad97c34  in-between commit -> fork point: overridden
               | 989bd92  develop commit
               o-develop * (untracked)
             """
         )
 
-        # Validate the full ANSI rendering of the green `-> fork point` annotation:
-        # the arrow must be the non-ASCII `\u279a` and the marker must be RED.
+        # Validate the full ANSI rendering of the green `-> fork point: overridden` annotation:
+        # the arrow must be the non-ASCII `\u279a`, the marker must be RED, and the
+        # `: overridden` suffix must stay outside the red span.
         E = FullTerminalAnsiOutputCodes
         raw_output = launch_command("status", "-L", "--color=always")
         expected_ansi = (
             f"  {E.BOLD}master{E.ENDC_BOLD_DIM}{E.ORANGE} (untracked){E.ENDC}\n"
             f"  {E.GREEN}│{E.ENDC}\n"
             f"  {E.GREEN}│{E.ENDC} {E.DIM}ad97c34{E.ENDC_BOLD_DIM}  {E.DIM}in-between commit{E.ENDC_BOLD_DIM} "
-            f"{E.RED}➔ fork point{E.ENDC}\n"
+            f"{E.RED}➔ fork point{E.ENDC}: overridden\n"
             f"  {E.GREEN}│{E.ENDC} {E.DIM}989bd92{E.ENDC_BOLD_DIM}  {E.DIM}develop commit{E.ENDC_BOLD_DIM}\n"
             f"  {E.GREEN}└─{E.ENDC}{E.BOLD}{E.UNDERLINE}develop{E.ENDC_UNDERLINE}{E.ENDC_BOLD_DIM}"
             f"{E.ORANGE} (untracked){E.ENDC}\n"
@@ -301,7 +356,7 @@ class TestForkPoint(BaseTest):
     def test_fork_point_override_marker_in_status(self) -> None:
         # When fork point is overridden to a non-trivial commit (not at the parent's tip),
         # `status -l` should still classify the edge as green and annotate the overridden
-        # fork-point commit with `-> fork point`.
+        # fork-point commit with `-> fork point: overridden`.
         with fixed_author_and_committer_date_in_past():
             create_repo()
             new_branch("master")
@@ -327,7 +382,7 @@ class TestForkPoint(BaseTest):
             """
             master
             |
-            | first develop commit -> fork point
+            | first develop commit -> fork point: overridden
             | second develop commit
             | third develop commit
             o-develop *

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -736,21 +736,23 @@ class TestStatus(BaseTest):
         """)
         assert raw_output == expected_ansi
 
-    def test_status_no_yellow_edge_when_parent_behind_remote(self) -> None:
+    def test_status_no_yellow_edge_when_parent_behind_remote(self, mocker: MockerFixture) -> None:
         # Reproduces a common false-positive yellow edge: the parent branch is just
         # behind its remote counterpart, but the child branch was forked from the
         # remote tip. The fork point of the child is then ahead of parent's local
         # HEAD, which used to render as a yellow edge. The edge should be green.
-        create_repo_with_remote()
-        new_branch("master")
-        commit("master commit 1")
-        push()
-        commit("master commit 2")
-        push()
-        new_branch("develop")
-        commit("develop commit")
-        check_out("master")
-        reset_to("HEAD~")  # master is now behind origin/master
+        self.patch_symbol(mocker, "git_machete.utils.terminal.is_terminal_fully_fledged", lambda: True)
+        with fixed_author_and_committer_date_in_past():
+            create_repo_with_remote()
+            new_branch("master")
+            commit("master commit 1")
+            push()
+            commit("master commit 2")
+            push()
+            new_branch("develop")
+            commit("develop commit")
+            check_out("master")
+            reset_to("HEAD~")  # master is now behind origin/master
 
         rewrite_branch_layout_file(
             """
@@ -775,11 +777,26 @@ class TestStatus(BaseTest):
             """
               master * (behind origin)
               |
-              | master commit 2 -> fork point
+              | master commit 2 -> fork point: commit 39710eb seems to be a part of the unique history of master
               | develop commit
               o-develop (untracked)
             """,
         )
+
+        # Same scenario, but validate the full ANSI rendering of the green-edge
+        # `-> fork point: ...` annotation: the marker must be RED, the inferring
+        # branch name underlined, and the colon must stay outside the red span.
+        E = FullTerminalAnsiOutputCodes
+        raw_output = launch_command('status', '-l', '--color=always')
+        expected_ansi = (
+            f"  {E.BOLD}{E.UNDERLINE}master{E.ENDC_UNDERLINE}{E.ENDC_BOLD_DIM}{E.RED} (behind {E.BOLD}origin{E.ENDC_BOLD_DIM}){E.ENDC}\n"
+            f"  {E.GREEN}│{E.ENDC}\n"
+            f"  {E.GREEN}│{E.ENDC} {E.DIM}master commit 2{E.ENDC_BOLD_DIM} {E.RED}➔ fork point{E.ENDC}:"
+            f" commit 39710eb seems to be a part of the unique history of {E.UNDERLINE}master{E.ENDC_UNDERLINE}\n"
+            f"  {E.GREEN}│{E.ENDC} {E.DIM}develop commit{E.ENDC_BOLD_DIM}\n"
+            f"  {E.GREEN}└─{E.ENDC}{E.BOLD}develop{E.ENDC_BOLD_DIM}{E.ORANGE} (untracked){E.ENDC}\n"
+        )
+        assert raw_output == expected_ansi
 
     def test_status_ansi_escapes(self, mocker: MockerFixture) -> None:
         # Setup: develop (root); feature-in-sync behind develop=RED; feature-merged merged into develop=DIM;


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1689

## Chain of upstream PRs as of 2026-05-14

* PR #1678:
  `master` ← `develop`

  * PR #1689:
    `develop` ← `refactor/argparse-to-getopt`

    * **PR #1690 (THIS ONE)**:
      `refactor/argparse-to-getopt` ← `ux/fork-point-green-edge`

<!-- end git-machete generated -->

Previously the verbose `commit XXX seems to be a part of the unique
history of <branches>` annotation only appeared after `-> fork point ???`
on yellow edges. On green edges (e.g. parent behind its remote, child
forked from the remote tip) the same fork point was rendered as a bare
`-> fork point` marker, which hides exactly where the inferred fork
point came from.

Append the same prose on green edges too, separated by a colon since
there is no `???` to break the line up:

```
| develop commit 1 -> fork point: commit 39710eb seems to be a part of the unique history of master
```

Override-driven fork points (empty inferring-branch list, e.g. after
`git machete fork-point --override-to-parent`) render as
`-> fork point: overridden`, so the marker still tells the user the
fork point did not come out of the usual reflog inference.

Also tighten the green-edge classification for the "parent behind its
remote" case. Instead of geometric `is_ancestor` checks between the
parent's local HEAD, its remote counterpart and the fork point, fire
only when the parent branch shows up among the inferring branches -
either directly as `parent_remote`, or as the `local_branch` side of a
`BranchPair(parent, parent)` entry produced when the inferred commit
survives on the parent's own filtered reflog after the push. This
matches the user-visible "the fork point was inferred from <parent>"
intent more directly, and the check is renamed accordingly to
`_is_fork_point_inferred_by_parent_remote_counterpart`.

A matching change is being applied to the IntelliJ plugin so that
`status` output and the in-IDE renderer stay in sync.

## Dedup inferring branches per hash

While testing the above, an unrelated nearby bug surfaced:
`fork-point --explain develop` could read
`"...part of the unique history of bump/... and master and master"`
in real repos with a non-trivial reflog (e.g. two ff-merges/pulls to
the same upstream tip on `master`). The same commit appears multiple
times in `master`'s filtered reflog, and
`__match_log_to_filtered_reflogs` used to append
`BranchPair(master, master)` once per occurrence into
`__branch_pairs_by_hash_in_reflog[hash]`.

The inferring list is semantically a set, not a multiset, so the fix
dedups branch pairs per hash at computation time. All consumers
(`status -l` annotation, the green-edge classifier, `_infer_parent`,
the merge-base "improve fork point" loop) are dedup-idempotent, so the
algorithm's outputs don't change - only the displayed branches list
shortens to its unique form, and the corresponding `debug(...)` logs
no longer repeat branch names.

Regression test:
`test_fork_point_explain_dedups_inferring_branches` builds a repo
where two consecutive `git merge --ff-only sidebranch` operations land
`master` on the same tip twice (with a `git reset --keep master~1`
in between, whose reflog subject is excluded by `filtered_reflog`).
Verified to fail without the dedup and pass with it.