### PR TITLE
Use American spelling consistently

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,9 @@
 
 - No trailing whitespace on any line.
 - Always leave a single newline at the end of every file.
+- Always use American English spelling (`color`, `behavior`, `honor`, `organize`, `modeled`, `normalized`, `unrecognized`, ...) -
+  never the British variants (`colour`, `behaviour`, `honour`, `organise`, `modelled`, `normalised`, `unrecognised`, ...).
+  Applies to code, identifiers, comments, docstrings, Markdown, commit messages and PR descriptions.
 - Don't hard-wrap prose (code comments, docstrings, Markdown, commit messages, PR descriptions) at 80 or so columns -
   the line-length limit is 140 (see `[flake8]` in `tox.ini`).
   Break on sentence or clause boundaries instead, so each line carries one thought rather than a fragment chopped by column count.

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -213,7 +213,7 @@ def launch_internal(orig_args: List[str]) -> None:
 
         parsed = parse_cmdline(orig_args)
 
-        # Set up `--debug` / `--verbose` first so that subsequent `git config` reads honour them.
+        # Set up `--debug` / `--verbose` first so that subsequent `git config` reads honor them.
         set_utils_global_variables(parsed)
 
         if "help" in parsed.opts:

--- a/git_machete/cli_commands.py
+++ b/git_machete/cli_commands.py
@@ -331,7 +331,7 @@ COMMANDS: Tuple[CommandSpec, ...] = (
             MutexGroup(("inferred", "override-to", "override-to-inferred",
                         "override-to-parent", "unset-override")),
             # `--explain` is informational and conflicts with anything that MUTATES the fork-point override.
-            # Modelled as four pair groups sharing the same custom message;
+            # Modeled as four pair groups sharing the same custom message;
             # only the first matching pair fires (we exit on the first violation).
             *(
                 MutexGroup(

--- a/git_machete/cli_parser.py
+++ b/git_machete/cli_parser.py
@@ -251,7 +251,7 @@ def _collect_unknown_tokens(
             else:
                 unknown.append(a)
                 # If `--foo bar` (no `=`) and `bar` is unlikely to be its own flag,
-                # also include it for display so the user sees the full unrecognised pair.
+                # also include it for display so the user sees the full unrecognized pair.
                 if "=" not in a and i + 1 < len(argv) and not argv[i + 1].startswith("-"):
                     i += 1
                     unknown.append(argv[i])
@@ -302,7 +302,7 @@ def _visible_choices(positional: PositionalSpec) -> Tuple[str, ...]:
 
 
 def _apply_color_setting(color: Optional[str]) -> None:
-    """Honour `--color` for stdout / stderr ANSI emission.
+    """Honor `--color` for stdout / stderr ANSI emission.
 
     Called from inside `parse_cmdline` (rather than waiting until the caller invokes `set_utils_global_variables`)
     so that any `MacheteException` raised from the validation phase below

--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -41,7 +41,7 @@ class MacheteClient:
                  interactively_slide_out_invalid_branches: bool = False) -> None:
         # Clients own their `Git` plumbing instance - command-dispatch code
         # (`cli.py`) and tests never touch it directly. Pass-throughs are
-        # avoided in favour of domain-specific methods on the client itself.
+        # avoided in favor of domain-specific methods on the client itself.
         self._git: Git = Git()
         self._config: MacheteConfig = MacheteConfig(self._git)
         self._git.owner = self

--- a/git_machete/client/state.py
+++ b/git_machete/client/state.py
@@ -9,7 +9,7 @@ class ManagedBranchName(LocalBranchShortName):
     """A `LocalBranchShortName` known to live in the `.git/machete` branch
     layout file.
 
-    The type is a marker - it carries no extra behaviour - and exists so that
+    The type is a marker - it carries no extra behavior - and exists so that
     mypy can distinguish "any local branch the user typed" from "a branch
     that has already been verified against the layout file". Every read
     accessor on `MacheteState` (and the corresponding `MacheteClient`

--- a/git_machete/utils/cmd.py
+++ b/git_machete/utils/cmd.py
@@ -55,7 +55,7 @@ def run_cmd(cmd: str, *args: str, cwd: Optional[Path] = None, env: Optional[Dict
 
     start = time.time()
     # Looked up via the `_subproc` module so that
-    # `mock.patch('git_machete.utils._subproc._run_cmd', ...)` is honoured.
+    # `mock.patch('git_machete.utils._subproc._run_cmd', ...)` is honored.
     exit_code: int = _subproc._run_cmd(cmd, *args, cwd=cwd, env=env)
     if measure_command_time:  # pragma: no cover
         end = time.time()

--- a/git_machete/utils/markup.py
+++ b/git_machete/utils/markup.py
@@ -8,7 +8,7 @@ TTY (and on `--color`).
 `_fmt` looks up `is_terminal_fully_fledged` via `terminal.is_terminal_fully_fledged()`
 (rather than via a `from .terminal import ...` binding) so that
 `unittest.mock.patch('git_machete.utils.terminal.is_terminal_fully_fledged', ...)`
-in tests is honoured at every call.
+in tests is honored at every call.
 """
 
 import re
@@ -41,7 +41,7 @@ def _fmt(s: str, *, use_ansi_escapes: bool) -> str:
     # Looked up via the `terminal` module (not via a top-level
     # `from .terminal import is_terminal_fully_fledged`) so that
     # `mock.patch('git_machete.utils.terminal.is_terminal_fully_fledged', ...)`
-    # is honoured.
+    # is honored.
     ao = FullTerminalAnsiOutputCodes if terminal.is_terminal_fully_fledged() else BasicTerminalAnsiOutputCodes
 
     # pattern                                  ansi replacement                            ascii replacement

--- a/git_machete/utils/paths.py
+++ b/git_machete/utils/paths.py
@@ -1,6 +1,6 @@
 """POSIX-style typed paths and helpers.
 
-Every `Path` / `AbsPath` instance is normalised to forward-slash form on
+Every `Path` / `AbsPath` instance is normalized to forward-slash form on
 construction (via `PurePath(value).as_posix()`), regardless of platform.
 This is load-bearing for:
 
@@ -14,7 +14,7 @@ This is load-bearing for:
   git-machete's state (caches, branch-layout-file path, ...).
 
 Pure I/O (`open`, `os.path.isfile`, `shutil.*`, `subprocess.run(cwd=...)`)
-accepts either form on Windows, so the normalisation is invisible there -
+accepts either form on Windows, so the normalization is invisible there -
 the value lies in the type-system guarantee that downstream comparisons
 and renders are stable.
 
@@ -34,7 +34,7 @@ from pathlib import PurePath, PurePosixPath
 class Path(str):
     """A filesystem path (relative or absolute), always in posix form.
 
-    All normalisation and invariants happen in `__new__` so that
+    All normalization and invariants happen in `__new__` so that
     `Path(value)` / `AbsPath(value)` is the single, obvious way to obtain
     a typed path - there are intentionally no `.of(...)` factory methods.
     """
@@ -56,13 +56,13 @@ class Path(str):
         anything before it).
 
         We use `PurePosixPath` (rather than the platform-aware `PurePath`)
-        for joining because `Path.__new__` has already normalised any
+        for joining because `Path.__new__` has already normalized any
         prior typed segment to forward-slash form, so the inputs here
         are guaranteed posix-style on every platform - `PurePosixPath`
         states that intent explicitly and avoids the Windows-only
         drive-letter / backslash parsing that `PureWindowsPath` would do.
         The result still passes through `Path.__new__` for a final
-        normalisation pass (cheap, idempotent).
+        normalization pass (cheap, idempotent).
         """
         return Path(str(PurePosixPath(*paths)))
 

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -89,7 +89,7 @@ class TestAdd(BaseTest):
 
     def test_add_check_out_remote_branch(self, mocker: MockerFixture) -> None:
         """
-        Verify the behaviour of a 'git machete add' command in the special case when a remote branch is checked out locally.
+        Verify the behavior of a 'git machete add' command in the special case when a remote branch is checked out locally.
         """
 
         create_repo_with_remote()

--- a/tests/test_anno.py
+++ b/tests/test_anno.py
@@ -16,7 +16,7 @@ class TestAnno(BaseTest):
 
     def test_anno(self) -> None:
         """
-        Verify behaviour of a 'git machete anno' command.
+        Verify behavior of a 'git machete anno' command.
         """
 
         create_repo_with_remote()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,7 +12,7 @@ class TestClient(BaseTest):
 
     def test_annotations_read_branch_layout_file(self) -> None:
         """
-        Verify behaviour of a 'MacheteClient.read_branch_layout_file()' method
+        Verify behavior of a 'MacheteClient.read_branch_layout_file()' method
         """
         create_repo_with_remote()
         new_branch('master')

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -15,7 +15,7 @@ class TestFile(BaseTest):
 
     def test_file(self) -> None:
         """
-        Verify behaviour of a 'git machete file' command.
+        Verify behavior of a 'git machete file' command.
         """
 
         create_repo()

--- a/tests/test_go.py
+++ b/tests/test_go.py
@@ -15,7 +15,7 @@ from .mockers import mock_input_returning
 class TestGo(BaseTest):
 
     def test_go_up(self) -> None:
-        """Verify behaviour of a 'git machete go up' command.
+        """Verify behavior of a 'git machete go up' command.
 
         Verify that 'git machete go up' performs 'git checkout' to the
         parent/upstream branch of the current branch.
@@ -60,7 +60,7 @@ class TestGo(BaseTest):
         assert 'level-1-branch' == launch_command("show", "current").strip()
 
     def test_go_down(self, mocker: MockerFixture) -> None:
-        """Verify behaviour of a 'git machete go down' command.
+        """Verify behavior of a 'git machete go down' command.
 
         Verify that 'git machete go down' performs 'git checkout' to the
         child/downstream branch of the current branch.
@@ -99,7 +99,7 @@ class TestGo(BaseTest):
         assert launch_command("show", "current").strip() == "level-2b-branch"
 
     def test_go_first_root_with_downstream(self) -> None:
-        """Verify behaviour of a 'git machete go first' command.
+        """Verify behavior of a 'git machete go first' command.
 
         Verify that 'git machete go first' performs 'git checkout' to
         the first downstream branch of a root branch in the config file
@@ -163,7 +163,7 @@ class TestGo(BaseTest):
              "has any downstream branches.")
 
     def test_go_first_root_without_downstream(self) -> None:
-        """Verify behaviour of a 'git machete go first' command.
+        """Verify behavior of a 'git machete go first' command.
 
         Verify that 'git machete go first' set current branch to root
         if root branch has no downstream.
@@ -182,7 +182,7 @@ class TestGo(BaseTest):
         assert 'level-0-branch' == launch_command("show", "current").strip(), \
             ("Verify that 'git machete go first' set current branch to root "
              "if root branch has no downstream.")
-        # check short command behaviour
+        # check short command behavior
         launch_command("g", "f")
 
         assert 'level-0-branch' == launch_command("show", "current").strip(), \
@@ -190,7 +190,7 @@ class TestGo(BaseTest):
              "if root branch has no downstream.")
 
     def test_go_last(self) -> None:
-        """Verify behaviour of a 'git machete go last' command.
+        """Verify behavior of a 'git machete go last' command.
 
         Verify that 'git machete go last' performs 'git checkout' to
         the last downstream branch of a root branch if root branch
@@ -249,7 +249,7 @@ class TestGo(BaseTest):
         assert 'branch-from-x-additional-root' == launch_command("show", "current").strip()
 
     def test_go_next_successor_exists(self) -> None:
-        """Verify behaviour of a 'git machete go next' command.
+        """Verify behavior of a 'git machete go next' command.
 
         Verify that 'git machete go next' performs 'git checkout' to
         the branch right after the current one in the config file
@@ -293,7 +293,7 @@ class TestGo(BaseTest):
              "config file if successor branch exists.")
 
     def test_go_next_successor_on_another_root_tree(self) -> None:
