### PR TITLE
Show actionable error when target branch is locked by another worktree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,20 @@
 
 - Don't `git commit` or `git push` unless explicitly asked.
 
+## Tests
+
+- Skip tests that require a minimum Git version with `@pytest.mark.skipif(get_git_version() < (X, Y), reason="...")`,
+  not with an `if get_git_version() < (X, Y): return` early-return at the top of the test body.
+  The decorator surfaces the skip in pytest's report (and in the JUnit XML CI uploads); the early-return silently masquerades as a pass.
+
+## Comments
+
+- Don't add code comments that narrate test-harness internals or explain why an assertion's expected value was massaged
+  to match the harness's output (e.g. "backticks are stripped by `_fmt` in ASCII mode, so the expected string omits them",
+  "the harness lower-cases this, so we compare against lower-case", etc.).
+  If the actual and expected values match, the assertion already documents itself; if they don't, fix the production code or the harness, don't annotate the workaround.
+  This generalizes: avoid comments that exist solely to justify a specific literal in a test - the test name and the assertion are the contract.
+
 ## Formatting
 
 - No trailing whitespace on any line.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## New in git-machete 3.41.1
 
+- fixed: `git machete go`, `slide-out` and `{github,gitlab} checkout-{pr,mr}s` now fail with an actionable error when the target branch is already checked out in another worktree, rather than the cryptic `fatal: '<branch>' is already used by worktree at <path>` from `git checkout` (reported by @lsierant)
+
 ## New in git-machete 3.41.0
 
 - added: an [Agent Skill](https://agentskills.io/) at `skills/git-machete/SKILL.md`

--- a/git_machete/client/go_interactive.py
+++ b/git_machete/client/go_interactive.py
@@ -132,7 +132,7 @@ class GoInteractiveMacheteClient(StatusMacheteClient):
         if selected_branch is not None and selected_branch != current_branch:
             print()
             print_fmt(f"Checking out <b>{selected_branch}</b>... ", newline=False)
-            self._git.checkout(selected_branch)
+            self._git.checkout_in_current_worktree(selected_branch)
             print_fmt(green_ok())
 
     def _pick_branch_interactively(self, *, current_branch: Optional[LocalBranchShortName]) -> Optional[LocalBranchShortName]:

--- a/git_machete/client/go_show.py
+++ b/git_machete/client/go_show.py
@@ -70,7 +70,7 @@ class GoShowMacheteClient(MacheteClient):
         dest = self._parse_direction(direction, branch=current_branch, allow_current=False, pick_if_multiple=True)[0]
         if dest != current_branch:
             print_fmt(f"Checking out <b>{dest}</b>... ", newline=False)
-            self._git.checkout(dest)
+            self._git.checkout_in_current_worktree(dest)
             print_fmt(green_ok())
         # Other directions (`up`/`prev`/`next`/`root`/`first`/`last`) are deterministic and plumbing-friendly,
         # but `down` may prompt to pick among multiple children - so it's the one direction whose users

--- a/git_machete/client/slide_out.py
+++ b/git_machete/client/slide_out.py
@@ -80,12 +80,12 @@ class SlideOutMacheteClient(MacheteClient):
         if self._git.get_current_branch_or_none() in branches_to_slide_out:
             if new_parent is not None:
                 print_fmt(f"Checking out <b>{new_parent}</b>... ", newline=False)
-                self._git.checkout(new_parent)
+                self._git.checkout_in_current_worktree(new_parent)
                 print_fmt(green_ok())
             elif new_children:
                 # If no parent and there are children, check out the first child
                 print_fmt(f"Checking out <b>{new_children[0]}</b>... ", newline=False)
-                self._git.checkout(new_children[0])
+                self._git.checkout_in_current_worktree(new_children[0])
                 print_fmt(green_ok())
             # Otherwise, stay on the current (slid-out) branch
 
@@ -97,7 +97,7 @@ class SlideOutMacheteClient(MacheteClient):
                 use_rebase = not use_merge and (not anno or anno.qualifiers.rebase)
                 if use_merge or use_rebase:
                     print_fmt(f"Checking out <b>{child}</b>... ", newline=False)
-                    self._git.checkout(child)
+                    self._git.checkout_in_current_worktree(child)
                     print_fmt(green_ok())
                 if use_merge:
                     print_fmt(f"Merging <b>{new_parent}</b> into <b>{child}</b>...")

--- a/git_machete/client/traverse.py
+++ b/git_machete/client/traverse.py
@@ -130,6 +130,8 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
 
                 checkout_msg = custom_checkout_message or f"Checking out <b>{target_branch}</b>"
                 print_fmt(f"{checkout_msg}... ", newline=False)
+                # Plain `git checkout`: traverse's snapshot already verified `target_branch` isn't held by
+                # any other worktree, so the extra guard in `checkout_in_current_worktree` is unnecessary here.
                 self._git.checkout(target_branch)
                 print_fmt(green_ok())
                 self._update_worktrees_cache_after_checkout(target_branch)

--- a/git_machete/client/with_code_hosting.py
+++ b/git_machete/client/with_code_hosting.py
@@ -883,7 +883,7 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
                      f'No remote tracking data will be set up for <b>{pr.head}</b> branch.')
                 refspec = f'{self.code_hosting_client.get_ref_name_for_pull_request(pr.number)}:{pr.head}'
                 self._git.fetch_refspec(org_repo_remote.remote, refspec)
