### PR TITLE
README: point users to the `git-machete` Agent Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,20 +235,21 @@ source <(git machete completion zsh)
 
 ### AI coding agents (Cursor, Claude Code, Codex CLI, GitHub Copilot, ...)
 
-`git machete` ships an [Agent Skill](https://agentskills.io/) that teaches AI coding agents which commands are safe to script, which require `-y/--yes` to avoid hanging on interactive prompts, and how to mutate the branch layout without corrupting it.
-Install it with the [GitHub CLI](https://cli.github.com/) (v2.90+):
+Install with [GitHub CLI](https://cli.github.com/) (v2.90+):
 
 ```shell script
-gh skill install VirtusLab/git-machete --scope user
+gh skill install VirtusLab/git-machete git-machete --scope user
 ```
 
-`--scope user` puts the skill under `~/.<agent>/skills/git-machete/` so every repo on your machine picks it up; without it `gh skill install` defaults to `.<agent>/skills/git-machete/` in the **current** repo only.
-In a TTY `gh` prompts for which agent(s) to install for; non-interactively it defaults to GitHub Copilot - pass `--agent claude-code` / `--agent cursor` / etc. (or pick multiple) for others.
-Most agents (Cursor, Codex CLI, Copilot, Gemini CLI, Cline, OpenCode, Warp, ...) share `~/.agents/skills/`, so one install covers them all; Claude Code uses its own `~/.claude/skills/`.
+`--scope user` puts the skill under `~/.<agent>/skills/git-machete/` so every repo on your machine picks it up;
+without it `gh skill install` defaults to `.<agent>/skills/git-machete/` in the **current** repo only.
+In a TTY `gh` prompts for which agent(s) to install for; non-interactively it defaults to GitHub Copilot &mdash;
+pass `--agent claude-code`/`--agent cursor` etc. for others.
 
 To pull in upstream changes later, run `gh skill update`.
 
-If you don't have `gh`, copy `skills/git-machete/SKILL.md` from this repo into `~/.cursor/skills/git-machete/`, `~/.claude/skills/git-machete/`, `~/.codex/skills/git-machete/`, or `~/.agents/skills/git-machete/` by hand.
+If you don't use `gh`, copy `skills/git-machete/SKILL.md` from this repo
+into `~/.cursor/skills/git-machete/`, `~/.claude/skills/git-machete/`, `~/.codex/skills/git-machete/`, or `~/.agents/skills/git-machete/` by hand.
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -233,6 +233,23 @@ eval "$(git machete completion zsh)"  # or, if it doesn't work:
 source <(git machete completion zsh)
 ```
 
+### AI coding agents (Cursor, Claude Code, Codex CLI, GitHub Copilot, ...)
+
+`git machete` ships an [Agent Skill](https://agentskills.io/) that teaches AI coding agents which commands are safe to script, which require `-y/--yes` to avoid hanging on interactive prompts, and how to mutate the branch layout without corrupting it.
+Install it with the [GitHub CLI](https://cli.github.com/) (v2.90+):
+
+```shell script
+gh skill install VirtusLab/git-machete --scope user
+```
+
+`--scope user` puts the skill under `~/.<agent>/skills/git-machete/` so every repo on your machine picks it up; without it `gh skill install` defaults to `.<agent>/skills/git-machete/` in the **current** repo only.
+In a TTY `gh` prompts for which agent(s) to install for; non-interactively it defaults to GitHub Copilot - pass `--agent claude-code` / `--agent cursor` / etc. (or pick multiple) for others.
+Most agents (Cursor, Codex CLI, Copilot, Gemini CLI, Cline, OpenCode, Warp, ...) share `~/.agents/skills/`, so one install covers them all; Claude Code uses its own `~/.claude/skills/`.
+
+To pull in upstream changes later, run `gh skill update`.
+
+If you don't have `gh`, copy `skills/git-machete/SKILL.md` from this repo into `~/.cursor/skills/git-machete/`, `~/.claude/skills/git-machete/`, `~/.codex/skills/git-machete/`, or `~/.agents/skills/git-machete/` by hand.
+
 <br/>
 
 ## FAQ

--- a/ci/checks/prohibit-ellipsis.sh
+++ b/ci/checks/prohibit-ellipsis.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail -u
+
+if git grep -n -F -e '…' -- :!ci/checks/ :!RELEASE_NOTES.md; then
+  echo
+  echo 'Stray usage of the `…` (U+2026) character found. Use plain `...` (three dots) instead.'
+  exit 1
+fi

--- a/ci/checks/run-all-checks.sh
+++ b/ci/checks/run-all-checks.sh
@@ -37,6 +37,7 @@ _ prohibit-bash-usages-from-python
 _ prohibit-current-date-in-tests
 _ prohibit-deploy-step-in-circleci
 _ prohibit-double-backticks-in-python
+_ prohibit-ellipsis
 _ prohibit-exempli-gratia-in-rst
 _ prohibit-fish-completion-repetition-checks-for-long-options
 _ prohibit-fork-point-in-git


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1692

## Chain of upstream PRs as of 2026-05-16

* PR #1678:
  `master` ← `develop`

  * PR #1692:
    `develop` ← `docs/skills`

    * **PR #1694 (THIS ONE)**:
      `docs/skills` ← `docs/skills-readme`

<!-- end git-machete generated -->

Add a short "AI coding agents" subsection right after shell completion,
since it's a similar kind of optional integration: a single block with
`gh skill install` / `npx skills add` lines (plus an `~/.<agent>/skills/`
copy-paste fallback) and a one-line note on `gh skill update` for pulling
in upstream changes later.

Kept separate from the `SKILL.md`-creation commit so the docs change can
land independently of the much larger skill file under review.