-        """Verify behaviour of a 'git machete go next' command.
+        """Verify behavior of a 'git machete go next' command.
 
         Verify that 'git machete go next' can checkout to branch that doesn't
         share root with the current branch.
@@ -331,7 +331,7 @@ class TestGo(BaseTest):
              "share root with the current branch.")
 
     def test_go_prev_successor_exists(self) -> None:
-        """Verify behaviour of a 'git machete go prev' command.
+        """Verify behavior of a 'git machete go prev' command.
 
         Verify that 'git machete go prev' performs 'git checkout' to
         the branch right before the current one in the config file
@@ -374,7 +374,7 @@ class TestGo(BaseTest):
              "when predecessor branch exists within the root tree.")
 
     def test_go_prev_successor_on_another_root_tree(self) -> None:
-        """Verify behaviour of a 'git machete go prev' command.
+        """Verify behavior of a 'git machete go prev' command.
 
         Verify that 'git machete go prev' raises an error when predecessor
         branch doesn't exist.
@@ -409,7 +409,7 @@ class TestGo(BaseTest):
              )
 
     def test_go_root(self) -> None:
-        """Verify behaviour of a 'git machete go root' command.
+        """Verify behavior of a 'git machete go root' command.
 
         Verify that 'git machete go root' performs 'git checkout' to
         the root of the current branch.