-                self._git.checkout(LocalBranchShortName.of(pr.head))
+                self._git.checkout_in_current_worktree(LocalBranchShortName.of(pr.head))
             if pr.state in ('closed', 'merged'):
                 warn(f'{pr.display_text()} is already closed.')
             debug(f'found {pr}')
@@ -915,7 +915,7 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
         debug(f'Current {spec.display_name} user is ' + (current_user or '<none>'))
         self.__sync_annotations_to_branch_layout_file(list(prs_to_annotate), current_user=current_user, include_urls=False, verbose=False)
         if len(applicable_prs) == 1:
-            self._git.checkout(LocalBranchShortName.of(applicable_prs[0].head))
+            self._git.checkout_in_current_worktree(LocalBranchShortName.of(applicable_prs[0].head))
 
     def __get_downwards_tree_excluding_pr(self, original_pr: PullRequest) -> List[Tuple[PullRequest, int]]:
         """Returns pairs of (PR, depth below the given PR)"""

--- a/git_machete/git.py
+++ b/git_machete/git.py
@@ -13,7 +13,7 @@ from .utils._subproc import PopenResult
 from .utils.cmd import get_cmd_shell_repr, popen_cmd, run_cmd
 from .utils.collections import get_non_empty_lines
 from .utils.debug_log import debug, hex_repr
