### PR TITLE
Reflow narrow agent-style comment blocks; document the convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,7 @@
 
 - No trailing whitespace on any line.
 - Always leave a single newline at the end of every file.
+- Don't hard-wrap prose (code comments, docstrings, Markdown, commit messages, PR descriptions) at 80 or so columns -
+  the line-length limit is 140 (see `[flake8]` in `tox.ini`).
+  Break on sentence or clause boundaries instead, so each line carries one thought rather than a fragment chopped by column count.
+  Prefer one sentence per line; for a sentence that exceeds 140 columns, split at a natural clause boundary (semicolons, parentheticals, conjunctions, ...).

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -43,18 +43,14 @@ def _populate_cli_options(
         cli_opts: git_machete.options.CommandLineOptions,
         parsed: ParsedCmd,
 ) -> None:
-    """Translate the raw `ParsedCmd` (flags as strings, positionals keyed by
-    display name) into the typed `CommandLineOptions` aggregate.
+    """Translate the raw `ParsedCmd` (flags as strings, positionals keyed by display name) into the typed `CommandLineOptions` aggregate.
 
-    Options are processed in user-input order so that "last one wins" works
-    intuitively: `git machete traverse -W --start-from=here` overrides the
-    `start-from` baked into the `-W` macro because `--start-from=here` is
-    seen later in the command line. Same goes for `--push` after `--no-push`.
+    Options are processed in user-input order so that "last one wins" works intuitively:
+    `git machete traverse -W --start-from=here` overrides the `start-from` baked into the `-W` macro
+    because `--start-from=here` is seen later in the command line. Same goes for `--push` after `--no-push`.
 
-    This is also the only place that knows how to coerce raw strings into the
-    project's domain types (`LocalBranchShortName`, `AnyRevision`,
-    comma-separated `--roots`, the `-W` macro that fans out to four other
-    flags, ...).
+    This is also the only place that knows how to coerce raw strings into the project's domain types
+    (`LocalBranchShortName`, `AnyRevision`, comma-separated `--roots`, the `-W` macro that fans out to four other flags, ...).
     """
     branch_positional: Optional[str] = parsed.positionals.get("branch")
     if branch_positional:
@@ -174,9 +170,8 @@ def _populate_cli_options(
         elif key == "yes":
             cli_opts.opt_yes = True
         # `debug`, `verbose`, `color`, `help`, `version`, `checkout-my-github-prs`,
-        # plus per-subcommand presence-only markers (`sync-github-prs` consumers
-        # of GitLab specs etc.) are picked up directly from `parsed.opts` by the
-        # dispatcher below or by `set_utils_global_variables`.
+        # plus per-subcommand presence-only markers (`sync-github-prs` consumers of GitLab specs etc.)
+        # are picked up directly from `parsed.opts` by the dispatcher below or by `set_utils_global_variables`.
 
     if cli_opts.opt_n or cli_opts.opt_yes:
         # Some branches may carry a merge strategy even when --merge isn't set,
@@ -196,9 +191,9 @@ def update_cli_options_using_config_keys(cli_opts: git_machete.options.CommandLi
 
 
 def set_utils_global_variables(parsed: ParsedCmd) -> None:
-    # `--color` is already applied inside `parse_cmdline` so that any
-    # `MacheteException` raised during validation gets the right ANSI
-    # treatment; here we just propagate the debug / verbose flags.
+    # `--color` is already applied inside `parse_cmdline`
+    # so that any `MacheteException` raised during validation gets the right ANSI treatment;
+    # here we just propagate the debug / verbose flags.
     debug_log.debug_mode = "debug" in parsed.opts
     cmd.verbose_mode = "verbose" in parsed.opts
 
@@ -218,8 +213,7 @@ def launch_internal(orig_args: List[str]) -> None:
 
         parsed = parse_cmdline(orig_args)
 
-        # Set up `--debug` / `--verbose` first so that subsequent
-        # `git config` reads honour them.
+        # Set up `--debug` / `--verbose` first so that subsequent `git config` reads honour them.
         set_utils_global_variables(parsed)
 
         if "help" in parsed.opts:
@@ -238,10 +232,8 @@ def launch_internal(orig_args: List[str]) -> None:
             print_fmt("Extra arguments after `--` are only allowed after `diff` and `log`")
             sys.exit(ExitCode.ARGUMENT_ERROR)
 
-        # `completion`, `help` and `version` neither read git config nor use
-        # `cli_opts`, so skip the config/CLI population for them - in
-        # particular, `help` must keep working even when a config key like
-        # `machete.squashMergeDetection` carries an invalid value.
+        # `completion`, `help` and `version` neither read git config nor use `cli_opts`, so skip the config/CLI population for them -
+        # in particular, `help` must keep working even when a config key like `machete.squashMergeDetection` carries an invalid value.
         if cmd not in ("completion", "help", "version"):
             update_cli_options_using_config_keys(cli_opts)
             _populate_cli_options(cli_opts, parsed)
@@ -338,11 +330,9 @@ def launch_internal(orig_args: List[str]) -> None:
             spec = GITHUB_API_SPEC if cmd == "github" else GITLAB_API_SPEC
             pr_or_mr = spec.pr_short_name.lower()
             request_ids: List[int] = parsed.positionals.get("request_id", [])
-            # Each option's compatibility with each subcommand is encoded
-            # in the github/gitlab `CommandSpec`'s `subcommands` tuple
-            # (see `cli_commands.py::_code_hosting_spec`), so the parser has
-            # already rejected the invalid combinations - the dispatcher
-            # just runs the subcommand.
+            # Each option's compatibility with each subcommand is encoded in the github/gitlab `CommandSpec`'s `subcommands` tuple
+            # (see `cli_commands.py::_code_hosting_spec`), so the parser has already rejected the invalid combinations -
+            # the dispatcher just runs the subcommand.
 
             github_or_gitlab_client = MacheteClientWithCodeHosting(spec)
 
@@ -427,8 +417,8 @@ def launch_internal(orig_args: List[str]) -> None:
             elif category == "slidable":
                 res = list_client.slidable_branches()
             elif category == "slidable-after":
-                # `list_branch` is non-None here: the early-exit check above
-                # raised when `category == 'slidable-after' and not list_branch`.
+                # `list_branch` is non-None here:
+                # the early-exit check above raised when `category == 'slidable-after' and not list_branch`.
                 assert list_branch is not None
                 target_branch = LocalBranchShortName.of(list_branch)
                 list_client.expect_in_managed_branches(target_branch)
@@ -459,12 +449,11 @@ def launch_internal(orig_args: List[str]) -> None:
                 raise MacheteException('`show current` with a `<branch>` argument does not make sense')
             GoShowMacheteClient(verify_branches=False).show(show_direction, opt_branch=cli_opts.opt_branch)
         elif cmd == "slide-out":
-            # `verify_branches=False` so that a branch the user is *explicitly* asking
-            # to slide out doesn't first trigger the "Warning: sliding invalid branch ..."
-            # auto-prune (which then makes the explicit slide-out fail with
-            # "not found in the tree of branch dependencies"). The auto-prune is useful
-            # for commands that just *read* the layout (e.g. `status`, `traverse`); for
-            # `slide-out` it's redundant with the user's own intent.
+            # `verify_branches=False` so that a branch the user is *explicitly* asking to slide out
+            # doesn't first trigger the "Warning: sliding invalid branch ..." auto-prune
+            # (which then makes the explicit slide-out fail with "not found in the tree of branch dependencies").
+            # The auto-prune is useful for commands that just *read* the layout (e.g. `status`, `traverse`);
+            # for `slide-out` it's redundant with the user's own intent.
             slide_out_client = SlideOutMacheteClient(verify_branches=False)
             branches_to_slide_out: List[str] = parsed.positionals.get("branches", [])
             if cli_opts.opt_removed_from_remote:
@@ -525,8 +514,7 @@ def launch_internal(orig_args: List[str]) -> None:
         else:  # rejected by the parser
             raise UnexpectedMacheteException(f"Unknown command: `{cmd}`")
     finally:
-        # Has been fixed in git itself as of 2.35.0, but we still defend
-        # against pre-2.35 + the underlying-checkout-moves-cwd case:
+        # Has been fixed in git itself as of 2.35.0, but we still defend against pre-2.35 + the underlying-checkout-moves-cwd case:
         # see https://github.com/git/git/blob/master/Documentation/RelNotes/2.35.0.txt#L81
         if initial_current_directory and not does_directory_exist(initial_current_directory):
             nearest_existing_parent_directory: AbsPath = initial_current_directory

--- a/git_machete/cli_commands.py
+++ b/git_machete/cli_commands.py
@@ -1,15 +1,11 @@
 """Spec types + catalog of git-machete CLI commands.
 