--- a/tests/test_is_managed.py
+++ b/tests/test_is_managed.py
@@ -9,7 +9,7 @@ class TestIsManaged(BaseTest):
 
     def test_is_managed(self) -> None:
         """
-        Verify behaviour of a 'git machete is-managed' command.
+        Verify behavior of a 'git machete is-managed' command.
         """
 
         create_repo()

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -9,7 +9,7 @@ class TestList(BaseTest):
 
     def test_list(self) -> None:
         """
-        Verify behaviour of a 'git machete list' command.
+        Verify behavior of a 'git machete list' command.
         """
 
         create_repo_with_remote()

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -40,7 +40,7 @@ class TestShow(BaseTest):
         assert_failure(["show", "current", "master"], "show current with a <branch> argument does not make sense")
 
     def test_show_up(self) -> None:
-        """Verify behaviour of a 'git machete show up' command.
+        """Verify behavior of a 'git machete show up' command.
 
         Verify that 'git machete show up' displays name of a parent/upstream
         branch one above current one in the config file from within current
@@ -99,7 +99,7 @@ class TestShow(BaseTest):
         )
 
     def test_show_down(self) -> None:
-        """Verify behaviour of a 'git machete show down' command.
+        """Verify behavior of a 'git machete show down' command.
 
         Verify that 'git machete show down' displays name of a
         child/downstream branch one below current one.
