### PR TITLE
ci(snap): retry `snapcraft upload` to mitigate transient store disconnects

### DIFF
--- a/ci/checks/enforce-shell-scripts-pass-shellcheck.sh
+++ b/ci/checks/enforce-shell-scripts-pass-shellcheck.sh
@@ -2,6 +2,11 @@
 
 set -e -o pipefail -u
 
+# Excluded checks (see https://www.shellcheck.net/wiki/SC<id>):
+#   SC2016 - "Expressions don't expand in single quotes"; we intentionally pass literal `$var` strings to awk/sed/ssh/etc. for the remote shell to expand.
+#   SC2086 - "Double quote to prevent globbing and word splitting"; we deliberately leave some expansions unquoted to let the shell word-split flag lists.
+#   SC2090 - "Quotes/backslashes in this variable will not be respected"; companion to SC2089, triggered by the same intentional unquoted-args patterns.
+#   SC2125 - "Brace expansions and globs are literal in assignments"; we assign glob patterns to variables and expand them later at the use site on purpose.
 { git grep --name-only '#!.*sh$' -- ':!*.md' ':!*.fish' ':!*.zsh'; git ls-files '*.sh'; } \
   | sort --unique \
-  | xargs shellcheck --check-sourced --exclude=SC1090,SC1091,SC2016,SC2086,SC2090,SC2125 --severity=info --shell=bash
+  | xargs shellcheck --check-sourced --exclude=SC2016,SC2086,SC2090,SC2125 --severity=info --shell=bash

--- a/ci/ci-run-commons.sh
+++ b/ci/ci-run-commons.sh
@@ -25,8 +25,10 @@ function docker_compose_pull_or_build_and_push() {
   cd "$(git rev-parse --show-toplevel)/ci/$image_name/"
 
   # Let's retry pulling the image in case of a spurious failure
-  # (`error pulling image configuration: Get "https://docker-images-prod.s3.dualstack.us-east-1.amazonaws.com/...": dial tcp ...:443: i/o timeout`)
-  retry 3 docker-compose --ansi=never pull "$image_name"
+  # (`error pulling image configuration: Get "https://docker-images-prod.s3.dualstack.us-east-1.amazonaws.com/...": dial tcp ...:443: i/o timeout`).
+  # `|| true` because a pull failure here is expected when the image hasn't been published yet (`manifest unknown`);
+  # we want to fall through to the build-and-push branch below rather than aborting under `set -e`.
+  retry 3 docker-compose --ansi=never pull "$image_name" || true
 
   # A very unpleasant workaround for https://github.com/docker/compose/issues/7258
   # (since v1.25.1, `docker-compose pull` is NOT failing when it can't fetch the image).

--- a/ci/ci-run-commons.sh
+++ b/ci/ci-run-commons.sh
@@ -6,14 +6,15 @@ function retry() {
   attempts=$1
   interval=5
   for i in $(seq 1 $attempts); do
-    if "${@:2}"; then break; fi
+    if "${@:2}"; then return 0; fi
 
-    echo "Attempt #$i out of $attempts at command '$*' failed"
+    echo "Attempt #$i out of $attempts at command '${*:2}' failed"
     if [[ $i -lt $attempts ]]; then
       echo "Sleeping $interval seconds..."
       sleep $interval
     fi
   done
+  return 1
 }
 
 # If image is not found by pull, build the image and push it to the Docker Hub.

--- a/ci/snap/ci-deploy.sh
+++ b/ci/snap/ci-deploy.sh
@@ -2,6 +2,9 @@
 
 set -e -o pipefail -u -x
 
+# shellcheck source=../ci-run-commons.sh
+source "$(git rev-parse --show-toplevel)/ci/ci-run-commons.sh"
+
 sudo apt-get update
 sudo apt-get install -y snapd
 sudo snap install snapcraft --classic
@@ -25,8 +28,11 @@ if [[ ${1-} == "--dry-run" || ${CIRCLE_BRANCH-} != "master" ]]; then
   fi
   sudo snap remove git-machete
 
-  snapcraft upload --release=edge git-machete_*_amd64.snap
-  snapcraft upload --release=edge git-machete_*_arm64.snap
+  # `snapcraft upload` occasionally drops the HTTPS connection right after the upload completes
+  # (`('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))`),
+  # which is a transient store-side flake; retry a few times before giving up.
+  retry 3 snapcraft upload --release=edge git-machete_*_amd64.snap
+  retry 3 snapcraft upload --release=edge git-machete_*_arm64.snap
 else
   # Relying on SNAPCRAFT_STORE_CREDENTIALS, provided by the CI
   snapcraft upload --release=stable git-machete_*_amd64.snap

--- a/ci/snap/ci-deploy.sh
+++ b/ci/snap/ci-deploy.sh
@@ -2,7 +2,7 @@
 
 set -e -o pipefail -u -x
 
-# shellcheck source=../ci-run-commons.sh
+# shellcheck source=/dev/null
 source "$(git rev-parse --show-toplevel)/ci/ci-run-commons.sh"
 
 sudo apt-get update

--- a/ci/tox/build-context/run.sh
+++ b/ci/tox/build-context/run.sh
@@ -23,6 +23,7 @@ tar tvf dist/git*machete-*.tar.gz | grep docs/man/git-machete.1
 unzip -v dist/git_machete-*.whl   | grep docs/man/git-machete.1
 
 $PYTHON -m venv venv/sdist/
+# shellcheck source=/dev/null
 . venv/sdist/bin/activate
 pip install dist/git*machete-*.tar.gz
 git machete version
@@ -32,6 +33,7 @@ if ! git machete completion fish | grep 'complete -c git-machete'; then
 fi
 
 $PYTHON -m venv venv/bdist_wheel/
+# shellcheck source=/dev/null
 . venv/bdist_wheel/bin/activate
 pip install dist/git_machete-*.whl
 git machete version

--- a/tests/completion_e2e/complete-bash.sh
+++ b/tests/completion_e2e/complete-bash.sh
@@ -8,13 +8,18 @@ if ! declare -f __git_complete &>/dev/null; then
   # __git_complete (defined in https://github.com/git/git/blob/master/contrib/completion/git-completion.bash#L3496-L3505)
   # is not public and is loaded by bash_completion dynamically on demand.
   # The solution is to source git completions (from one of these common locations).
+  # The `source=/dev/null` directives below tell shellcheck not to try to follow these distro-specific runtime paths.
   if [ -e /usr/share/bash-completion/completions/git ]; then
+    # shellcheck source=/dev/null
     source /usr/share/bash-completion/completions/git
   elif [ -f /usr/local/share/bash-completion/completions/git ]; then
+    # shellcheck source=/dev/null
     source /usr/local/share/bash-completion/completions/git
   elif [ -e /etc/bash_completion.d/git ]; then
+    # shellcheck source=/dev/null
     source /etc/bash_completion.d/git
   elif [ -e "$(brew --prefix)/etc/bash_completion.d/git-completion.bash" ]; then
+    # shellcheck source=/dev/null
     source "$(brew --prefix)/etc/bash_completion.d/git-completion.bash"
   else
     exit 1


### PR DESCRIPTION
`snapcraft upload --release=edge` occasionally drops the HTTPS connection right after the upload completes
(`('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))`),
which is a transient store-side flake. Wrap the two dry-run uploads with `retry 3`.

Also fix the `retry` helper in `ci/ci-run-commons.sh` to actually propagate the final exit code:
previously, if all attempts failed, the function still returned 0 (the `for` loop fell through to an `echo`/`sleep`),
so `set -e` in callers would silently swallow the failure.