-This module owns both the data model (`OptSpec`, `PositionalSpec`,
-`MutexGroup`, `SubcommandSpec`, `CommandSpec`, `ParsedCmd`) and the
-data itself (`COMMANDS`, `COMMON_OPTIONS`, `COMMAND_BY_NAME_OR_ALIAS`).
-The parsing engine that consumes these lives in `cli_parser.py` and
-imports from here.
+This module owns both the data model (`OptSpec`, `PositionalSpec`, `MutexGroup`, `SubcommandSpec`, `CommandSpec`, `ParsedCmd`)
+and the data itself (`COMMANDS`, `COMMON_OPTIONS`, `COMMAND_BY_NAME_OR_ALIAS`).
+The parsing engine that consumes these lives in `cli_parser.py` and imports from here.
 
-Keeping types + data together (rather than splitting types into the
-parser module) keeps `cli_parser.py → cli_commands.py` as a one-way
-dependency and removes the need for any forward references or
-parameterization.
+Keeping types + data together (rather than splitting types into the parser module)
+keeps `cli_parser.py → cli_commands.py` as a one-way dependency and removes the need for any forward references or parameterization.
 """
 
 from typing import (Any, Callable, Dict, FrozenSet, List, NamedTuple, Optional,
@@ -25,10 +21,9 @@ from git_machete.help import commands_and_aliases
 class OptSpec(NamedTuple):
     """One option (long, short or both).
 
-    `takes_value` is True iff the option requires an argument (e.g. `--onto
-    foo` or `-o foo`). The display name used in error messages is built
-    from whichever of `short`/`long` is set (preferring `-short/--long` if
-    both are present).
+    `takes_value` is True iff the option requires an argument (e.g. `--onto foo` or `-o foo`).
+    The display name used in error messages is built from whichever of `short`/`long` is set
+    (preferring `-short/--long` if both are present).
     """
     long: Optional[str] = None
     short: Optional[str] = None
@@ -41,9 +36,8 @@ class OptSpec(NamedTuple):
             return f"-{self.short}/--{self.long}"
         if self.long:
             return f"--{self.long}"
-        # Short-only options exist in the catalog (e.g. `-W`, `-n`) but
-        # none of them currently participate in a mutex group, so the
-        # only call site - the mutex-error formatter - never lands here.
+        # Short-only options exist in the catalog (e.g. `-W`, `-n`) but none of them currently participate in a mutex group,
+        # so the only call site - the mutex-error formatter - never lands here.
         assert self.short is not None  # pragma: no cover
         return f"-{self.short}"  # pragma: no cover
 
@@ -56,22 +50,18 @@ class OptSpec(NamedTuple):
 class PositionalSpec(NamedTuple):
     """One positional argument.
 
-    `multiple=True` collects every remaining positional into a list;
-    `required=False` makes a single-valued positional optional.
+    `multiple=True` collects every remaining positional into a list; `required=False` makes a single-valued positional optional.
 
-    `choices` constrains the allowed values; `hidden_choices` is the
-    subset that's still accepted by the parser but never surfaced in
-    error messages or close-match suggestions (used for the deprecated
-    `github sync` subcommand).
+    `choices` constrains the allowed values;
+    `hidden_choices` is the subset that's still accepted by the parser but never surfaced in error messages or close-match suggestions
+    (used for the deprecated `github sync` subcommand).
 