@@ -128,7 +128,7 @@ class TestShow(BaseTest):
         assert_failure(["show", "d", "level-1b-branch"], "Branch level-1b-branch has no downstream branch")
 
     def test_show_first(self) -> None:
-        """Verify behaviour of a 'git machete show first' command.
+        """Verify behavior of a 'git machete show first' command.
 
         Verify that 'git machete show first' displays name of the first downstream
         branch of a root branch of the current branch in the config file if root
@@ -181,7 +181,7 @@ class TestShow(BaseTest):
         )
 
     def test_show_last(self) -> None:
-        """Verify behaviour of a 'git machete show last' command.
+        """Verify behavior of a 'git machete show last' command.
 
         Verify that 'git machete show last' displays name of the last downstream
         branch of a root branch of the current branch in the config file if root
@@ -232,7 +232,7 @@ class TestShow(BaseTest):
         )
 
     def test_show_next(self) -> None:
-        """Verify behaviour of a 'git machete show next' command.
+        """Verify behavior of a 'git machete show next' command.
 
         Verify that 'git machete show next' displays name of
         a branch right after the current one in the config file
@@ -265,7 +265,7 @@ class TestShow(BaseTest):
         assert_failure(["show", "n", "level-1b-branch"], "Branch level-1b-branch has no successor")
 
     def test_show_prev(self) -> None:
-        """Verify behaviour of a 'git machete show prev' command.
+        """Verify behavior of a 'git machete show prev' command.
 
         Verify that 'git machete show prev' displays name of
         a branch right before the current one in the config file
@@ -297,7 +297,7 @@ class TestShow(BaseTest):
         assert_failure(["show", "p", "level-0-branch"], "Branch level-0-branch has no predecessor")
 
     def test_show_root(self) -> None:
-        """Verify behaviour of a 'git machete show root' command.
+        """Verify behavior of a 'git machete show root' command.
 
         Verify that 'git machete show root' displays name of the root of
         the current branch.

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -13,7 +13,7 @@ class TestVersion:
         )
 
     def test_version_flag(self) -> None:
-        # `--version` should be honoured as a top-level flag too, equivalently to `git machete version`.
+        # `--version` should be honored as a top-level flag too, equivalently to `git machete version`.
         assert_success(
             ["--version"],
             f"git-machete version {__version__}\n"

--- a/tox.ini
+++ b/tox.ini
@@ -169,7 +169,7 @@ deps =
   -r{[requirements]dir}/vulture-check.txt
 # Names below are referenced dynamically by external frameworks (pytest, ssl mocks)
 # and `vulture` cannot see those call sites. We use `--ignore-names` rather than inline `# noqa`
-# because `vulture` only honours `# noqa` for unused imports (V104) and unused variables (V841),
+# because `vulture` only honors `# noqa` for unused imports (V104) and unused variables (V841),
 # *not* for unused methods/classes/functions - see https://github.com/jendrikseipp/vulture/issues/205.
 commands = vulture --ignore-names check_hostname,verify_mode,pytest_* git_machete/ tests/
 


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1678

## Chain of upstream PRs as of 2026-05-16

* PR #1678:
  `master` ← `develop`

  * **PR #1693 (THIS ONE)**:
    `develop` ← `chore/ame-spelling`

<!-- end git-machete generated -->
