### PR TITLE
AGENTS.md: don't run `tox -e flake8` / `tox -e vulture` from a Cursor agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,8 @@
 - Run autoformatters and linters via `tox`. Never invoke `flake8`, `isort`,
   `mypy`, `vulture`, `pylint` (etc.) directly - go through their respective
   `tox -e <env>` invocation so dependency versions stay pinned.
+- Exception: do NOT run `tox -e flake8` or `tox -e vulture` (or those binaries directly).
+  They hang indefinitely inside Cursor's terminal for an unidentified reason - rely on CI to catch any violations.
 - Run tests with `tox -e py [-- <pytest flags like -k>...]`. Do NOT run
   `pytest`, `python -m pytest`, or any tox-built venv's pytest binary
   directly. Tox's `passenv` shielding is what keeps test runs deterministic

--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -39,46 +39,39 @@ class MacheteClient:
 
     def __init__(self, *, read_layout_file: bool = True, verify_branches: bool = True,
                  interactively_slide_out_invalid_branches: bool = False) -> None:
-        # Clients own their `Git` plumbing instance - command-dispatch code
-        # (`cli.py`) and tests never touch it directly. Pass-throughs are
-        # avoided in favor of domain-specific methods on the client itself.
+        # Clients own their `Git` plumbing instance - command-dispatch code (`cli.py`) and tests never touch it directly.
+        # Pass-throughs are avoided in favor of domain-specific methods on the client itself.
         self._git: Git = Git()
         self._config: MacheteConfig = MacheteConfig(self._git)
         self._git.owner = self
 
         self._branch_layout_file_path: AbsPath = self.__get_git_machete_branch_layout_file_path()
-        # Cwd-relative rendition of the layout path, captured at init time
-        # for use in user-facing messages (compact, points at the file as
-        # the user invoked us from). I/O always uses the absolute path so
-        # it survives any mid-run `chdir` (e.g. into a linked worktree).
+        # Cwd-relative rendition of the layout path, captured at init time for use in user-facing messages
+        # (compact, points at the file as the user invoked us from).
+        # I/O always uses the absolute path so it survives any mid-run `chdir` (e.g. into a linked worktree).
         try:
             self._branch_layout_file_path_for_display: Path = Path.relative(self._branch_layout_file_path)
         except Exception:  # pragma: no cover
             self._branch_layout_file_path_for_display = self._branch_layout_file_path
         if not os.path.exists(self._branch_layout_file_path):
             # We're opening in "append" and not "write" mode to avoid a race condition:
-            # if other process writes to the file between we check the
-            # result of `os.path.exists` and call `open`,
-            # then open(..., "w") would result in us clearing up the file
-            # contents, while open(..., "a") has no effect.
+            # if other process writes to the file between we check the result of `os.path.exists` and call `open`,
+            # then open(..., "w") would result in us clearing up the file contents, while open(..., "a") has no effect.
             with open(self._branch_layout_file_path, "a"):
                 pass
         elif os.path.isdir(self._branch_layout_file_path):
-            # Extremely unlikely case, basically checking if anybody
-            # tampered with the repository.
+            # Extremely unlikely case, basically checking if anybody tampered with the repository.
             raise MacheteException(
                 f"{self._branch_layout_file_path_for_display} is a directory "
                 "rather than a regular file, aborting")
 
         self.__init_state()
 