-from .utils.exceptions import (UnderlyingGitException,
+from .utils.exceptions import (MacheteException, UnderlyingGitException,
                                UnexpectedMacheteException)
 from .utils.fs import is_executable, slurp_file
 from .utils.markup import escape_markup, print_fmt
@@ -726,7 +726,29 @@ class Git:
     # === Branch listing & loading ===
 
     def checkout(self, branch: LocalBranchShortName) -> None:
+        """Plain `git checkout <branch>` in the current worktree.
+
+        Callers that need to guard against the "branch is already checked out in another linked worktree" case
+        (which would otherwise surface as the cryptic `fatal: '<branch>' is already used by worktree at <path>`)
+        should use `checkout_in_current_worktree` instead.
+        """
         self._run_git("checkout", "--quiet", branch, "--", flush_caches=True)
+
+    def checkout_in_current_worktree(self, branch: LocalBranchShortName) -> None:
+        """Like `checkout`, but if `<branch>` is already checked out in another linked worktree,
+        raise a `MacheteException` naming that worktree instead of letting `git checkout` fail with
+        `fatal: '<branch>' is already used by worktree at <path>` (exit 128).
+
+        No `os.chdir` is performed: `os.chdir` only mutates the current Python process and cannot propagate
+        back to the calling shell, so chdir-then-exit-0 would falsely signal success to interactive users and scripts.
+        """
+        target_worktree_root_dir = self.get_worktree_root_dirs_by_branch().get(branch)
+        if target_worktree_root_dir is not None and target_worktree_root_dir != self.get_current_worktree_root_dir():
+            raise MacheteException(
+                f"Branch <b>{branch}</b> is already checked out in another worktree at <b>{target_worktree_root_dir}</b>.\n"
+                f"Run `cd {target_worktree_root_dir}` to work on it there,\n"
+                f"or `git worktree remove {target_worktree_root_dir}` to drop that worktree.")
+        self.checkout(branch)
 
     def get_local_branches(self) -> List[LocalBranchShortName]:
         if self.__local_branches_cached is None:

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 from git_machete.git import (AnyBranchName, AnyRevision, FullCommitHash, Git,
                              LocalBranchShortName)
 
@@ -198,11 +200,8 @@ class TestGitOperations(BaseTest):
         # should raise an UnexpectedMacheteException.
         git.get_reflog(AnyBranchName.of("feature@foo"))
 
+    @pytest.mark.skipif(get_git_version() < (2, 5), reason="git worktree command was introduced in git 2.5")
     def test_get_worktree_root_dirs_by_branch(self) -> None:
-        if get_git_version() < (2, 5):
-            # git worktree command was introduced in git 2.5
-            return
-
         create_repo()
         new_branch("main")
         commit("main commit")

--- a/tests/test_go.py
+++ b/tests/test_go.py
@@ -1,10 +1,12 @@
 import os
 
+import pytest
 from pytest_mock import MockerFixture
+
+from git_machete.utils.paths import AbsPath
 
 from .base_test import BaseTest
 from .cli_runner import (assert_failure, assert_success, launch_command,
-                         launch_command_capturing_output_and_exception,
                          rewrite_branch_layout_file)
 from .git_repository import (add_worktree, check_out, commit, create_repo,
                              get_commit_hash, get_git_version, new_branch,
@@ -483,12 +485,13 @@ class TestGo(BaseTest):
           * git machete gitlab checkout-mrs --mine"""
         assert_failure(["g", "root"], expected_error_message)
 
+    @pytest.mark.skipif(get_git_version() < (2, 5), reason="git worktree command was introduced in git 2.5")
     def test_go_with_worktree(self) -> None:
-        """Test that go fails gracefully when target branch is checked out in a worktree."""
-        if get_git_version() < (2, 5):
-            # git worktree command was introduced in git 2.5
-            return
-
+        """`go down` fails with an actionable machete-level error (not the raw `git checkout` error)
+        when the target branch is already checked out in a linked worktree, and the user's cwd is
+        left untouched (we deliberately do NOT silently `cd` into the linked worktree - `os.chdir`
+        can never propagate back to the user's shell, so doing so + exiting 0 would mislead both
+        interactive users and scripts/agents into thinking the checkout succeeded)."""
         create_repo()
         new_branch("develop")
         commit()
@@ -505,26 +508,23 @@ class TestGo(BaseTest):
             """
         rewrite_branch_layout_file(body)
 
-        # Create a worktree for feature-1
         check_out("develop")
-        add_worktree("feature-1")
+        feature_1_worktree = add_worktree("feature-1")
 
-        # Now try to `go down` from develop to feature-1
-        # feature-1 is already checked out in a worktree
         check_out("develop")
         initial_dir = os.getcwd()
-        output, exception = launch_command_capturing_output_and_exception("go", "down")
 
-        # Verify that `go` command fails when trying to checkout a branch in a worktree
-        # Git checkout fails with exit code 128 and stderr: "fatal: 'feature-1' is already used by worktree..."
-        assert exception is not None, "Expected go command to fail when target branch is in a worktree"
-        from git_machete.utils.exceptions import UnderlyingGitException
-        assert isinstance(exception, UnderlyingGitException)
-        assert "returned 128" in str(exception)  # Git checkout failure
-        assert "checkout" in str(exception).lower()
+        normalized_feature_1_worktree = AbsPath(feature_1_worktree)
+        assert_failure(
+            ["go", "down"],
+            f"Branch feature-1 is already checked out in another worktree at {normalized_feature_1_worktree}.\n"
+            f"Run cd {normalized_feature_1_worktree} to work on it there,\n"
+            f"or git worktree remove {normalized_feature_1_worktree} to drop that worktree.",
+        )
 
-        # Also verify the directory hasn't changed (unlike traverse which cd's into worktrees)
         assert os.getcwd() == initial_dir, "go should not change directory"
+        assert launch_command("show", "current").strip() == "develop", \
+            "HEAD should remain on develop - the failed `go down` must not silently leave a partial state."
 
     def test_go_directions_when_detached_head(self) -> None:
         """Verify behavior of 'git machete go' commands when in detached HEAD mode.

--- a/tests/test_slide_out.py
+++ b/tests/test_slide_out.py
@@ -2,14 +2,17 @@
 import pytest
 from pytest_mock import MockerFixture
 
+from git_machete.utils.paths import AbsPath
+
 from .base_test import BaseTest
 from .cli_runner import (assert_failure, assert_success, launch_command,
                          read_branch_layout_file, rewrite_branch_layout_file)
-from .git_repository import (amend_commit, check_out, commit, create_repo,
-                             create_repo_with_remote, delete_branch,
-                             delete_remote_branch, get_current_branch,
-                             get_current_commit_hash, get_local_branches,
-                             new_branch, push)
+from .git_repository import (add_worktree, amend_commit, check_out, commit,
+                             create_repo, create_repo_with_remote,
+                             delete_branch, delete_remote_branch,
+                             get_current_branch, get_current_commit_hash,
+                             get_git_version, get_local_branches, new_branch,
+                             push)
 from .mockers import (fixed_author_and_committer_date_in_past,
                       mock_input_returning_y)
 from .shell import read_file, set_file_executable, write_to_file
@@ -789,3 +792,44 @@ class TestSlideOut(BaseTest):
 
         expected_layout = ["branch-0", "    branch-2"]
         assert read_branch_layout_file().splitlines() == expected_layout
+
+    @pytest.mark.skipif(get_git_version() < (2, 5), reason="git worktree command was introduced in git 2.5")
+    def test_slide_out_fails_when_new_parent_is_in_another_worktree(self) -> None:
+        """`slide-out` fails with an actionable machete-level error (not the raw `git checkout` error)
+        when the new parent that `slide-out` would `git checkout` is already checked out in a linked worktree.
+        Importantly, `slide-out` must NOT silently `cd` into that worktree as a workaround - `os.chdir` from
+        a Python subprocess cannot propagate back to the user's shell, so exit-0 + a silent chdir would mislead
+        scripts/agents into thinking the slide-out completed in the current worktree."""
+        create_repo()
+        new_branch("develop")
+        commit()
+        new_branch("feature-1")
+        commit()
+        new_branch("feature-2")
+        commit()
+
+        body: str = \
+            """
+            develop
+                feature-1
+                    feature-2
+            """
+        rewrite_branch_layout_file(body)
+
+        # Pin `develop` to a linked worktree, then move the main worktree off it
+        # so `slide-out feature-1` (run from the main worktree, currently on `feature-1`)
+        # will try to `git checkout develop` here.
+        check_out("develop")
+        develop_worktree = add_worktree("develop")
+        check_out("feature-1")
+
+        normalized_develop_worktree = AbsPath(develop_worktree)
+        assert_failure(
+            ["slide-out", "--no-rebase"],  # skip post-slide-out rebase so the test stays focused on the checkout step
+            f"Branch develop is already checked out in another worktree at {normalized_develop_worktree}.\n"
+            f"Run cd {normalized_develop_worktree} to work on it there,\n"
+            f"or git worktree remove {normalized_develop_worktree} to drop that worktree.",
+            # `slide-out` had already printed "Checking out develop... " (newline=False, no `OK` yet)
+            # when `Git.checkout` raised the actionable error - keep that captured so we don't lose the breadcrumb.
+            expected_output="Checking out develop...",
+        )


### PR DESCRIPTION
## Summary

`git machete go`, `git machete slide-out` and `git machete {github,gitlab} checkout-{pr,mr}s` used to fail with the cryptic `fatal: '<branch>' is already used by worktree at <path>` (exit 128) from `git checkout` when the target branch was already checked out in another linked worktree.
They now fail with a clean machete-level error that names the locking worktree and points the user at the two reasonable next steps:

> Branch `<branch>` is already checked out in another worktree at `<path>`.
> Run `cd <path>` to work on it there, or `git worktree remove <path>` to drop that worktree.

## Why not just `os.chdir` into the linked worktree (the obvious "fix")?

Because we can't.

`os.chdir` from a Python subprocess (which `git machete` is) mutates the cwd of *that subprocess only*.
The instant the process exits, the user's shell is back where it started - no portable way to "export the cd back to the shell" without involving a shell function wrapper (`eval "$(git machete go --print-cd)"` style), which we don't ship.

So a silent chdir + exit-0 would:

- mislead **interactive users** (`git machete go down` claims success, prints "Changing directory to ...", exits - and the user's shell cwd is unchanged, with no branch newly checked out anywhere they can see),
- silently break **agents / CI** (exit 0 implies "checkout succeeded" - caller then runs `git status` / `git log` against the *wrong* branch in the *wrong* worktree, with no signal that anything went sideways).

Failing with a clear, actionable, non-zero-exit error is strictly safer.

## Factoring

`Git` stays machete-agnostic and exposes two methods:

- `Git.checkout(branch)` - plain `git checkout <branch>`, unchanged from before.
- `Git.checkout_in_current_worktree(branch)` - new; runs `git worktree list --porcelain` itself, raises the actionable `MacheteException` above if `<branch>` is held by another linked worktree, otherwise delegates to `Git.checkout`.

Callers:

- `go`, `slide-out`, `{github,gitlab} checkout-{pr,mr}s` use `checkout_in_current_worktree` - one-shot commands that must not silently land in the wrong worktree.
- `traverse` keeps using plain `Git.checkout`.
  It already maintains its own up-front worktree snapshot (`TraverseMacheteClient.__worktree_root_dir_for_branch`) and pre-routes any branch held by another worktree into its existing chdir path inside `_switch_branch` - so the guard in `checkout_in_current_worktree` would be redundant there.
  Traverse's chdir behavior is intentionally kept: it's a long-running session, subsequent `git rebase` / `git merge` / `git push` calls within the same process do observe the new cwd, and traverse already prints a hint reminding the user to `cd` themselves at the end of the loop.

## Test plan

- [x] New `tests/test_go.py::TestGo::test_go_with_worktree` - asserts the new actionable `MacheteException` text, asserts `os.getcwd()` is unchanged, asserts HEAD is unchanged.
- [x] New `tests/test_slide_out.py::TestSlideOut::test_slide_out_fails_when_new_parent_is_in_another_worktree` - same shape for the slide-out path.
- [x] Existing `tests/test_traverse.py` + `tests/test_traverse_worktrees.py` - traverse's chdir-into-linked-worktree behavior preserved.
- [x] Existing `tests/test_github_checkout_prs.py` + `tests/test_gitlab_checkout_mrs.py` - exercise the new `checkout_in_current_worktree` path; all green.
- [x] `tox -e mypy` clean.
- [x] CI matrix (Python 3.6 + git 1.8.0 through Python 3.14 + git 2.51.0).

Reported by @lsierant.