-    `display_name` overrides the human-readable label used in error
-    messages while `name` stays the stable storage key (e.g. github's
-    `request_id` storage key but `PR number` in errors).
+    `display_name` overrides the human-readable label used in error messages
+    while `name` stays the stable storage key (e.g. github's `request_id` storage key but `PR number` in errors).
 
-    `only_with_subcommand`, when set, restricts this positional to a set
-    of subcommands. Used together with the `subcommands` field of
-    `CommandSpec` to surface "X is only valid with Y subcommand" errors
-    from the parser rather than from the dispatcher.
+    `only_with_subcommand`, when set, restricts this positional to a set of subcommands.
+    Used together with the `subcommands` field of `CommandSpec`
+    to surface "X is only valid with Y subcommand" errors from the parser rather than from the dispatcher.
     """
     name: str
     required: bool = True
@@ -90,33 +80,27 @@ class PositionalSpec(NamedTuple):
 class MutexGroup(NamedTuple):
     """A set of options that may not be used together.
 
-    `options` lists `OptSpec.storage_key`s. If two or more of them are
-    set, the group fires.
+    `options` lists `OptSpec.storage_key`s. If two or more of them are set, the group fires.
 
-    If `message` is None, a generic wording is emitted: `Argument X: not
-    allowed with argument Y` (exit code `ARGUMENT_ERROR`).
+    If `message` is None, a generic wording is emitted: `Argument X: not allowed with argument Y` (exit code `ARGUMENT_ERROR`).
 
-    If `message` is a string, it's raised verbatim as a
-    `MacheteException` (exit code `MACHETE_EXCEPTION`). Use this for
-    semantic rejections like "Option `-d/--down-fork-point` only makes
-    sense when using rebase and cannot be specified together with
-    `-M/--merge`." - the message is fully owned by the spec and doesn't
-    depend on which option came first on the command line.
+    If `message` is a string, it's raised verbatim as a `MacheteException` (exit code `MACHETE_EXCEPTION`).
+    Use this for semantic rejections like
+    "Option `-d/--down-fork-point` only makes sense when using rebase and cannot be specified together with `-M/--merge`." -
+    the message is fully owned by the spec and doesn't depend on which option came first on the command line.
     """
     options: Tuple[str, ...]
     message: Optional[str] = None
 
 
 class SubcommandSpec(NamedTuple):
-    """One second-level subcommand of a command that dispatches on its
-    first positional (currently `github` and `gitlab`).
+    """One second-level subcommand of a command that dispatches on its first positional (currently `github` and `gitlab`).
 
-    Each subcommand owns its own option set + mutex groups; the parser
-    unions them across the command's subcommands for the actual parsing
-    pass but validates that any option used on a given command line is
-    accepted by the selected subcommand. `hidden=True` keeps the
-    subcommand accepted by the parser while excluding it from
-    user-facing listings (used for the deprecated `github sync`).
+    Each subcommand owns its own option set + mutex groups;
+    the parser unions them across the command's subcommands for the actual parsing pass
+    but validates that any option used on a given command line is accepted by the selected subcommand.
+    `hidden=True` keeps the subcommand accepted by the parser while excluding it from user-facing listings
+    (used for the deprecated `github sync`).
     """
     name: str
     options: Tuple[OptSpec, ...] = ()
@@ -127,12 +111,11 @@ class SubcommandSpec(NamedTuple):
 class CommandSpec(NamedTuple):
     """One git-machete command.
 
-    `options`, `positionals` and `mutex_groups` describe what's accepted
-    regardless of any subcommand. `subcommands`, when non-empty, makes
-    the first positional a subcommand selector; the parser auto-generates
-    its `PositionalSpec` (with the storage key `{cmd.name}_subcommand`
-    and the display label `{cmd.name} subcommand`) and merges in the
-    selected subcommand's options/mutex_groups for validation.
+    `options`, `positionals` and `mutex_groups` describe what's accepted regardless of any subcommand.
+    `subcommands`, when non-empty, makes the first positional a subcommand selector;
+    the parser auto-generates its `PositionalSpec`
+    (with the storage key `{cmd.name}_subcommand` and the display label `{cmd.name} subcommand`)
+    and merges in the selected subcommand's options/mutex_groups for validation.
     """
     name: str
     aliases: Tuple[str, ...] = ()
@@ -153,13 +136,11 @@ class CommandSpec(NamedTuple):
 class ParsedCmd(NamedTuple):
     """The output of `parse_cmdline`.
 
-    `opts` keys are `OptSpec.storage_key` (the long name, or short if
-    long-less). Boolean flags map to `""`; valued options map to their
-    string value.
+    `opts` keys are `OptSpec.storage_key` (the long name, or short if long-less).
+    Boolean flags map to `""`; valued options map to their string value.
 
-    `positionals` keys are `PositionalSpec.name` (the human-readable name
-    used in error messages); the value is a string, list of strings, or
-    list of converted values depending on `multiple`/`type_conv`.
+    `positionals` keys are `PositionalSpec.name` (the human-readable name used in error messages);
+    the value is a string, list of strings, or list of converted values depending on `multiple`/`type_conv`.
 
     `pass_through` is everything after a literal `--` in argv.
     """
@@ -194,14 +175,12 @@ _SHOW_DIRECTION_CHOICES: Tuple[str, ...] = ("c", "current") + _GO_DIRECTION_CHOI
 
 
 def _code_hosting_spec(*, command: str, pr_or_mr: str, include_sync: bool) -> CommandSpec:
-    """github/gitlab share an identical surface modulo `sync` being deep into
-    deprecation on github-only - build them from one mould.
+    """github/gitlab share an identical surface modulo `sync` being deep into deprecation on github-only - build them from one mould.
 
-    Each second-level subcommand owns its own options; the dispatcher in
-    `cli.py` only needs to look up the selected subcommand and run its
-    command-specific logic, because invalid combinations
-    (`github anno-prs --draft`, `gitlab retarget-mr 123`, ...) are
-    rejected by the parser before the dispatcher ever sees them.
+    Each second-level subcommand owns its own options;
+    the dispatcher in `cli.py` only needs to look up the selected subcommand and run its command-specific logic,
+    because invalid combinations (`github anno-prs --draft`, `gitlab retarget-mr 123`, ...)
+    are rejected by the parser before the dispatcher ever sees them.
     """
     subcommands: Tuple[SubcommandSpec, ...] = (
         SubcommandSpec(
@@ -219,10 +198,9 @@ def _code_hosting_spec(*, command: str, pr_or_mr: str, include_sync: bool) -> Co
         SubcommandSpec(
             name=f"create-{pr_or_mr}",
             options=(
-                # Intentionally undocumented (see commit 336c152): an escape
-                # hatch for the rare case when the parent branch detected by
-                # git-machete isn't the desired PR/MR base. Not exposed
-                # anywhere user-facing on purpose.
+                # Intentionally undocumented (see commit 336c152): an escape hatch for the rare case
+                # when the parent branch detected by git-machete isn't the desired PR/MR base.
+                # Not exposed anywhere user-facing on purpose.
                 OptSpec(long="base", takes_value=True),
                 OptSpec(long="draft"),
                 OptSpec(long="title", takes_value=True),
@@ -349,14 +327,12 @@ COMMANDS: Tuple[CommandSpec, ...] = (
             OptSpec(long="unset-override"),
         ),
         mutex_groups=(
-            # Any two of these clobber each other (`--inferred` vs the
-            # override-*/unset-override family is also covered).
+            # Any two of these clobber each other (`--inferred` vs the override-*/unset-override family is also covered).
             MutexGroup(("inferred", "override-to", "override-to-inferred",
                         "override-to-parent", "unset-override")),
-            # `--explain` is informational and conflicts with anything that
-            # MUTATES the fork-point override. Modelled as four pair groups
-            # sharing the same custom message; only the first matching pair
-            # fires (we exit on the first violation).
+            # `--explain` is informational and conflicts with anything that MUTATES the fork-point override.
+            # Modelled as four pair groups sharing the same custom message;
+            # only the first matching pair fires (we exit on the first violation).
             *(
                 MutexGroup(
                     ("explain", override_opt),

--- a/git_machete/cli_parser.py
+++ b/git_machete/cli_parser.py
@@ -1,14 +1,12 @@
 """Command-line argument parser for git-machete.
 
-A small hand-rolled parser layered on top of `getopt.gnu_getopt`. The
-heavy-lifting features (typo suggestions, scoped close-match hints,
-hidden-but-still-accepted choices, required-positional listings, ...)
-all live here; `getopt` is only used for the option-parsing primitive.
+A small hand-rolled parser layered on top of `getopt.gnu_getopt`.
+The heavy-lifting features (typo suggestions, scoped close-match hints, hidden-but-still-accepted choices,
+required-positional listings, ...) all live here; `getopt` is only used for the option-parsing primitive.
 
-The spec types this parser operates on, plus the actual catalog of
-git-machete commands (`COMMANDS`, `COMMON_OPTIONS`, ...) live in
-`cli_commands.py`. This file imports them and runs the parsing pass;
-`cli.py` is the single external caller, via `parse_cmdline(argv)`.
+The spec types this parser operates on, plus the actual catalog of git-machete commands
+(`COMMANDS`, `COMMON_OPTIONS`, ...) live in `cli_commands.py`.
+This file imports them and runs the parsing pass; `cli.py` is the single external caller, via `parse_cmdline(argv)`.
 """
 
 import difflib
@@ -37,14 +35,12 @@ def parse_cmdline(argv: List[str]) -> ParsedCmd:
     """Parse `argv` into a `ParsedCmd` or exit with an argument error."""
     direct, pass_through = _split_on_dashdash(argv)
 
-    # Locate the command in `direct`. Anything before it must be a
-    # common-option flag; anything after is parsed against the merged
-    # spec (common + command-specific + selected-subcommand).
+    # Locate the command in `direct`. Anything before it must be a common-option flag;
+    # anything after is parsed against the merged spec (common + command-specific + selected-subcommand).
     cmd_pos = _find_command_position(direct)
 
     if cmd_pos is None:
-        # Either there are no positionals at all (`git machete --help`) or
-        # the only "positional" we'd see is an unknown flag (e.g. `-q`).
+        # Either there are no positionals at all (`git machete --help`) or the only "positional" we'd see is an unknown flag (e.g. `-q`).
         # Validate against common options only and return.
         opts, _, unknowns = _scan(direct, COMMON_OPTIONS)
         _apply_color_setting(opts.get("color"))
@@ -57,27 +53,22 @@ def parse_cmdline(argv: List[str]) -> ParsedCmd:
     if cmd is None:
         _fail_invalid_command(cmd_name_typed)
 
-    # Build the union of every option this command may accept on any
-    # subcommand: needed so the option parser knows what's syntactically
-    # valid. We later cross-check each used option against the SELECTED
-    # subcommand and emit a friendlier "only valid with X subcommand"
-    # error for the legal-but-not-here case.
+    # Build the union of every option this command may accept on any subcommand:
+    # needed so the option parser knows what's syntactically valid.
+    # We later cross-check each used option against the SELECTED subcommand
+    # and emit a friendlier "only valid with X subcommand" error for the legal-but-not-here case.
     all_command_options = _collect_all_options(cmd)
     merged_options = COMMON_OPTIONS + all_command_options
     other_args = direct[:cmd_pos] + direct[cmd_pos + 1:]
     opts, positionals, unknowns = _scan(other_args, merged_options)
-    # Apply `--color` before any downstream validation step that might
-    # construct a `MacheteException`: the exception captures the current
-    # `markup.use_ansi_escapes_in_*` values at __init__ time and rendering
-    # is one-shot.
+    # Apply `--color` before any downstream validation step that might construct a `MacheteException`:
+    # the exception captures the current `markup.use_ansi_escapes_in_*` values at __init__ time and rendering is one-shot.
     _apply_color_setting(opts.get("color"))
     if unknowns:
         _fail_unrecognized(unknowns, command=cmd.name)
 
-    # `--help` and `--version` short-circuit positional/mutex validation
-    # so that e.g. `git machete completion --help` prints the completion
-    # help page instead of complaining about the missing `shell`
-    # positional.
+    # `--help` and `--version` short-circuit positional/mutex validation so that
+    # e.g. `git machete completion --help` prints the completion help page instead of complaining about the missing `shell` positional.
     if "help" in opts or "version" in opts:
         return ParsedCmd(command=cmd.name, opts=opts, positionals={}, pass_through=pass_through)
 
@@ -109,8 +100,7 @@ def _collect_all_options(cmd: CommandSpec) -> Tuple[OptSpec, ...]:
 
 
 def _effective_positionals(cmd: CommandSpec) -> Tuple[PositionalSpec, ...]:
-    """Build the final positional list for this command, prepending a
-    synthetic subcommand selector when `cmd.subcommands` is non-empty."""
+    """Build the final positional list for this command, prepending a synthetic subcommand selector when `cmd.subcommands` is non-empty."""
     if not cmd.subcommands:
         return cmd.positionals
     selector = PositionalSpec(
@@ -130,8 +120,7 @@ def _selected_subcommand(
         return None
     name = parsed_positionals.get(cmd.subcommand_positional_name)
     if name is None:  # pragma: no cover
-        # Unreachable in practice: `_validate_positionals` rejects a missing
-        # required subcommand positional before this function is called.
+        # Unreachable in practice: `_validate_positionals` rejects a missing required subcommand positional before this function is called.
         return None
     return next((s for s in cmd.subcommands if s.name == name), None)
 
@@ -147,10 +136,11 @@ def _split_on_dashdash(argv: List[str]) -> Tuple[List[str], List[str]]:
 
 
 def _find_command_position(direct: List[str]) -> Optional[int]:
-    """Walk `direct`, skipping common-option flags, and return the index of
-    the first positional token. `None` if there is no positional at all
-    (or if we hit something option-looking we can't classify - in which
-    case the parser will surface it as an unknown flag below)."""
+    """Walk `direct`, skipping common-option flags, and return the index of the first positional token.
+
+    `None` if there is no positional at all (or if we hit something option-looking we can't classify -
+    in which case the parser will surface it as an unknown flag below).
+    """
     common_long = {o.long for o in COMMON_OPTIONS if o.long}
     common_short = {o.short for o in COMMON_OPTIONS if o.short}
     i = 0
@@ -162,16 +152,13 @@ def _find_command_position(direct: List[str]) -> Optional[int]:
                 # None of the common options take a value, so just step over.
                 i += 1
                 continue
-            # Unknown long option in the top-level segment - bail out
-            # without picking a command. The unknown-flag scan downstream
-            # will turn this into a proper error.
+            # Unknown long option in the top-level segment - bail out without picking a command.
+            # The unknown-flag scan downstream will turn this into a proper error.
             return None
         if a.startswith("-") and len(a) > 1:
             short = a[1:]
-            # Single-letter short → check against the common short
-            # flags; longer `-XXX` (e.g. `-gs`) is by definition not a
-            # common short flag, so bail out for the same reason as
-            # above.
+            # Single-letter short → check against the common short flags;
+            # longer `-XXX` (e.g. `-gs`) is by definition not a common short flag, so bail out for the same reason as above.
             if len(short) == 1 and short in common_short:
                 i += 1
                 continue
@@ -186,15 +173,13 @@ def _scan(
 ) -> Tuple[Dict[str, str], List[str], List[str]]:
     """The actual option scanner.
 
-    Uses `getopt.gnu_getopt` for the happy path (so we inherit its handling
-    of `--long=value`, `--long value`, `-x value`, `-xvalue`, combined
-    short flags, ...). On `GetoptError` we fall back to a single-pass
-    manual sweep that collects EVERY unknown flag (and its trailing value,
-    if any) so the user sees them all at once - rather than getting picked
-    off one by one as they fix typos.
+    Uses `getopt.gnu_getopt` for the happy path
+    (so we inherit its handling of `--long=value`, `--long value`, `-x value`, `-xvalue`, combined short flags, ...).
+    On `GetoptError` we fall back to a single-pass manual sweep that collects EVERY unknown flag (and its trailing value, if any)
+    so the user sees them all at once - rather than getting picked off one by one as they fix typos.
 
-    Returns `(opts, positionals, unknown_flag_tokens)`. `unknown_flag_tokens`
-    is the raw arg list as the user typed it (e.g. `["--srart-from", "foo"]`)
+    Returns `(opts, positionals, unknown_flag_tokens)`.
+    `unknown_flag_tokens` is the raw arg list as the user typed it (e.g. `["--srart-from", "foo"]`)
     so the error formatter can re-emit it verbatim.
     """
     long_specs: Dict[str, OptSpec] = {o.long: o for o in options if o.long}
@@ -210,9 +195,9 @@ def _scan(
         for lng, spec in long_specs.items()
     ]
 
-    # `getopt` treats `-b=foo` as `-b` with value `"=foo"`, but we want
-    # `-b foo` semantics so callers can write either `-b foo`, `-bfoo`
-    # or `-b=foo` interchangeably. Normalize the `-X=value` form here.
+    # `getopt` treats `-b=foo` as `-b` with value `"=foo"`, but we want `-b foo` semantics
+    # so callers can write either `-b foo`, `-bfoo` or `-b=foo` interchangeably.
+    # Normalize the `-X=value` form here.
     normalized_argv = []
     for a in argv:
         if (len(a) >= 4 and a.startswith("-") and not a.startswith("--") and
@@ -226,15 +211,13 @@ def _scan(
     try:
         pairs, positionals = getopt.gnu_getopt(normalized_argv, short_str, long_list)
     except getopt.GetoptError as e:
-        # Recover all unknowns ourselves, so the error message lists every
-        # bad token at once.
+        # Recover all unknowns ourselves, so the error message lists every bad token at once.
         unknown_tokens = _collect_unknown_tokens(argv, long_specs, short_specs)
         if unknown_tokens:
             return {}, [], unknown_tokens
-        # getopt raised for some other reason (typically "option X requires
-        # argument" when the user passes a value-taking flag with no value
-        # after it). Surface getopt's own message as a regular argument
-        # error rather than letting an uncaught `GetoptError` propagate.
+        # getopt raised for some other reason
+        # (typically "option X requires argument" when the user passes a value-taking flag with no value after it).
+        # Surface getopt's own message as a regular argument error rather than letting an uncaught `GetoptError` propagate.
         _argument_error(str(e))
 
     opts: Dict[str, str] = {}
@@ -250,12 +233,10 @@ def _collect_unknown_tokens(
         long_specs: Dict[str, OptSpec],
         short_specs: Dict[str, OptSpec],
 ) -> List[str]:
-    """Walk `argv` once and return the user-typed tokens of every unknown
-    flag, paired with their adjacent value when one was supplied.
+    """Walk `argv` once and return the user-typed tokens of every unknown flag, paired with their adjacent value when one was supplied.
 
     The output is meant to be re-emitted verbatim in the error message,
-    so we preserve the user's syntax (e.g. `--foo=bar` stays a single
-    token while `--foo bar` stays two).
+    so we preserve the user's syntax (e.g. `--foo=bar` stays a single token while `--foo bar` stays two).
     """
     unknown: List[str] = []
     i = 0
@@ -269,9 +250,8 @@ def _collect_unknown_tokens(
                     i += 1  # consume the value
             else:
                 unknown.append(a)
-                # If `--foo bar` (no `=`) and `bar` is unlikely to be its
-                # own flag, also include it for display so the user sees
-                # the full unrecognised pair.
+                # If `--foo bar` (no `=`) and `bar` is unlikely to be its own flag,
+                # also include it for display so the user sees the full unrecognised pair.
                 if "=" not in a and i + 1 < len(argv) and not argv[i + 1].startswith("-"):
                     i += 1
                     unknown.append(argv[i])
@@ -279,8 +259,7 @@ def _collect_unknown_tokens(
             continue
         if a.startswith("-") and len(a) > 1:
             short = a[1:]
-            # Match `-X`, `-Xvalue` (when -X takes a value) but treat
-            # anything else (e.g. `-gs`, `-q`) as unknown.
+            # Match `-X`, `-Xvalue` (when -X takes a value) but treat anything else (e.g. `-gs`, `-q`) as unknown.
             if short[0] in short_specs and (
                     len(short) == 1 or short_specs[short[0]].takes_value):
                 spec = short_specs[short[0]]
@@ -315,9 +294,8 @@ def _format_choices(choices: Iterable[str]) -> str:
 
 
 def _visible_choices(positional: PositionalSpec) -> Tuple[str, ...]:
-    # Callers (`_fail_invalid_choice`, `_fail_missing_required`) only
-    # reach this helper for positionals that already carry `choices=`, so
-    # the empty-choices fallback is just a safety net.
+    # Callers (`_fail_invalid_choice`, `_fail_missing_required`) only reach this helper for positionals that already carry `choices=`,
+    # so the empty-choices fallback is just a safety net.
     if not positional.choices:  # pragma: no cover
         return ()
     return tuple(c for c in positional.choices if c not in positional.hidden_choices)
@@ -326,12 +304,10 @@ def _visible_choices(positional: PositionalSpec) -> Tuple[str, ...]:
 def _apply_color_setting(color: Optional[str]) -> None:
     """Honour `--color` for stdout / stderr ANSI emission.
 
-    Called from inside `parse_cmdline` (rather than waiting until the
-    caller invokes `set_utils_global_variables`) so that any
-    `MacheteException` raised from the validation phase below picks up
-    the same flag values that the rest of the program will use. The
-    exception's `.msg` is rendered once at `__init__` time, so the
-    globals must be correct BEFORE the raise.
+    Called from inside `parse_cmdline` (rather than waiting until the caller invokes `set_utils_global_variables`)
+    so that any `MacheteException` raised from the validation phase below
+    picks up the same flag values that the rest of the program will use.
+    The exception's `.msg` is rendered once at `__init__` time, so the globals must be correct BEFORE the raise.
     """
     use_in_stdout = color == "always" or (color in {None, "auto"} and terminal.is_stdout_a_tty())
     use_in_stderr = color == "always" or (color in {None, "auto"} and terminal.is_stderr_a_tty())
@@ -353,8 +329,7 @@ def _fail_invalid_command(typed: str) -> NoReturn:
     if suggestions:
         lines.append(_format_suggestions(suggestions))
     else:
-        # With ~30 commands the full listing would dwarf the error, so
-        # steer the user to `help` instead.
+        # With ~30 commands the full listing would dwarf the error, so steer the user to `help` instead.
         lines.append("Run `git machete help` to see all available commands.")
     _argument_error("\n".join(lines))
 
@@ -362,8 +337,8 @@ def _fail_invalid_command(typed: str) -> NoReturn:
 def _fail_unrecognized(unknown_tokens: List[str], *, command: Optional[str]) -> NoReturn:
     message = "Unrecognized arguments: " + " ".join(unknown_tokens)
 
-    # Build per-flag suggestions. `--foo=bar` is split before fuzzy-matching
-    # so `--foo` (the actual misspelling) is what we compare against.
+    # Build per-flag suggestions.
+    # `--foo=bar` is split before fuzzy-matching so `--foo` (the actual misspelling) is what we compare against.
     flag_suggestions: List[Tuple[str, List[str]]] = []
     known_options = COMMON_OPTIONS + (
         COMMAND_BY_NAME_OR_ALIAS[command].options if command is not None else ()
@@ -405,10 +380,8 @@ def _validate_positionals(
             values = remaining
             remaining = []
             if pspec.required and not values:  # pragma: no cover
-                # No `multiple=True, required=True` positional currently
-                # exists in COMMANDS - kept as a safety net so we'd notice
-                # immediately if a future command introduced one without
-                # also adding a test.
+                # No `multiple=True, required=True` positional currently exists in COMMANDS -
+                # kept as a safety net so we'd notice immediately if a future command introduced one without also adding a test.
                 _fail_missing_required(pspec)
             converted = [_convert_positional(pspec, v) for v in values]
             result[pspec.name] = converted
@@ -474,9 +447,8 @@ def _validate_mutex_groups(
         if len(seen) < 2:
             continue
         if group.message is not None:
-            # Semantic rejection: propagated as MacheteException so it
-            # surfaces via `assert_failure` and exits with
-            # MACHETE_EXCEPTION rather than ARGUMENT_ERROR.
+            # Semantic rejection: propagated as MacheteException
+            # so it surfaces via `assert_failure` and exits with MACHETE_EXCEPTION rather than ARGUMENT_ERROR.
             raise MacheteException(group.message)
         first = option_by_key[seen[0]].canonical_name
         second = option_by_key[seen[1]].canonical_name
@@ -489,9 +461,10 @@ def _validate_subcommand_restrictions(
         cmd: CommandSpec,
         selected: SubcommandSpec,
 ) -> None:
-    """For every option/positional that's been parsed, verify the selected
-    subcommand accepts it. Raise `MacheteException` with the
-    `<thing> is only valid with <sub> subcommand(s).` wording if not."""
+    """For every option/positional that's been parsed, verify the selected subcommand accepts it.
+
+    Raise `MacheteException` with the `<thing> is only valid with <sub> subcommand(s).` wording if not.
+    """
 
     # ---- options ----------------------------------------------------------
     selected_keys = {o.storage_key for o in selected.options}
@@ -502,8 +475,7 @@ def _validate_subcommand_restrictions(
         offering = [s.name for s in cmd.subcommands
                     if any(o.storage_key == key for o in s.options)]
         if not offering:
-            # Should be unreachable: the parser only accepts options that
-            # belong to SOMETHING.
+            # Should be unreachable: the parser only accepts options that belong to SOMETHING.
             continue  # pragma: no cover
         opt_spec = _find_option_by_key(cmd, key)
         flag_label = f"--{opt_spec.long}" if opt_spec and opt_spec.long else f"-{key}"
@@ -515,14 +487,12 @@ def _validate_subcommand_restrictions(
     # ---- positionals ------------------------------------------------------
     for pspec in cmd.positionals:
         if pspec.only_with_subcommand is None:  # pragma: no cover
-            # Every positional declared on a command-with-subcommands
-            # currently scopes itself to a subcommand (github/gitlab's
-            # `request_id`); the unrestricted branch is kept defensively.
+            # Every positional declared on a command-with-subcommands currently scopes itself to a subcommand
+            # (github/gitlab's `request_id`); the unrestricted branch is kept defensively.
             continue
         value = parsed_positionals.get(pspec.name)
-        # `multiple` positionals come back as lists; treat empty/None as
-        # "not supplied" so we only fire when the user actually provided
-        # the positional under the wrong subcommand.
+        # `multiple` positionals come back as lists; treat empty/None as "not supplied"
+        # so we only fire when the user actually provided the positional under the wrong subcommand.
         if not value:
             continue
         if selected.name in pspec.only_with_subcommand:
@@ -535,11 +505,9 @@ def _validate_subcommand_restrictions(
 
 
 def _find_option_by_key(cmd: CommandSpec, key: str) -> Optional[OptSpec]:
-    # Flatten cmd-level options and per-subcommand options into one stream so
-    # we don't need a separately-tested branch for each level - in practice
-    # the only caller is the github/gitlab subcommand-restriction validator,
-    # which only ever queries keys defined on a subcommand (cmd.options is
-    # empty for both code-hosting commands).
+    # Flatten cmd-level options and per-subcommand options into one stream so we don't need a separately-tested branch for each level -
+    # in practice the only caller is the github/gitlab subcommand-restriction validator,
+    # which only ever queries keys defined on a subcommand (cmd.options is empty for both code-hosting commands).
     candidates = itertools.chain(
         cmd.options,
         *(sub.options for sub in cmd.subcommands),

--- a/git_machete/client/status.py
+++ b/git_machete/client/status.py
@@ -254,13 +254,12 @@ class StatusMacheteClient(MacheteClient):
             *,
             parent_branch: LocalBranchShortName,
             inferring_branches: List[BranchPair]) -> bool:
-        # Suppresses the spurious yellow edge that appears when the parent branch is merely behind
-        # its remote counterpart and the child branch was forked from the remote tip. We only
-        # fire here for parents that have a remote counterpart at all (otherwise the "behind
-        # remote" situation cannot arise), and only if `parent_branch` appears among the inferring
-        # branches - either directly as `parent_remote`, or as the `local_branch` side of a
-        # `BranchPair(parent_branch, parent_branch)` entry produced when the inferred commit
-        # survives on `parent_branch`'s own filtered reflog after the push.
+        # Suppresses the spurious yellow edge that appears when the parent branch is merely behind its remote counterpart
+        # and the child branch was forked from the remote tip.
+        # We only fire here for parents that have a remote counterpart at all (otherwise the "behind remote" situation cannot arise),
+        # and only if `parent_branch` appears among the inferring branches -
+        # either directly as `parent_remote`, or as the `local_branch` side of a `BranchPair(parent_branch, parent_branch)` entry
+        # produced when the inferred commit survives on `parent_branch`'s own filtered reflog after the push.
         parent_remote = self._git.get_combined_counterpart_for_fetching_of_branch(parent_branch)
         if parent_remote is None:
             return False
@@ -363,9 +362,9 @@ class StatusMacheteClient(MacheteClient):
                                     f' seems to be a part of the unique history of {fp_branches_formatted}'
                                 )
                             else:
-                                # Reaching the green-edge marker with no inferring branches means the
-                                # fork point comes from an active override (a fallback-to-parent fork
-                                # point equals the parent hash, so it never appears in `parent..branch`).
+                                # Reaching the green-edge marker with no inferring branches
+                                # means the fork point comes from an active override
+                                # (a fallback-to-parent fork point equals the parent hash, so it never appears in `parent..branch`).
                                 fp_suffix = f' {marker}: overridden'
                         commits.append((commit, fp_suffix))
                 commits_by_branch[branch] = commits

--- a/tests/cli_runner.py
+++ b/tests/cli_runner.py
@@ -67,14 +67,13 @@ def assert_failure(cmd_and_args: Iterable[str], expected_message: str, expected_
 
 
 def assert_argument_error(cmd_and_args: Iterable[str], expected_output: str) -> None:
-    """Run the CLI and assert it exits with `ARGUMENT_ERROR` after emitting
-    exactly `expected_output` (a literal multi-line string) on stdout/stderr.
+    """Run the CLI and assert it exits with `ARGUMENT_ERROR`
+    after emitting exactly `expected_output` (a literal multi-line string) on stdout/stderr.
 
     `assert_failure` reads the failure text from `MacheteException.msg`,
-    but syntactic argument errors (mutex groups, invalid choices, missing
-    required, unrecognized flags, ...) bubble up as `SystemExit`
-    (carrying only an exit code) with the actual message written to
-    stdout/stderr - hence this dedicated helper.
+    but syntactic argument errors (mutex groups, invalid choices, missing required, unrecognized flags, ...)
+    bubble up as `SystemExit` (carrying only an exit code) with the actual message written to stdout/stderr -
+    hence this dedicated helper.
     """
     output, e = launch_command_capturing_output_and_exception(*cmd_and_args)
     assert type(e) is SystemExit

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,9 +16,8 @@ from .git_repository import create_repo
 class TestCLI(BaseTest):
     @pytest.mark.parametrize("flag", ["--debug", "-v", "--verbose"])
     def test_verbose_no_command(self, flag: str) -> None:
-        # Asserting on the full help output here would be brittle (the listing
-        # tracks every (sub)command); we only smoke-check that `--help`-style
-        # output is what we get instead of a stack trace.
+        # Asserting on the full help output here would be brittle (the listing tracks every (sub)command);
+        # we only smoke-check that `--help`-style output is what we get instead of a stack trace.
         output, e = launch_command_capturing_output_and_exception(flag)
         assert output and "Usage: git machete" in output
         assert type(e) is SystemExit
@@ -60,9 +59,9 @@ class TestCLI(BaseTest):
             "Did you mean: `traverse`?")
 
     def test_unknown_subcommand_no_close_match(self) -> None:
-        """A garbage top-level command without a near-miss should steer the
-        user to `git machete help` (the help hint is suppressed when there IS
-        a close match - that match is the actionable suggestion)."""
+        """A garbage top-level command without a near-miss should steer the user to `git machete help`
+        (the help hint is suppressed when there IS a close match - that match is the actionable suggestion).
+        """
         assert_argument_error(
             ["xyzzy"],
             "Invalid command: 'xyzzy'\n"
@@ -92,11 +91,9 @@ class TestCLI(BaseTest):
             "Did you mean: `--start-from`?")
 
     def test_unknown_flag_with_uppercase_letter_suggests_close_match(self) -> None:
-        """A wrong-case typo (`--list-commitS` vs `--list-commits`) is still
-        within difflib's similarity threshold and should be suggested.
+        """A wrong-case typo (`--list-commitS` vs `--list-commits`) is still within difflib's similarity threshold and should be suggested.
 
-        Also serves as the regression test for the message prefix being
-        sentence-cased (`Unrecognized`, not `unrecognized`).
+        Also serves as the regression test for the message prefix being sentence-cased (`Unrecognized`, not `unrecognized`).
         """
         assert_argument_error(
             ["status", "--list-commitS"],
@@ -106,13 +103,11 @@ class TestCLI(BaseTest):
     def test_unknown_flag_scoped_to_subparser(self) -> None:
         """Suggestions only consider options of the active subcommand.
 
-        `--checked-out-since` exists on `discover` but not on `traverse`. A typo
-        of it under `traverse` must NOT trigger a suggestion based on `discover`'s
-        vocabulary - otherwise we'd be telling the user to use a flag that the
-        active subcommand rejects.
+        `--checked-out-since` exists on `discover` but not on `traverse`.
+        A typo of it under `traverse` must NOT trigger a suggestion based on `discover`'s vocabulary -
+        otherwise we'd be telling the user to use a flag that the active subcommand rejects.
 
-        Since there is no spelling-correction hint, the message falls back to
-        pointing the user at the subcommand's help page.
+        Since there is no spelling-correction hint, the message falls back to pointing the user at the subcommand's help page.
         """
         assert_argument_error(
             ["traverse", "--checked-out-snc", "foo"],
@@ -127,9 +122,9 @@ class TestCLI(BaseTest):
             "Did you mean: `--checked-out-since`?")
 
     def test_two_unknown_flags_each_with_suggestion(self) -> None:
-        """When multiple unrecognized flags each have a close match, every
-        suggestion line is prefixed with the originating flag name so the
-        user can tell them apart."""
+        """When multiple unrecognized flags each have a close match,
+        every suggestion line is prefixed with the originating flag name so the user can tell them apart.
+        """
         assert_argument_error(
             ["traverse", "--srart-from", "foo", "--debugg"],
             "Unrecognized arguments: --srart-from foo --debugg\n"
@@ -137,25 +132,25 @@ class TestCLI(BaseTest):
             "For `--debugg`: did you mean: `--debug`?")
 
     def test_unknown_short_flag_points_to_help(self) -> None:
-        """Short flags like `-q` or `-gs` have no long-option close match,
-        so the message falls back to the subcommand help page."""
+        """Short flags like `-q` or `-gs` have no long-option close match, so the message falls back to the subcommand help page."""
         assert_argument_error(
             ["status", "-q"],
             "Unrecognized arguments: -q\n"
             "See `git machete help status` for usage.")
 
     def test_unknown_short_flags_nested_subcommand_points_to_help(self) -> None:
-        """For a two-level subcommand (`github create-pr`), the hint points
-        at the top-level subcommand (`github`) since that is what
-        `git machete help` accepts as its argument."""
+        """For a two-level subcommand (`github create-pr`), the hint points at the top-level subcommand (`github`)
+        since that is what `git machete help` accepts as its argument.
+        """
         assert_argument_error(
             ["github", "create-pr", "-gs"],
             "Unrecognized arguments: -gs\n"
             "See `git machete help github` for usage.")
 
     def test_unknown_flag_no_subcommand_no_hint(self) -> None:
-        """At the top level (no subcommand selected), there is no help page
-        to point at, so no hint is appended when there is also no suggestion."""
+        """At the top level (no subcommand selected), there is no help page to point at,
+        so no hint is appended when there is also no suggestion.
+        """
         assert_argument_error(
             ["-q"],
             "Unrecognized arguments: -q")
@@ -172,9 +167,8 @@ class TestCLI(BaseTest):
     def test_invalid_nested_choice_no_close_match_lists_all(self) -> None:
         """Nested invalid choices without a near-miss list every option.
 
-        The top-level "Run `git machete help`" hint would point the user at
-        the wrong help topic for nested subcommands, and the choice sets here
-        are small enough that printing them all is the friendlier option.
+        The top-level "Run `git machete help`" hint would point the user at the wrong help topic for nested subcommands,
+        and the choice sets here are small enough that printing them all is the friendlier option.
         """
         # github subcommand
         assert_argument_error(
@@ -188,8 +182,8 @@ class TestCLI(BaseTest):
             "Invalid gitlab subcommand: 'xyzzy'\n"
             "Possible values for gitlab subcommand are: "
             "anno-mrs, checkout-mrs, create-mr, restack-mr, retarget-mr, update-mr-descriptions")
-        # `go` direction (note: aliases like `d`, `f` are part of the choice set
-        # and so legitimately show up here, mirroring the missing-required path)
+        # `go` direction
+        # (note: aliases like `d`, `f` are part of the choice set and so legitimately show up here, mirroring the missing-required path)
         assert_argument_error(
             ["go", "xyzzy"],
             "Invalid go direction: 'xyzzy'\n"
@@ -232,8 +226,7 @@ class TestCLI(BaseTest):
     def test_missing_required_choice_for_github(self) -> None:
         """`git machete github` lists subcommands.
 
-        `sync` is intentionally omitted from the listing - see
-        `test_github_sync_hidden_from_close_match_suggestions` for the rationale.
+        `sync` is intentionally omitted from the listing - see `test_github_sync_hidden_from_close_match_suggestions` for the rationale.
         """
         assert_argument_error(
             ["github"],
@@ -244,9 +237,8 @@ class TestCLI(BaseTest):
     def test_invalid_choice_for_subcommand_positional(self) -> None:
         """`git machete github creat-pr` should suggest `create-pr`.
 
-        Several `*-pr` subcommands are similar enough that difflib returns more
-        than one candidate; we pin down the full ordered list since the order
-        is deterministic (best match first by difflib's similarity ratio).
+        Several `*-pr` subcommands are similar enough that difflib returns more than one candidate;
+        we pin down the full ordered list since the order is deterministic (best match first by difflib's similarity ratio).
         """
         assert_argument_error(
             ["github", "creat-pr"],
@@ -254,15 +246,15 @@ class TestCLI(BaseTest):
             "Did you mean: `create-pr`, `retarget-pr`, `restack-pr`?")
 
     def test_github_sync_hidden_from_close_match_suggestions(self) -> None:
-        """`github sync` is deep into deprecation. It must remain accepted by
-        the parser, but a typo close to `sync` must NOT suggest it - that
-        would advertise a command we're trying to retire. Same goes for the
-        `Possible values` listing in `test_missing_required_choice_for_github`.
+        """`github sync` is deep into deprecation.
+
+        It must remain accepted by the parser, but a typo close to `sync` must NOT suggest it -
+        that would advertise a command we're trying to retire.
+        Same goes for the `Possible values` listing in `test_missing_required_choice_for_github`.
         """
-        # `snc` is similar to `sync` (and to nothing else under github), so
-        # without the `_hidden_from_listing` filter we'd suggest `sync` here.
-        # With the filter, no close-match line is produced and we fall through
-        # to the "Possible values" listing instead.
+        # `snc` is similar to `sync` (and to nothing else under github),
+        # so without the `_hidden_from_listing` filter we'd suggest `sync` here.
+        # With the filter, no close-match line is produced and we fall through to the "Possible values" listing instead.
         assert_argument_error(
             ["github", "snc"],
             "Invalid github subcommand: 'snc'\n"
@@ -282,9 +274,9 @@ class TestCLI(BaseTest):
     # ─── Missing required positional WITHOUT `choices=` ──────────────────────
 
     def test_missing_required_positional_without_choices(self) -> None:
-        """`git machete rename` requires `<new_name>` but has no `choices=`, so
-        the "Possible values" follow-up line MUST NOT be appended - we just
-        report which positional is missing."""
+        """`git machete rename` requires `<new_name>` but has no `choices=`,
+        so the "Possible values" follow-up line MUST NOT be appended - we just report which positional is missing.
+        """
         assert_argument_error(
             ["rename"],
             "The following arguments are required: new_name")
@@ -292,16 +284,14 @@ class TestCLI(BaseTest):
     # ─── Excess / unrecognized positionals ───────────────────────────────────
 
     def test_excess_positionals_after_last_scalar(self) -> None:
-        """`add` accepts at most one positional (`<branch>`). Extras must be
-        reported as unrecognized arguments."""
+        """`add` accepts at most one positional (`<branch>`). Extras must be reported as unrecognized arguments."""
         assert_argument_error(
             ["add", "foo", "bar"],
             "Unrecognized arguments: bar\n"
             "See `git machete help add` for usage.")
 
     def test_positionals_on_command_without_positional_specs(self) -> None:
-        """`advance` takes no positionals at all; anything passed is rejected
-        as unrecognized."""
+        """`advance` takes no positionals at all; anything passed is rejected as unrecognized."""
         assert_argument_error(
             ["advance", "foo"],
             "Unrecognized arguments: foo\n"
@@ -311,9 +301,9 @@ class TestCLI(BaseTest):
 
     def test_invalid_int_positional_for_github_pr_number(self) -> None:
         """`github checkout-prs` takes one or more PR numbers (`type_conv=int`).
-        A non-integer must surface as "invalid int value" with the
-        user-facing `PR number` label, not the internal `request_id`
-        storage key."""
+
+        A non-integer must surface as "invalid int value" with the user-facing `PR number` label, not the internal `request_id` storage key.
+        """
         assert_argument_error(
             ["github", "checkout-prs", "not-a-number"],
             "Argument PR number: invalid int value: 'not-a-number'")
@@ -321,16 +311,13 @@ class TestCLI(BaseTest):
     # ─── Mutex group WITHOUT a custom message ────────────────────────────────
 
     def test_mutex_group_default_message(self) -> None:
-        """`fork-point` declares a 5-way mutex group on the override flags
-        with NO custom message; that path emits the generic
-        `Argument X: not allowed with argument Y` wording. Picking two
-        long-only flags here also covers `OptSpec.canonical_name`'s
-        long-only branch."""
-        # The wording lists the two flags in their MutexGroup-declaration
-        # order (not the user's argv order): `("override-to-inferred",
-        # "override-to-parent")` is the declared order, so the error
-        # complains about `--override-to-parent` against
-        # `--override-to-inferred` regardless of which the user typed first.
+        """`fork-point` declares a 5-way mutex group on the override flags with NO custom message;
+        that path emits the generic `Argument X: not allowed with argument Y` wording.
+        Picking two long-only flags here also covers `OptSpec.canonical_name`'s long-only branch.
+        """
+        # The wording lists the two flags in their MutexGroup-declaration order (not the user's argv order):
+        # `("override-to-inferred", "override-to-parent")` is the declared order,
+        # so the error complains about `--override-to-parent` against `--override-to-inferred` regardless of which the user typed first.
         assert_argument_error(
             ["fork-point", "--override-to-parent", "--override-to-inferred"],
             "Argument --override-to-parent: not allowed with argument --override-to-inferred")
@@ -338,10 +325,11 @@ class TestCLI(BaseTest):
     # ─── Boolean flag passed WITH a value ────────────────────────────────────
 
     def test_boolean_flag_passed_with_value(self) -> None:
-        """`--yes` is a boolean flag (no `takes_value`). Passing `--yes=true`
-        must surface a sane argument error, not let getopt's raw
-        `GetoptError` propagate. We pass the message through verbatim
-        from getopt rather than maintaining a bespoke re-wording."""
+        """`--yes` is a boolean flag (no `takes_value`).
+
+        Passing `--yes=true` must surface a sane argument error, not let getopt's raw `GetoptError` propagate.
+        We pass the message through verbatim from getopt rather than maintaining a bespoke re-wording.
+        """
         assert_argument_error(
             ["add", "--yes=true"],
             "option --yes must not have an argument")
@@ -349,17 +337,17 @@ class TestCLI(BaseTest):
     # ─── Value-taking flag passed without a value ────────────────────────────
 
     def test_value_taking_flag_without_value(self) -> None:
-        """`getopt` raises "option requires argument" for `-o` / `--onto` with
-        no value after it. The parser must catch this rather than let
-        the raw `GetoptError` propagate; we re-emit getopt's message
-        verbatim."""
+        """`getopt` raises "option requires argument" for `-o` / `--onto` with no value after it.
+
+        The parser must catch this rather than let the raw `GetoptError` propagate;
+        we re-emit getopt's message verbatim.
+        """
         # Short form.
         assert_argument_error(
             ["add", "-o"],
             "option -o requires argument")
-        # Long form. `gnu_getopt`'s "long with =" parsing would accept an
-        # explicit empty `--onto=`, so we exercise the no-`=`, end-of-argv
-        # case to actually trigger the recovery path.
+        # Long form. `gnu_getopt`'s "long with =" parsing would accept an explicit empty `--onto=`,
+        # so we exercise the no-`=`, end-of-argv case to actually trigger the recovery path.
         assert_argument_error(
             ["add", "--onto"],
             "option --onto requires argument")
@@ -367,12 +355,12 @@ class TestCLI(BaseTest):
     # ─── Unknown-flag recovery preserves adjacent KNOWN options ──────────────
 
     def test_unknown_flag_recovery_skips_over_known_separated_value(self) -> None:
-        """When the unknown-token recovery path walks argv after getopt has
-        failed, it must NOT mistake the value of a *known* long option
-        (passed in separated form like `--color always`) for a positional
-        and append it to the unknown list. Same idea for short options
-        like `-o develop`. We feed both forms next to an unknown
-        `--definitely-not-a-flag` and assert only the unknown surfaces."""
+        """When the unknown-token recovery path walks argv after getopt has failed,
+        it must NOT mistake the value of a *known* long option (passed in separated form like `--color always`)
+        for a positional and append it to the unknown list.
+        Same idea for short options like `-o develop`.
+        We feed both forms next to an unknown `--definitely-not-a-flag` and assert only the unknown surfaces.
+        """
         # Long-form: `--color always` adjacent to the unknown flag.
         assert_argument_error(
             ["status", "--color", "always", "--definitely-not-a-flag"],

--- a/tests/test_traverse.py
+++ b/tests/test_traverse.py
@@ -29,13 +29,11 @@ from .shell import write_to_file
 
 class TestTraverse(BaseTest):
 
-    # Building the "standard tree" from scratch takes ~4.3 s per test, dominated
-    # by ~25 git subprocess invocations plus a hard 1.5 s `time.sleep` in
-    # `wait_to_bump_commit_timestamp`. Since the tree is identical across every
-    # test that uses it, we build it once per process and let each test
-    # `shutil.copytree` it into a fresh temp directory. The copy of a small
-    # bare/non-bare repo pair is sub-10 ms, so ~18 call sites in this file
-    # collectively save tens of seconds of CI time.
+    # Building the "standard tree" from scratch takes ~4.3 s per test, dominated by ~25 git subprocess invocations
+    # plus a hard 1.5 s `time.sleep` in `wait_to_bump_commit_timestamp`.
+    # Since the tree is identical across every test that uses it, we build it once per process
+    # and let each test `shutil.copytree` it into a fresh temp directory.
+    # The copy of a small bare/non-bare repo pair is sub-10 ms, so ~18 call sites in this file collectively save tens of seconds of CI time.
     _standard_tree_template: ClassVar[Optional[Tuple[str, str]]] = None
 
     @classmethod
@@ -109,9 +107,8 @@ class TestTraverse(BaseTest):
         shutil.copytree(template_remote, new_remote)
 
         os.chdir(new_local)
-        # The local repo's `origin` URL still points at the template's remote
-        # path (baked in by `add_remote` during template build); repoint it
-        # so that any further push/fetch in the test exercises this copy.
+        # The local repo's `origin` URL still points at the template's remote path (baked in by `add_remote` during template build);
+        # repoint it so that any further push/fetch in the test exercises this copy.
         set_remote_url("origin", new_remote)
 
     def test_traverse_slide_out(self, mocker: MockerFixture) -> None:
@@ -189,8 +186,7 @@ class TestTraverse(BaseTest):
         )
 
     def test_traverse_sync_both_github_and_gitlab(self) -> None:
-        # `-H/--sync-github-prs` and `-L/--sync-gitlab-mrs` are pairwise
-        # mutually exclusive on `traverse`, enforced via a mutex group.
+        # `-H/--sync-github-prs` and `-L/--sync-gitlab-mrs` are pairwise mutually exclusive on `traverse`, enforced via a mutex group.
         assert_argument_error(
             ["traverse", "--sync-github-prs", "--sync-gitlab-mrs"],
             "Argument -L/--sync-gitlab-mrs: not allowed with argument -H/--sync-github-prs"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -13,8 +13,7 @@ class TestVersion:
         )
 
     def test_version_flag(self) -> None:
-        # `--version` should be honoured as a top-level flag too, equivalently
-        # to `git machete version`.
+        # `--version` should be honoured as a top-level flag too, equivalently to `git machete version`.
         assert_success(
             ["--version"],
             f"git-machete version {__version__}\n"


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1678

## Chain of upstream PRs as of 2026-05-18

* PR #1678:
  `master` ← `develop`

  * **PR #1697 (THIS ONE)**:
    `develop` ← `chore/reflow-agent-comments`

<!-- end git-machete generated -->

The recent CLI rework series (`Replace argparse with getopt-based hand-rolled parser`
through `Move agent rules from .cursor/rules into AGENTS.md`) was largely agent-driven
and ended up wrapping comments and docstrings at ~80 columns - a habit baked into LLMs
that doesn't match this project's actual `[flake8] max-line-length = 140` (see `tox.ini`).
Narrow wrapping fragments single thoughts across 5-8 lines and is harder to read than
sentence-per-line layout, especially for multi-clause explanations.

Reflow every such block touched by the recent agent commits into a natural layout:
one sentence per line; long sentences split at semicolons, parentheticals, or conjunctions;
no line over 140 columns. No code changes - comments and docstrings only.

Files touched: `cli.py`, `cli_parser.py`, `cli_commands.py`, `client/status.py`,
plus the test helpers `cli_runner.py` and the agent-touched portions of `test_cli.py`,
`test_traverse.py`, `test_version.py`.

Also extend `AGENTS.md` with an explicit rule against narrow hard-wrapping
(applies to code comments, docstrings, Markdown, commit messages and PR descriptions)
so future agent sessions default to the project's actual style.