-        # Load the layout file as part of construction so that callers
-        # consistently get a ready-to-use client; subclasses don't need
-        # to remember a separate `client.read_branch_layout_file(...)`
-        # step (and easily get its flags wrong for the command at hand).
-        # `read_layout_file=False` is for the few commands (`edit`, `file`)
-        # that must work even when the layout file is malformed - their
-        # whole point is to let the user inspect or fix it.
+        # Load the layout file as part of construction so that callers consistently get a ready-to-use client;
+        # subclasses don't need to remember a separate `client.read_branch_layout_file(...)` step
+        # (and easily get its flags wrong for the command at hand).
+        # `read_layout_file=False` is for the few commands (`edit`, `file`) that must work even when the layout file is malformed -
+        # their whole point is to let the user inspect or fix it.
         if read_layout_file:
             self.read_branch_layout_file(
                 verify_branches=verify_branches,
@@ -89,12 +82,10 @@ class MacheteClient:
             machete_file_directory = self._git.get_main_worktree_git_dir()
         else:
             machete_file_directory = self._git.get_current_worktree_git_dir()
-        # Keep the path absolute: `traverse` and other commands may `chdir` into
-        # linked worktrees mid-run, and a stored cwd-relative path would then
-        # resolve against the wrong directory - inside a linked worktree `.git`
-        # is a gitdir-pointer file, so `.git/machete` no longer points at the
-        # layout file. The underlying `get_SOMETHING_worktree_git_dir()` helpers already
-        # return absolute paths (via `git rev-parse` + `abs_path`).
+        # Keep the path absolute: `traverse` and other commands may `chdir` into linked worktrees mid-run,
+        # and a stored cwd-relative path would then resolve against the wrong directory -
+        # inside a linked worktree `.git` is a gitdir-pointer file, so `.git/machete` no longer points at the layout file.
+        # The underlying `get_SOMETHING_worktree_git_dir()` helpers already return absolute paths (via `git rev-parse` + `abs_path`).
         return machete_file_directory.join_fragments('machete')
 
     def __init_state(self) -> None:
@@ -122,9 +113,8 @@ class MacheteClient:
     # === Branch existence assertions ===
 
     def expect_in_managed_branches(self, branch: LocalBranchShortName) -> ManagedBranchName:
-        """Verify `branch` lives in the layout file; on success, narrow its
-        type to `ManagedBranchName` so the caller can pass it to layout-
-        mutating APIs without a re-check."""
+        """Verify `branch` lives in the layout file;
+        on success, narrow its type to `ManagedBranchName` so the caller can pass it to layout-mutating APIs without a re-check."""
         managed = self._state.as_managed(branch)
         if managed is None:
             raise MacheteException(
@@ -321,11 +311,9 @@ class MacheteClient:
             if parent and parent_hash and \
                     self._git.is_ancestor_or_equal(parent.full_name(), branch.full_name()) and \
                     not self._git.is_ancestor_or_equal(parent.full_name(), computed_fork_point):
-                # That happens very rarely in practice (typically current head
-                # of any branch, including parent, should occur on the reflog
-                # of this branch, thus is_ancestor(parent, branch) should imply
-                # is_ancestor(parent, FP(branch)), but it's still possible in
-                # case reflog of parent is incomplete for whatever reason.
+                # That happens very rarely in practice (typically current head of any branch, including parent,
+                # should occur on the reflog of this branch, thus is_ancestor(parent, branch) should imply is_ancestor(parent, FP(branch)),
+                # but it's still possible in case reflog of parent is incomplete for whatever reason.
                 debug(
                     f"{parent} is an ancestor of {branch}, "
                     f"but the inferred fork point commit {computed_fork_point} is NOT a descendant of {parent}; "
@@ -430,15 +418,13 @@ class MacheteClient:
 
             self.__branch_pairs_by_hash_in_reflog = {}
             for hash, branch_pair in generate_entries():
-                # We dedup `branch_pair`s per hash so that a commit which appears
-                # multiple times in a single branch's filtered reflog (e.g. via a
-                # `git reset --hard` back to it followed by an advance, then
-                # another reset back) doesn't end up listed twice in
-                # `inferring_branches`. Without this, `fork-point --explain` and
-                # `status -l` would print things like
+                # We dedup `branch_pair`s per hash so that a commit which appears multiple times in a single branch's filtered reflog
+                # (e.g. via a `git reset --hard` back to it followed by an advance, then another reset back)
+                # doesn't end up listed twice in `inferring_branches`.
+                # Without this, `fork-point --explain` and `status -l` would print things like
                 # "...part of the unique history of master and master".
-                # The list-of-pairs shape is preserved (rather than a set) because
-                # downstream code relies on sorted ordering and indexed iteration.
+                # The list-of-pairs shape is preserved (rather than a set) because downstream code relies on sorted ordering
+                # and indexed iteration.
                 existing = self.__branch_pairs_by_hash_in_reflog.setdefault(hash, [])
                 if branch_pair not in existing:
                     existing.append(branch_pair)
@@ -465,9 +451,8 @@ class MacheteClient:
                                                    initial_count=INITIAL_COMMIT_COUNT_FOR_LOG,
                                                    total_count=TOTAL_COMMIT_COUNT_FOR_LOG):
             if hash in self.__branch_pairs_by_hash_in_reflog:
-                # The entries must be sorted by lb_or_rb to make sure the
-                # parent inference is deterministic (and does not depend on the
-                # order in which `generate_entries` iterated through the local branches).
+                # The entries must be sorted by lb_or_rb to make sure the parent inference is deterministic
+                # (and does not depend on the order in which `generate_entries` iterated through the local branches).
                 branch_pairs: List[BranchPair] = self.__branch_pairs_by_hash_in_reflog[hash]
 
                 def lb_is_not_b(lb: str, _lb_or_rb: str) -> bool:
@@ -588,10 +573,8 @@ class MacheteClient:
         if branch in self.managed_branches:
             raise MacheteException(f"Branch <b>{branch}</b> already exists in the tree of branch dependencies")
 
-        # `onto` is tracked as a `ManagedBranchName` from this point on so
-        # that the final `add_as_child(parent=...)` call type-checks; every
-        # path that assigns to it (explicit `--onto`, current branch, inferred
-        # parent) is gated on the branch being in the layout.
+        # `onto` is tracked as a `ManagedBranchName` from this point on so that the final `add_as_child(parent=...)` call type-checks;
+        # every path that assigns to it (explicit `--onto`, current branch, inferred parent) is gated on the branch being in the layout.
         onto: Optional[ManagedBranchName] = self.expect_in_managed_branches(opt_onto) if opt_onto else None
 
         if branch not in self._git.get_local_branches():
@@ -606,8 +589,7 @@ class MacheteClient:
                     self._git.create_branch(branch, remote_branch.full_name(), switch_head=switch_head_if_new_branch)
                 else:
                     return
-                # Not dealing with `onto` here. If it hasn't been explicitly
-                # specified via `--onto`, we'll try to infer it now.
+                # Not dealing with `onto` here. If it hasn't been explicitly specified via `--onto`, we'll try to infer it now.
             else:
                 out_of = LocalBranchShortName.of(onto).full_name() if onto else HEAD
                 out_of_str = f"<b>{onto}</b>" if onto else "the current HEAD"

--- a/git_machete/client/branch_layout.py
+++ b/git_machete/client/branch_layout.py
@@ -11,15 +11,12 @@ from git_machete.utils.paths import AbsPath, Path
 def parse(path: AbsPath, *, display_path: Optional[Path] = None) -> Tuple[MacheteState, Optional[str]]:
     """Parse the branch layout file at *path*.
 
-    Returns a new `MacheteState` populated from the file together with
-    the indent string detected in the file (`None` when no indented
-    line was found, e.g. a single-root flat layout).
+    Returns a new `MacheteState` populated from the file together with the indent string detected in the file
+    (`None` when no indented line was found, e.g. a single-root flat layout).
 
-    Raises `MacheteException` for structural errors (duplicate branch,
-    bad indent, excess depth). The `display_path` argument, if provided,
-    is used in error messages in place of `path` - useful when `path` is
-    an absolute internal location and the caller wants a more compact
-    cwd-relative form shown to the user.
+    Raises `MacheteException` for structural errors (duplicate branch, bad indent, excess depth).
+    The `display_path` argument, if provided, is used in error messages in place of `path` -
+    useful when `path` is an absolute internal location and the caller wants a more compact cwd-relative form shown to the user.
     """
     msg_path: Path = display_path if display_path is not None else path
     with open(path) as f:
@@ -27,9 +24,8 @@ def parse(path: AbsPath, *, display_path: Optional[Path] = None) -> Tuple[Machet
 
     state = MacheteState()
     indent: Optional[str] = None
-    # Every entry has by now been handed to `state.add_branch(...)`, so a
-    # `ManagedBranchName` is the natural type for "branch at depth N-1
-    # that the next line's parent will point at".
+    # Every entry has by now been handed to `state.add_branch(...)`,
+    # so a `ManagedBranchName` is the natural type for "branch at depth N-1 that the next line's parent will point at".
     at_depth: Dict[int, ManagedBranchName] = {}
     last_depth = -1
     hint = "Edit the branch layout file manually with `git machete edit`"
@@ -37,9 +33,8 @@ def parse(path: AbsPath, *, display_path: Optional[Path] = None) -> Tuple[Machet
     for index, line in enumerate(lines):
         if line == "":
             continue
-        # Undocumented: lines whose first non-whitespace character is `#`
-        # are ignored as comments.  They are not preserved when
-        # git-machete writes the branch layout file.
+        # Undocumented: lines whose first non-whitespace character is `#` are ignored as comments.
+        # They are not preserved when git-machete writes the branch layout file.
         if line.lstrip().startswith("#"):
             continue
 

--- a/git_machete/client/slide_out.py
+++ b/git_machete/client/slide_out.py
@@ -23,9 +23,8 @@ class SlideOutMacheteClient(MacheteClient):
         raw_branches: List[LocalBranchShortName] = opt_branches or [self._git.get_current_branch()]
 
         # Verify that all branches exist, are managed and are NOT annotated with slide-out=no qualifier.
-        # `expect_in_managed_branches` narrows to `ManagedBranchName`, which we keep
-        # for the rest of the method so we can hand the values to layout mutators
-        # (`splice_out`, `_remove_branches_from_layout`) without re-checking.
+        # `expect_in_managed_branches` narrows to `ManagedBranchName`, which we keep for the rest of the method
+        # so we can hand the values to layout mutators (`splice_out`, `_remove_branches_from_layout`) without re-checking.
         branches_to_slide_out: List[ManagedBranchName] = []
         for branch in raw_branches:
             managed = self.expect_in_managed_branches(branch)

--- a/git_machete/client/squash.py
+++ b/git_machete/client/squash.py
@@ -49,18 +49,15 @@ class SquashMacheteClient(MacheteClient):
                           GIT_AUTHOR_DATE=earliest_author_date,
                           GIT_AUTHOR_EMAIL=earliest_author_email,
                           GIT_AUTHOR_NAME=earliest_author_name)
-        # Using `git commit-tree` since it's cleaner than any high-level command
-        # like `git merge --squash` or `git rebase --interactive`.
+        # Using `git commit-tree` since it's cleaner than any high-level command like `git merge --squash` or `git rebase --interactive`.
         # The tree (HEAD^{tree}) argument must be passed as first,
-        # otherwise the entire `commit-tree` will fail on some ancient supported
-        # versions of git (at least on v1.7.10).
+        # otherwise the entire `commit-tree` will fail on some ancient supported versions of git (at least on v1.7.10).
         squashed_hash = FullCommitHash.of(self._git.commit_tree_with_given_parent_and_message_and_env(
             fork_point, earliest_full_message, author_env).strip())
 
         # This can't be done with `git reset` since it doesn't allow for a custom reflog message.
         # Even worse, reset's reflog message would be filtered out in our fork point algorithm,
-        # so the squashed commit would not even be considered to "belong"
-        # (in the fork-point sense) to the current branch's history.
+        # so the squashed commit would not even be considered to "belong" (in the fork-point sense) to the current branch's history.
         self._git.update_head_ref_to_new_hash_with_reflog_subject(
             squashed_hash, f"squash: {earliest_commit.subject}")
 

--- a/git_machete/client/state.py
+++ b/git_machete/client/state.py
@@ -6,19 +6,16 @@ from git_machete.utils.collections import flat_map
 
 
 class ManagedBranchName(LocalBranchShortName):
-    """A `LocalBranchShortName` known to live in the `.git/machete` branch
-    layout file.
+    """A `LocalBranchShortName` known to live in the `.git/machete` branch layout file.
 
-    The type is a marker - it carries no extra behavior - and exists so that
-    mypy can distinguish "any local branch the user typed" from "a branch
-    that has already been verified against the layout file". Every read
-    accessor on `MacheteState` (and the corresponding `MacheteClient`
-    helpers, including `expect_in_managed_branches`) hands back an instance
-    of this type; every mutation method that operates on a presumed-managed
-    branch (`splice_out`, `remove_leaf`, `add_as_child`'s `parent`, etc.)
-    accepts only this type. The "promote raw -> managed" conversion lives
-    in those methods alone, so accidentally feeding an unverified branch
-    into the layout-file mutators becomes a type error.
+    The type is a marker - it carries no extra behavior - and exists so that mypy can distinguish
+    "any local branch the user typed" from "a branch that has already been verified against the layout file".
+    Every read accessor on `MacheteState` (and the corresponding `MacheteClient` helpers, including `expect_in_managed_branches`)
+    hands back an instance of this type;
+    every mutation method that operates on a presumed-managed branch (`splice_out`, `remove_leaf`, `add_as_child`'s `parent`, etc.)
+    accepts only this type.
+    The "promote raw -> managed" conversion lives in those methods alone,
+    so accidentally feeding an unverified branch into the layout-file mutators becomes a type error.
     """
 
 
@@ -29,14 +26,12 @@ class MacheteState:
     The five internal fields are kept mutually consistent:
       - `_managed_branches`: DFS-ordered flat list of every managed branch.
       - `_roots`: root branches (those with no parent in the layout).
-      - `_parent_of`: child → parent mapping for every non-root branch.
-      - `_children_of`: parent → ordered list of children.
+      - `_parent_of`: child -> parent mapping for every non-root branch.
+      - `_children_of`: parent -> ordered list of children.
       - `_annotations`: per-branch annotation metadata.
 
-    All five fields are private.  Callers may read them freely through the
-    properties and accessor methods below, but every structural change must go
-    through the mutation methods so that the invariants above are never
-    violated.
+    All five fields are private. Callers may read them freely through the properties and accessor methods below,
+    but every structural change must go through the mutation methods so that the invariants above are never violated.
     """
 
     def __init__(self) -> None:
@@ -86,10 +81,9 @@ class MacheteState:
 
     # ── Adding branches ─────────────────────────────────────────────────────
     #
-    # The methods in this section are the gateway from `LocalBranchShortName`
-    # to `ManagedBranchName`: the branch passed in is *becoming* managed by
-    # virtue of the call itself, so the input type is the broader one and
-    # the value is stored internally as the narrower `ManagedBranchName`.
+    # The methods in this section are the gateway from `LocalBranchShortName` to `ManagedBranchName`:
+    # the branch passed in is *becoming* managed by virtue of the call itself,
+    # so the input type is the broader one and the value is stored internally as the narrower `ManagedBranchName`.
 
     def add_branch(
         self,
@@ -143,8 +137,7 @@ class MacheteState:
     def splice_out(self, branch: ManagedBranchName) -> None:
         """Remove a branch from the tree, wiring its children to its parent.
 
-        If branch is a root, its children become new roots in its place.
-        Removes branch from managed_branches and deletes its annotation.
+        If branch is a root, its children become new roots in its place. Removes branch from managed_branches and deletes its annotation.
         """
         children = list(self._children_of.get(branch) or [])
         parent = self._parent_of.get(branch)
@@ -170,8 +163,7 @@ class MacheteState:
     def remove_leaf(self, branch: ManagedBranchName) -> None:
         """Remove a childless branch from the layout.
 
-        Detaches it from its parent (or roots), removes it from managed_branches,
-        and deletes its annotation.
+        Detaches it from its parent (or roots), removes it from managed_branches, and deletes its annotation.
         """
         self._managed_branches.remove(branch)
         self._annotations.pop(branch, None)
@@ -201,8 +193,7 @@ class MacheteState:
     ) -> None:
         """Wire child under parent without touching managed_branches.
 
-        Intended for incremental tree building when managed_branches will be
-        set in bulk afterwards via set_managed().
+        Intended for incremental tree building when managed_branches will be set in bulk afterwards via set_managed().
         """
         managed_parent = ManagedBranchName(parent)
         managed_child = ManagedBranchName(child)
@@ -215,8 +206,7 @@ class MacheteState:
     def wire_as_root(self, branch: LocalBranchShortName) -> None:
         """Append branch to roots without touching managed_branches.
 
-        Intended for incremental tree building when managed_branches will be
-        set in bulk afterwards via set_managed().
+        Intended for incremental tree building when managed_branches will be set in bulk afterwards via set_managed().
         """
         self._roots.append(ManagedBranchName(branch))
 

--- a/git_machete/client/status.py
+++ b/git_machete/client/status.py
@@ -66,9 +66,8 @@ class StatusData(NamedTuple):
     """All precomputed data needed to render status output (tree and optional warning)."""
 
     flags: StatusFlags
-    # Keep the dict keyed on the broader `LocalBranchShortName` to spare every
-    # downstream helper from `ManagedBranchName`-narrowing dance when indexing
-    # via a parent/sibling-of-ancestor (which mypy tracks as the broader type).
+    # Keep the dict keyed on the broader `LocalBranchShortName` to spare every downstream helper from `ManagedBranchName`-narrowing dance
+    # when indexing via a parent/sibling-of-ancestor (which mypy tracks as the broader type).
     branches: Dict[LocalBranchShortName, StatusBranch]
     branches_in_display_order: List[ManagedBranchName]
     roots: List[ManagedBranchName]

--- a/git_machete/client/traverse.py
+++ b/git_machete/client/traverse.py
@@ -62,8 +62,7 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
         Update the worktrees cache after a checkout operation in the current worktree.
         This avoids the need to re-fetch the full worktree list.
 
-        Only the current worktree's entry needs to be updated - linked worktrees
-        don't change when we checkout in a different worktree.
+        Only the current worktree's entry needs to be updated - linked worktrees don't change when we checkout in a different worktree.
         """
         current_worktree_root_dir = self._git.get_current_worktree_root_dir()
 
@@ -268,8 +267,7 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
                 skipping_parent_sync = False
 
                 if needs_slide_out:
-                    # Avoid unnecessary fork point check if we already know that the
-                    # branch qualifies for slide out;
+                    # Avoid unnecessary fork point check if we already know that the branch qualifies for slide out;
                     # neither rebase nor merge will be suggested in such case anyway.
                     needs_parent_sync: bool = False
                 elif s in (SyncToRemoteStatus.BEHIND_REMOTE, SyncToRemoteStatus.DIVERGED_FROM_AND_OLDER_THAN_REMOTE):
@@ -347,14 +345,11 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
                     if ans in ('y', 'yes', 'yq'):
                         if use_merge:
                             self._git.merge(branch=parent, into=branch, opt_no_edit_merge=opt_no_edit_merge)
-                            # It's clearly possible that merge can be in progress
-                            # after 'git merge' returned non-zero exit code;
+                            # It's clearly possible that merge can be in progress after 'git merge' returned non-zero exit code;
                             # this happens most commonly in case of conflicts.
-                            # As for now, we're not aware of any case when merge can
-                            # be still in progress after 'git merge' returns zero,
-                            # at least not with the options that git-machete passes
-                            # to merge; this happens though in case of 'git merge
-                            # --no-commit' (which we don't ever invoke).
+                            # As for now, we're not aware of any case when merge can be still in progress after 'git merge' returns zero,
+                            # at least not with the options that git-machete passes to merge;
+                            # this happens though in case of 'git merge --no-commit' (which we don't ever invoke).
                             # It's still better, however, to be on the safe side.
                             if self._git.is_merge_in_progress():
                                 print("\nMerge in progress; stopping the traversal")

--- a/git_machete/git.py
+++ b/git_machete/git.py
@@ -189,14 +189,13 @@ class BranchPair(NamedTuple):
 
 HEAD = AnyRevision.of("HEAD")
 
-# Explicitly suppress showing GPG signatures in `git log`
-# operations to simplify log parsing. This option must be passed as a
-# configuration parameter because the `git log` command's `--no-show-signature`
-# flag does not exist prior to `git` version 2.10.0; `git` does not emit an
-# error if it is passed via the `-c` flag a configuration setting that does not
-# exist, so compatibility with `git` versions earlier than version 2.10.0 is
-# preserved, even though the `log.showSignature` setting also does not exist
-# prior to version 2.10.0. Fixes a bug documented in GitHub issue #1286.
+# Explicitly suppress showing GPG signatures in `git log` operations to simplify log parsing.
+# This option must be passed as a configuration parameter because the `git log` command's `--no-show-signature` flag
+# does not exist prior to `git` version 2.10.0;
+# `git` does not emit an error if it is passed via the `-c` flag a configuration setting that does not exist,
+# so compatibility with `git` versions earlier than version 2.10.0 is preserved,
+# even though the `log.showSignature` setting also does not exist prior to version 2.10.0.
+# Fixes a bug documented in GitHub issue #1286.
 GIT_EXEC = ("git", "-c", "log.showSignature=false")
 
 
@@ -313,11 +312,10 @@ class Git:
 
     # === Worktree & repository paths ===
     #
-    # All path-returning helpers in this section return `AbsPath`: relative
-    # paths can lead to subtle bugs when CWD changes between worktrees
-    # mid-run (e.g. `traverse` chdir-ing into a linked worktree - the latent
-    # source of issue #1681 and similar). The conversion happens once here,
-    # in `__rev_parse_path`, via `abs_path`.
+    # All path-returning helpers in this section return `AbsPath`:
+    # relative paths can lead to subtle bugs when CWD changes between worktrees mid-run
+    # (e.g. `traverse` chdir-ing into a linked worktree - the latent source of issue #1681 and similar).
+    # The conversion happens once here, in `__rev_parse_path`, via `abs_path`.
 
     def __rev_parse_path(self, flag: str) -> AbsPath:
         return AbsPath(self._popen_git("rev-parse", flag).stdout.strip())
@@ -351,8 +349,7 @@ class Git:
                 # If worktrees aren't supported, just return the current root dir
                 self.__main_worktree_root_dir = self.get_current_worktree_root_dir()
             else:
-                # We can't rely on `git rev-parse --git-common-dir`
-                # since in some earlier supported versions of git
+                # We can't rely on `git rev-parse --git-common-dir` since in some earlier supported versions of git
                 # this path is apparently printed in a faulty way when dealing with worktrees.
                 # Let's parse the output of of `git worktree list` instead.
                 result = self._popen_git("worktree", "list", "--porcelain")
@@ -1015,9 +1012,8 @@ class Git:
                 f.write(f"{hash1} {hash2}\n")
 
     def __get_merge_base_for_commit_hashes(self, hash1: FullCommitHash, hash2: FullCommitHash) -> Optional[FullCommitHash]:  # noqa: KW
-        # This if statement is not changing the outcome of the later return, but
-        # it enhances the efficiency of the script. If both hashes are the same,
-        # there is no point running git merge-base.
+        # This if statement is not changing the outcome of the later return, but it enhances the efficiency of the script.
+        # If both hashes are the same, there is no point running git merge-base.
         if hash1 == hash2:
             return hash1
         # Load cache lazily on first use
@@ -1197,10 +1193,8 @@ class Git:
     # === Hooks ===
 
     def get_hook_path(self, hook_name: str) -> Path:
-        # `core.hooksPath` may be unset, relative, or absolute - so the
-        # combined result is only ever known to be a `Path`, not `AbsPath`.
-        # `core.hooksPath` may be unset, relative, or absolute - the joined
-        # `hook_dir` is therefore only ever known to be a `Path`.
+        # `core.hooksPath` may be unset, relative, or absolute - the joined `hook_dir` is therefore only ever known to be a `Path`,
+        # not `AbsPath`.
         hook_dir: Path = Path(self.get_config_attr_or_none("core.hooksPath") or self.get_main_worktree_git_subpath("hooks"))
         return Path.join_paths(hook_dir, hook_name)
 

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -86,9 +86,8 @@ class GitHubToken(NamedTuple):
         # gh version 2.18.0 (2022-10-18)
         # https://github.com/cli/cli/releases/tag/v2.18.0
         #
-        # Custom/devel builds (e.g. Homebrew `--HEAD`, Arch's `gh-git`,
-        # built-from-source) append a `git describe`-style suffix directly
-        # after the patch number, with no space before the date:
+        # Custom/devel builds (e.g. Homebrew `--HEAD`, Arch's `gh-git`, built-from-source)
+        # append a `git describe`-style suffix directly after the patch number, with no space before the date:
         #
         # gh version 2.92.0-7-ga3efb25a (2026-04-30)
         #

--- a/git_machete/utils/_subproc.py
+++ b/git_machete/utils/_subproc.py
@@ -1,10 +1,9 @@
 """Lowest-level subprocess wrappers used elsewhere in :mod:`git_machete.utils`.
 
-These helpers deliberately do **not** print anything (no debug/verbose
-logging), so they can be safely called from code paths that themselves
-implement that logging - in particular from
-:func:`git_machete.utils.terminal.is_terminal_fully_fledged`, whose result
-the logging path itself depends on.
+These helpers deliberately do **not** print anything (no debug/verbose logging),
+so they can be safely called from code paths that themselves implement that logging -
+in particular from :func:`git_machete.utils.terminal.is_terminal_fully_fledged`,
+whose result the logging path itself depends on.
 """
 
 import subprocess
@@ -17,11 +16,10 @@ class PopenResult(NamedTuple):
     stderr: str
 
 
-# `cwd` is typed as plain `str` here (not `Path`) to keep this lowest-level
-# module free of internal dependencies - `utils.paths` transitively pulls in
-# `utils.markup`/`utils.terminal`, which in turn re-imports from this module,
-# creating a circular import. The outer wrappers in `utils.cmd` enforce the
-# `Path` discipline.
+# `cwd` is typed as plain `str` here (not `Path`) to keep this lowest-level module free of internal dependencies -
+# `utils.paths` transitively pulls in `utils.markup`/`utils.terminal`, which in turn re-imports from this module,
+# creating a circular import.
+# The outer wrappers in `utils.cmd` enforce the `Path` discipline.
 def _run_cmd(cmd: str, *args: str, cwd: Optional[str] = None, env: Optional[Dict[str, str]] = None) -> int:
     return subprocess.run([cmd] + list(args), stdout=None, stderr=None, cwd=cwd, env=env).returncode
 

--- a/git_machete/utils/cmd.py
+++ b/git_machete/utils/cmd.py
@@ -1,15 +1,12 @@
 """High-level wrappers around subprocess that respect verbose/debug mode.
 
-Compared to `._subproc` (used internally for capability detection),
-the helpers here:
+Compared to `._subproc` (used internally for capability detection), the helpers here:
 
-* log the command being run when `verbose_mode` / `debug_mode` /
-  `measure_command_time` is set (via `print_fmt`),
+* log the command being run when `verbose_mode` / `debug_mode` / `measure_command_time` is set (via `print_fmt`),
 * redact GitHub / GitLab access tokens from captured stdout/stderr,
 * update the cached "current directory still exists" flag,
-* delegate the actual `subprocess` call to `_subproc._run_cmd` /
-  `_subproc._popen_cmd` so that tests can patch the former without
-  losing the surrounding logic.
+* delegate the actual `subprocess` call to `_subproc._run_cmd` / `_subproc._popen_cmd`
+  so that tests can patch the former without losing the surrounding logic.
 """
 
 import os
@@ -27,10 +24,8 @@ from .paths import AbsPath, Path
 
 # === Mutable runtime flags ===
 #
-# `verbose_mode` / `measure_command_time` toggle command logging; set by
-# `cli.py` (and the env var `GIT_MACHETE_MEASURE_COMMAND_TIME`).
-# `current_directory_confirmed_to_exist` is an internal cache used to
-# avoid a `getcwd()` syscall before every command.
+# `verbose_mode` / `measure_command_time` toggle command logging; set by `cli.py` (and the env var `GIT_MACHETE_MEASURE_COMMAND_TIME`).
+# `current_directory_confirmed_to_exist` is an internal cache used to avoid a `getcwd()` syscall before every command.
 current_directory_confirmed_to_exist: bool = False
 measure_command_time: bool = os.environ.get('GIT_MACHETE_MEASURE_COMMAND_TIME') == 'true'  # undocumented, internal
 verbose_mode: bool = False
@@ -54,16 +49,14 @@ def run_cmd(cmd: str, *args: str, cwd: Optional[Path] = None, env: Optional[Dict
         print_command(escaped_flat_cmd)
 
     start = time.time()
-    # Looked up via the `_subproc` module so that
-    # `mock.patch('git_machete.utils._subproc._run_cmd', ...)` is honored.
+    # Looked up via the `_subproc` module so that `mock.patch('git_machete.utils._subproc._run_cmd', ...)` is honored.
     exit_code: int = _subproc._run_cmd(cmd, *args, cwd=cwd, env=env)
     if measure_command_time:  # pragma: no cover
         end = time.time()
         elapsed_ms = int((end - start) * 1e3)
         print(f"{elapsed_ms} ms")
 
-    # Let's defensively assume that every command executed via run_cmd
-    # (but not via popen_cmd) can make the current directory disappear.
+    # Let's defensively assume that every command executed via run_cmd (but not via popen_cmd) can make the current directory disappear.
     # In practice, it's mostly 'git checkout' that carries such risk.
     mark_current_directory_as_possibly_non_existent()
 

--- a/git_machete/utils/debug_log.py
+++ b/git_machete/utils/debug_log.py
@@ -1,8 +1,7 @@
 """Debug-mode logging.
 
-`debug` is a no-op unless `debug_mode` is set (typically because `--debug`
-was passed on the command line). It pulls argument names and values
-directly from the caller's frame via `inspect`.
+`debug` is a no-op unless `debug_mode` is set (typically because `--debug` was passed on the command line).
+It pulls argument names and values directly from the caller's frame via `inspect`.
 """
 
 import inspect
@@ -43,8 +42,7 @@ def debug(msg: str) -> None:
     func = inspect.stack()[1].function
     args, _, _, values_original = inspect.getargvalues(inspect.stack()[1].frame)
     # Do not write over the original values!
-    # Since Python 3.13, the result of `getargvalues` keeps a map of local variables
-    # that the Python runtime actually keeps on the stack,
+    # Since Python 3.13, the result of `getargvalues` keeps a map of local variables that the Python runtime actually keeps on the stack,
     # so overwriting a key in values_original changes the local variable.
     values: Dict[str, Any] = dict(values_original)
 

--- a/git_machete/utils/markup.py
+++ b/git_machete/utils/markup.py
@@ -1,14 +1,12 @@
 """Markup formatting and styled output helpers.
 
-The markup language is intentionally tiny - a handful of `<tag>...</tag>`
-blocks plus a few self-closing tags - and is rendered to either ANSI escape
-sequences or plain ASCII depending on whether the destination stream is a
-TTY (and on `--color`).
+The markup language is intentionally tiny - a handful of `<tag>...</tag>` blocks plus a few self-closing tags -
+and is rendered to either ANSI escape sequences or plain ASCII
+depending on whether the destination stream is a TTY (and on `--color`).
 
 `_fmt` looks up `is_terminal_fully_fledged` via `terminal.is_terminal_fully_fledged()`
 (rather than via a `from .terminal import ...` binding) so that
-`unittest.mock.patch('git_machete.utils.terminal.is_terminal_fully_fledged', ...)`
-in tests is honored at every call.
+`unittest.mock.patch('git_machete.utils.terminal.is_terminal_fully_fledged', ...)` in tests is honored at every call.
 """
 
 import re
@@ -21,9 +19,8 @@ from .terminal import BasicTerminalAnsiOutputCodes, FullTerminalAnsiOutputCodes
 
 # === Mutable runtime flags ===
 #
-# Whether to emit ANSI escapes on stdout / stderr. Set by `cli.py` based on
-# `--color` and TTY detection; read by `print_fmt`, `input_fmt`, and -
-# indirectly via `_fmt` - by `MacheteException` / `UnderlyingGitException`.
+# Whether to emit ANSI escapes on stdout / stderr. Set by `cli.py` based on `--color` and TTY detection;
+# read by `print_fmt`, `input_fmt`, and - indirectly via `_fmt` - by `MacheteException` / `UnderlyingGitException`.
 use_ansi_escapes_in_stdout: bool = sys.stdout.isatty()
 use_ansi_escapes_in_stderr: bool = sys.stderr.isatty()
 
@@ -31,17 +28,14 @@ use_ansi_escapes_in_stderr: bool = sys.stderr.isatty()
 def escape_markup(s: str) -> str:
     """Escape characters that `_fmt` would interpret as markup.
 
-    Use on user-provided content (annotation text, commit subjects, hook
-    output) before embedding it into markup strings.
+    Use on user-provided content (annotation text, commit subjects, hook output) before embedding it into markup strings.
     """
     return s.replace('&', '&amp;').replace('`', '&backtick;').replace('<', '&lt;')
 
 
 def _fmt(s: str, *, use_ansi_escapes: bool) -> str:
-    # Looked up via the `terminal` module (not via a top-level
-    # `from .terminal import is_terminal_fully_fledged`) so that
-    # `mock.patch('git_machete.utils.terminal.is_terminal_fully_fledged', ...)`
-    # is honored.
+    # Looked up via the `terminal` module (not via a top-level `from .terminal import is_terminal_fully_fledged`)
+    # so that `mock.patch('git_machete.utils.terminal.is_terminal_fully_fledged', ...)` is honored.
     ao = FullTerminalAnsiOutputCodes if terminal.is_terminal_fully_fledged() else BasicTerminalAnsiOutputCodes
 
     # pattern                                  ansi replacement                            ascii replacement
@@ -76,9 +70,7 @@ def print_fmt(s: str, *, file: Optional[Any] = None, newline: bool = True) -> No
     ANSI / Unicode styling follows the same rules as for direct writes to `file`
     (stdout vs stderr, TTY detection, `--color`, etc.).
 
-    When newline=False, output is flushed immediately so that a
-    subsequent print_fmt (e.g. "OK") appears on the same line
-    without delay.
+    When newline=False, output is flushed immediately so that a subsequent print_fmt (e.g. "OK") appears on the same line without delay.
     """
     use_ansi = use_ansi_escapes_in_stderr if file is sys.stderr else use_ansi_escapes_in_stdout
     # Defaults to stdout at call time so that contextlib.redirect_stdout is respected.

--- a/git_machete/utils/paths.py
+++ b/git_machete/utils/paths.py
@@ -1,29 +1,23 @@
 """POSIX-style typed paths and helpers.
 
-Every `Path` / `AbsPath` instance is normalized to forward-slash form on
-construction (via `PurePath(value).as_posix()`), regardless of platform.
-This is load-bearing for:
+Every `Path` / `AbsPath` instance is normalized to forward-slash form on construction (via `PurePath(value).as_posix()`),
+regardless of platform. This is load-bearing for:
 
-* path equality / dictionary membership (`current_worktree_root_dir ==
-  target_worktree_root_dir`, `worktrees_by_branch.get(branch)`, ...) -
-  mixing native and posix separators on Windows would silently miscompare
-  paths produced by Python helpers vs. paths returned by `git` itself,
-* user-facing output and test snapshots (one form across all platforms,
-  matching `git`'s own output style),
-* cross-platform consistency of any path stored long-term in
-  git-machete's state (caches, branch-layout-file path, ...).
+* path equality / dictionary membership
+  (`current_worktree_root_dir == target_worktree_root_dir`, `worktrees_by_branch.get(branch)`, ...) -
+  mixing native and posix separators on Windows would silently miscompare paths produced by Python helpers
+  vs. paths returned by `git` itself,
+* user-facing output and test snapshots (one form across all platforms, matching `git`'s own output style),
+* cross-platform consistency of any path stored long-term in git-machete's state
+  (caches, branch-layout-file path, ...).
 
-Pure I/O (`open`, `os.path.isfile`, `shutil.*`, `subprocess.run(cwd=...)`)
-accepts either form on Windows, so the normalization is invisible there -
-the value lies in the type-system guarantee that downstream comparisons
-and renders are stable.
+Pure I/O (`open`, `os.path.isfile`, `shutil.*`, `subprocess.run(cwd=...)`) accepts either form on Windows,
+so the normalization is invisible there - the value lies in the type-system guarantee that downstream comparisons and renders are stable.
 
-The `Path` / `AbsPath` hierarchy mirrors the discipline used for branch
-names (`AnyBranchName` / `LocalBranchShortName` etc.): production code
-converts raw `str`s at the earliest boundary, so the type system enforces
-"absolute" semantics where a stored path must outlive a possible
-`os.chdir` (most notably `traverse` switching into linked worktrees -
-the latent source of issue #1681 and friends).
+The `Path` / `AbsPath` hierarchy mirrors the discipline used for branch names (`AnyBranchName` / `LocalBranchShortName` etc.):
+production code converts raw `str`s at the earliest boundary, so the type system enforces "absolute" semantics
+where a stored path must outlive a possible `os.chdir`
+(most notably `traverse` switching into linked worktrees - the latent source of issue #1681 and friends).
 """
 
 import os
@@ -34,35 +28,28 @@ from pathlib import PurePath, PurePosixPath
 class Path(str):
     """A filesystem path (relative or absolute), always in posix form.
 
-    All normalization and invariants happen in `__new__` so that
-    `Path(value)` / `AbsPath(value)` is the single, obvious way to obtain
-    a typed path - there are intentionally no `.of(...)` factory methods.
+    All normalization and invariants happen in `__new__` so that `Path(value)` / `AbsPath(value)` is the single, obvious way
+    to obtain a typed path - there are intentionally no `.of(...)` factory methods.
     """
 
     def __new__(cls, value: str = "") -> "Path":
-        # `PurePath` is platform-aware: on Windows it parses both `\` and `/`
-        # as separators, on POSIX only `/`. `str(PurePath(...))` then renders
-        # back to the platform-native form (so `str(PurePath("a/b"))` is
-        # `"a\\b"` on Windows). `as_posix()` instead always renders with `/`,
-        # which is the invariant we want every typed path to satisfy.
+        # `PurePath` is platform-aware: on Windows it parses both `\` and `/` as separators, on POSIX only `/`.
+        # `str(PurePath(...))` then renders back to the platform-native form (so `str(PurePath("a/b"))` is `"a\\b"` on Windows).
+        # `as_posix()` instead always renders with `/`, which is the invariant we want every typed path to satisfy.
         return super().__new__(cls, PurePath(value).as_posix())
 
     @staticmethod
     def join_paths(*paths: str) -> "Path":
         """Combine one or more path-like strings into a single `Path`.
 
-        Inputs may be relative or absolute; downstream semantics follow
-        `PurePosixPath`'s join rules (an absolute fragment discards
-        anything before it).
+        Inputs may be relative or absolute; downstream semantics follow `PurePosixPath`'s join rules
+        (an absolute fragment discards anything before it).
 
-        We use `PurePosixPath` (rather than the platform-aware `PurePath`)
-        for joining because `Path.__new__` has already normalized any
-        prior typed segment to forward-slash form, so the inputs here
-        are guaranteed posix-style on every platform - `PurePosixPath`
-        states that intent explicitly and avoids the Windows-only
-        drive-letter / backslash parsing that `PureWindowsPath` would do.
-        The result still passes through `Path.__new__` for a final
-        normalization pass (cheap, idempotent).
+        We use `PurePosixPath` (rather than the platform-aware `PurePath`) for joining because `Path.__new__` has already normalized
+        any prior typed segment to forward-slash form, so the inputs here are guaranteed posix-style on every platform -
+        `PurePosixPath` states that intent explicitly and avoids the Windows-only drive-letter / backslash parsing
+        that `PureWindowsPath` would do.
+        The result still passes through `Path.__new__` for a final normalization pass (cheap, idempotent).
         """
         return Path(str(PurePosixPath(*paths)))
 
@@ -75,10 +62,9 @@ class Path(str):
 class AbsPath(Path):
     """A path confirmed absolute at construction time, in posix form.
 
-    `AbsPath(value)` resolves `value` against the current working
-    directory if it isn't already absolute, follows symlinks and
-    collapses `.`/`..` segments via `pathlib.Path.resolve`. The
-    resulting instance is canonical and stable across `os.chdir`.
+    `AbsPath(value)` resolves `value` against the current working directory if it isn't already absolute,
+    follows symlinks and collapses `.`/`..` segments via `pathlib.Path.resolve`.
+    The resulting instance is canonical and stable across `os.chdir`.
     """
 
     def __new__(cls, value: str = "") -> "AbsPath":
@@ -92,20 +78,16 @@ class AbsPath(Path):
     def parent_dir(self) -> "AbsPath":
         """The directory containing this path.
 
-        For the filesystem root, returns the root itself (so the caller
-        can use this in a loop without an extra guard against runaway
-        traversal).
+        For the filesystem root, returns the root itself
+        (so the caller can use this in a loop without an extra guard against runaway traversal).
         """
         return AbsPath(str(PyPath(self).parent))
 
     def join_fragments(self, *fragments: str) -> "AbsPath":
-        """Append `fragments` (path segments, not absolute paths themselves)
-        under this absolute base; result is also absolute.
+        """Append `fragments` (path segments, not absolute paths themselves) under this absolute base; result is also absolute.
 
-        `PurePosixPath` is used here for the same reason as in
-        `Path.join_paths`: `self` is already a posix-form `AbsPath`, so
-        we want a join engine that doesn't try to reinterpret the input
-        on Windows. The final renormalisation happens in `AbsPath.__new__`
-        via `pathlib.Path.resolve().as_posix()`.
+        `PurePosixPath` is used here for the same reason as in `Path.join_paths`:
+        `self` is already a posix-form `AbsPath`, so we want a join engine that doesn't try to reinterpret the input on Windows.
+        The final renormalization happens in `AbsPath.__new__` via `pathlib.Path.resolve().as_posix()`.
         """
         return AbsPath(str(PurePosixPath(self, *fragments)))


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1678

## Chain of upstream PRs as of 2026-05-18

* PR #1678:
  `master` ← `develop`

  * **PR #1698 (THIS ONE)**:
    `develop` ← `chore/reflow-more`

<!-- end git-machete generated -->

Both reliably hang the agent's terminal until the inner subprocess times
out. The root cause hasn't been pinned down (they run fine from a regular
shell), but a 100% reproduction rate makes it worth steering agents away
from those two envs entirely - flake8/vulture violations are caught in
CI anyway, so losing the ability to lint locally is a fair trade.