### PR TITLE
Use absolute imports only; enforce in CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,14 @@
   not with an `if get_git_version() < (X, Y): return` early-return at the top of the test body.
   The decorator surfaces the skip in pytest's report (and in the JUnit XML CI uploads); the early-return silently masquerades as a pass.
 
+## Imports
+
+- Always use absolute imports (`from git_machete.<...> import ...`, `from tests.<...> import ...`) - never relative ones (`from .x import y`, `from ..x import y`, ...),
+  not even for siblings inside the same package and not even inside a function body.
+  Absolute imports are easier to follow when reading code in isolation (no need to know the file's package)
+  and survive moving a file across packages without a silent semantic change.
+  Enforced by `ci/checks/prohibit-relative-imports.sh`.
+
 ## Comments
 
 - Don't add code comments that narrate test-harness internals or explain why an assertion's expected value was massaged

--- a/ci/checks/prohibit-relative-imports.sh
+++ b/ci/checks/prohibit-relative-imports.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail -u
+
+# Match `from .x import y` / `from ..x import y` style relative imports,
+# whether at top level or indented inside a function/method.
+# `\bfrom\s+\.` keeps the regex tight enough to avoid false positives on
+# unrelated occurrences of the literal string "from ." inside string literals,
+# since those are practically never preceded by "from " followed by whitespace
+# at the start of a logical import statement.
+if git grep -n -P '^\s*from\s+\.+\w*\s+import\b' -- '*.py'; then
+  echo
+  echo 'Do not use relative imports (`from .x import y`, `from ..x import y`, ...) in Python code.'
+  echo 'Use the fully-qualified absolute form instead: `from git_machete.<...> import ...` or `from tests.<...> import ...`.'
+  echo 'Absolute imports are easier to follow when reading code in isolation (no need to know the file'"'"'s package)'
+  echo 'and survive moving a file across packages without a silent semantic change.'
+  exit 1
+fi

--- a/ci/checks/run-all-checks.sh
+++ b/ci/checks/run-all-checks.sh
@@ -49,6 +49,7 @@ _ prohibit-id-est-in-rst
 _ prohibit-markdown-links-in-rst
 _ prohibit-mrs-in-github-files
 _ prohibit-prs-in-gitlab-files
+_ prohibit-relative-imports
 _ prohibit-single-backtick-in-rst
 _ prohibit-sleep-in-python
 _ prohibit-split-backslash-n

--- a/git_machete/bin.py
+++ b/git_machete/bin.py
@@ -16,6 +16,6 @@ def main():  # type: ignore
 
     validate_python_version()  # type: ignore
 
-    from . import cli
+    from git_machete import cli
 
     cli.main()

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -25,18 +25,19 @@ from git_machete.client.traverse import TraverseMacheteClient, TraverseReturnTo
 from git_machete.client.update import UpdateMacheteClient
 from git_machete.client.with_code_hosting import MacheteClientWithCodeHosting
 from git_machete.config import MacheteConfig, SquashMergeDetection
+from git_machete.git import AnyRevision, LocalBranchShortName
 from git_machete.github import GITHUB_API_SPEC
 from git_machete.gitlab import GITLAB_API_SPEC
-
-from .git import AnyRevision, LocalBranchShortName
-from .help import alias_by_command, get_help_description, version
-from .utils import cmd, debug_log, terminal
-from .utils.exceptions import (ExitCode, InteractionStopped, MacheteException,
-                               UnderlyingGitException,
-                               UnexpectedMacheteException)
-from .utils.fs import does_directory_exist, get_current_directory_or_none
-from .utils.markup import print_fmt, warn
-from .utils.paths import AbsPath
+from git_machete.help import alias_by_command, get_help_description, version
+from git_machete.utils import cmd, debug_log, terminal
+from git_machete.utils.exceptions import (ExitCode, InteractionStopped,
+                                          MacheteException,
+                                          UnderlyingGitException,
+                                          UnexpectedMacheteException)
+from git_machete.utils.fs import (does_directory_exist,
+                                  get_current_directory_or_none)
+from git_machete.utils.markup import print_fmt, warn
+from git_machete.utils.paths import AbsPath
 
 
 def _populate_cli_options(

--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -15,6 +15,7 @@ from git_machete.git import (HEAD, AnyBranchName, AnyRevision, BranchPair,
                              ForkPointOverrideData, FullCommitHash, Git,
                              LocalBranchShortName, RemoteBranchShortName,
                              SyncToRemoteStatus)
+from git_machete.utils import fs
 from git_machete.utils.cmd import run_cmd
 from git_machete.utils.collections import excluding, get_second, tupled
 from git_machete.utils.debug_log import debug
@@ -22,8 +23,6 @@ from git_machete.utils.exceptions import (InteractionStopped, MacheteException,
                                           UnexpectedMacheteException)
 from git_machete.utils.markup import input_fmt, pretty_choices, print_fmt, warn
 from git_machete.utils.paths import AbsPath, Path
-
-from ..utils import fs
 
 _BranchT = TypeVar("_BranchT", bound=LocalBranchShortName)
 

--- a/git_machete/client/go_interactive.py
+++ b/git_machete/client/go_interactive.py
@@ -12,6 +12,7 @@ except ImportError:  # pragma: no cover; Windows-specific
 from git_machete.client.status import (StatusData, StatusFlags,
                                        StatusMacheteClient)
 from git_machete.git import LocalBranchShortName
+from git_machete.utils import terminal
 from git_machete.utils.collections import index_or_none
 from git_machete.utils.exceptions import (MacheteException,
                                           UnexpectedMacheteException)
@@ -20,8 +21,6 @@ from git_machete.utils.terminal import (AnsiInputCodes,
                                         BasicTerminalAnsiOutputCodes,
                                         FullTerminalAnsiOutputCodes,
                                         is_terminal_fully_fledged)
-
-from ..utils import terminal
 
 AI = AnsiInputCodes
 

--- a/git_machete/client/status.py
+++ b/git_machete/client/status.py
@@ -7,19 +7,18 @@ from enum import Enum, auto
 from typing import Dict, List, NamedTuple, Optional, Tuple
 
 from git_machete.annotation import Annotation
+from git_machete.client.base import MacheteClient
+from git_machete.client.state import ManagedBranchName
 from git_machete.config import SquashMergeDetection
 from git_machete.git import (BranchPair, FullCommitHash, GitLogEntry,
                              LocalBranchShortName, SyncToRemoteStatus)
+from git_machete.utils import markup
 from git_machete.utils._subproc import PopenResult
 from git_machete.utils.cmd import popen_cmd
 from git_machete.utils.debug_log import debug
 from git_machete.utils.exceptions import MacheteException
 from git_machete.utils.markup import escape_markup, print_fmt, warn
 from git_machete.utils.paths import Path
-
-from ..utils import markup
-from .base import MacheteClient
-from .state import ManagedBranchName
 
 
 class SyncToParentStatus(Enum):

--- a/git_machete/client/with_code_hosting.py
+++ b/git_machete/client/with_code_hosting.py
@@ -13,6 +13,7 @@ from git_machete.config import PRDescriptionIntroStyle, SquashMergeDetection
 from git_machete.git import (GitFormatPatterns, GitLogEntry,
                              LocalBranchShortName, RemoteBranchShortName,
                              SyncToRemoteStatus)
+from git_machete.utils import date
 from git_machete.utils.collections import find_or_none, get_non_empty_lines
 from git_machete.utils.debug_log import debug
 from git_machete.utils.exceptions import (MacheteException,
@@ -21,8 +22,6 @@ from git_machete.utils.fs import slurp_file
 from git_machete.utils.markup import (colored_yes_no, green_ok, pretty_choices,
                                       print_fmt, warn)
 from git_machete.utils.paths import AbsPath
-
-from ..utils import date
 
 
 class MacheteClientWithCodeHosting(StatusMacheteClient):

--- a/git_machete/git.py
+++ b/git_machete/git.py
@@ -8,16 +8,17 @@ from pathlib import Path as PyPath
 from typing import (Any, Dict, Iterator, List, Match, NamedTuple, Optional,
                     Set, Tuple)
 
-from .constants import MAX_COMMITS_FOR_SQUASH_MERGE_DETECTION
-from .utils._subproc import PopenResult
-from .utils.cmd import get_cmd_shell_repr, popen_cmd, run_cmd
-from .utils.collections import get_non_empty_lines
-from .utils.debug_log import debug, hex_repr
-from .utils.exceptions import (MacheteException, UnderlyingGitException,
-                               UnexpectedMacheteException)
-from .utils.fs import is_executable, slurp_file
-from .utils.markup import escape_markup, print_fmt
-from .utils.paths import AbsPath, Path
+from git_machete.constants import MAX_COMMITS_FOR_SQUASH_MERGE_DETECTION
+from git_machete.utils._subproc import PopenResult
+from git_machete.utils.cmd import get_cmd_shell_repr, popen_cmd, run_cmd
+from git_machete.utils.collections import get_non_empty_lines
+from git_machete.utils.debug_log import debug, hex_repr
+from git_machete.utils.exceptions import (MacheteException,
+                                          UnderlyingGitException,
+                                          UnexpectedMacheteException)
+from git_machete.utils.fs import is_executable, slurp_file
+from git_machete.utils.markup import escape_markup, print_fmt
+from git_machete.utils.paths import AbsPath, Path
 
 
 class AnyRevision(str):

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -18,10 +18,9 @@ from git_machete.utils.cmd import popen_cmd
 from git_machete.utils.debug_log import compact_dict, debug
 from git_machete.utils.exceptions import (MacheteException,
                                           UnexpectedMacheteException)
+from git_machete.utils.fs import slurp_file
 from git_machete.utils.markup import warn
 from git_machete.utils.paths import AbsPath
-
-from .utils.fs import slurp_file
 
 GITHUB_TOKEN_ENV_VAR = 'GITHUB_TOKEN'
 

--- a/git_machete/gitlab.py
+++ b/git_machete/gitlab.py
@@ -20,9 +20,8 @@ from git_machete.utils.collections import map_truthy_only
 from git_machete.utils.debug_log import compact_dict, debug
 from git_machete.utils.exceptions import (MacheteException,
                                           UnexpectedMacheteException)
-
-from .utils.fs import slurp_file
-from .utils.paths import AbsPath
+from git_machete.utils.fs import slurp_file
+from git_machete.utils.paths import AbsPath
 
 GITLAB_TOKEN_ENV_VAR = 'GITLAB_TOKEN'
 

--- a/git_machete/options.py
+++ b/git_machete/options.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
-from .config import SquashMergeDetection
-from .git import AnyRevision, LocalBranchShortName
+from git_machete.config import SquashMergeDetection
+from git_machete.git import AnyRevision, LocalBranchShortName
 
 
 class CommandLineOptions:

--- a/git_machete/utils/cmd.py
+++ b/git_machete/utils/cmd.py
@@ -15,12 +15,12 @@ import sys
 import time
 from typing import Dict, Optional
 
-from . import _subproc, debug_log
-from ._subproc import PopenResult, _popen_cmd
-from .debug_log import debug
-from .fs import get_current_directory_or_none
-from .markup import escape_markup, print_fmt
-from .paths import AbsPath, Path
+from git_machete.utils import _subproc, debug_log
+from git_machete.utils._subproc import PopenResult, _popen_cmd
+from git_machete.utils.debug_log import debug
+from git_machete.utils.fs import get_current_directory_or_none
+from git_machete.utils.markup import escape_markup, print_fmt
+from git_machete.utils.paths import AbsPath, Path
 
 # === Mutable runtime flags ===
 #

--- a/git_machete/utils/debug_log.py
+++ b/git_machete/utils/debug_log.py
@@ -10,8 +10,8 @@ import sys
 import textwrap
 from typing import Any, Dict
 
-from .collections import excluding
-from .markup import escape_markup, print_fmt
+from git_machete.utils.collections import excluding
+from git_machete.utils.markup import escape_markup, print_fmt
 
 # === Mutable runtime flags ===
 #

--- a/git_machete/utils/exceptions.py
+++ b/git_machete/utils/exceptions.py
@@ -9,8 +9,8 @@ output.
 from enum import Enum, IntEnum
 from typing import Optional, Type, TypeVar
 
-from . import markup
-from .markup import _fmt
+from git_machete.utils import markup
+from git_machete.utils.markup import _fmt
 
 E = TypeVar('E', bound=Enum)
 

--- a/git_machete/utils/fs.py
+++ b/git_machete/utils/fs.py
@@ -9,8 +9,8 @@ import os
 import sys
 from typing import Optional
 
-from .debug_log import debug
-from .paths import AbsPath, Path
+from git_machete.utils.debug_log import debug
+from git_machete.utils.paths import AbsPath, Path
 
 
 def does_directory_exist(path: Path) -> bool:

--- a/git_machete/utils/markup.py
+++ b/git_machete/utils/markup.py
@@ -13,9 +13,10 @@ import re
 import sys
 from typing import Any, List, Optional, Tuple
 
-from . import terminal
-from .collections import map_truthy_only
-from .terminal import BasicTerminalAnsiOutputCodes, FullTerminalAnsiOutputCodes
+from git_machete.utils import terminal
+from git_machete.utils.collections import map_truthy_only
+from git_machete.utils.terminal import (BasicTerminalAnsiOutputCodes,
+                                        FullTerminalAnsiOutputCodes)
 
 # === Mutable runtime flags ===
 #

--- a/git_machete/utils/terminal.py
+++ b/git_machete/utils/terminal.py
@@ -11,7 +11,7 @@ import os
 import sys
 from typing import Optional
 
-from ._subproc import _popen_cmd
+from git_machete.utils._subproc import _popen_cmd
 
 
 def is_stdout_a_tty() -> bool:

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -1,14 +1,15 @@
 
 from pytest_mock import MockerFixture
 
-from .base_test import BaseTest
-from .cli_runner import (assert_failure, assert_success,
-                         read_branch_layout_file, rewrite_branch_layout_file)
-from .git_repository import (check_out, commit, create_repo,
-                             create_repo_with_remote, delete_branch,
-                             get_commit_hash, get_current_commit_hash,
-                             new_branch, push)
-from .mockers import mock_input_returning, mock_input_returning_y
+from tests.base_test import BaseTest
+from tests.cli_runner import (assert_failure, assert_success,
+                              read_branch_layout_file,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (check_out, commit, create_repo,
+                                  create_repo_with_remote, delete_branch,
+                                  get_commit_hash, get_current_commit_hash,
+                                  new_branch, push)
+from tests.mockers import mock_input_returning, mock_input_returning_y
 
 
 class TestAdd(BaseTest):

--- a/tests/test_advance.py
+++ b/tests/test_advance.py
@@ -5,16 +5,16 @@ from pytest_mock import MockerFixture
 
 from git_machete.utils.exceptions import ExitCode, UnderlyingGitException
 from git_machete.utils.terminal import FullTerminalAnsiOutputCodes
-
-from .base_test import BaseTest
-from .cli_runner import (assert_failure, assert_success, launch_command,
-                         launch_command_capturing_output_and_exception,
-                         rewrite_branch_layout_file)
-from .git_repository import (check_out, commit, create_repo,
-                             create_repo_with_remote, fetch, get_commit_hash,
-                             get_current_commit_hash, new_branch, push,
-                             reset_to, wait_to_bump_commit_timestamp)
-from .mockers import mock_input_returning, mock_input_returning_y
+from tests.base_test import BaseTest
+from tests.cli_runner import (assert_failure, assert_success, launch_command,
+                              launch_command_capturing_output_and_exception,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (check_out, commit, create_repo,
+                                  create_repo_with_remote, fetch,
+                                  get_commit_hash, get_current_commit_hash,
+                                  new_branch, push, reset_to,
+                                  wait_to_bump_commit_timestamp)
+from tests.mockers import mock_input_returning, mock_input_returning_y
 
 
 class TestAdvance(BaseTest):

--- a/tests/test_anno.py
+++ b/tests/test_anno.py
@@ -1,15 +1,15 @@
 from pytest_mock import MockerFixture
 
-from . import mockers_github, mockers_gitlab
-from .base_test import BaseTest
-from .cli_runner import (assert_argument_error, assert_success, launch_command,
-                         rewrite_branch_layout_file)
-from .git_repository import (add_remote, check_out, commit, create_repo,
-                             create_repo_with_remote, new_branch)
-from .mockers_github import (MockGitHubAPIState,
-                             mock_github_token_for_domain_fake)
-from .mockers_gitlab import (MockGitLabAPIState,
-                             mock_gitlab_token_for_domain_fake)
+from tests import mockers_github, mockers_gitlab
+from tests.base_test import BaseTest
+from tests.cli_runner import (assert_argument_error, assert_success,
+                              launch_command, rewrite_branch_layout_file)
+from tests.git_repository import (add_remote, check_out, commit, create_repo,
+                                  create_repo_with_remote, new_branch)
+from tests.mockers_github import (MockGitHubAPIState,
+                                  mock_github_token_for_domain_fake)
+from tests.mockers_gitlab import (MockGitLabAPIState,
+                                  mock_gitlab_token_for_domain_fake)
 
 
 class TestAnno(BaseTest):

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,13 +1,14 @@
 from pytest_mock import MockerFixture
 
-from .base_test import BaseTest
-from .cli_runner import (assert_success, launch_command,
-                         read_branch_layout_file, rewrite_branch_layout_file)
-from .git_repository import (add_remote, check_out, commit, create_repo,
-                             create_repo_with_remote, get_local_branches,
-                             new_branch, push)
-from .mockers import mock_input_returning_y
-from .mockers_github import mock_github_token_for_domain_none
+from tests.base_test import BaseTest
+from tests.cli_runner import (assert_success, launch_command,
+                              read_branch_layout_file,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (add_remote, check_out, commit, create_repo,
+                                  create_repo_with_remote, get_local_branches,
+                                  new_branch, push)
+from tests.mockers import mock_input_returning_y
+from tests.mockers_github import mock_github_token_for_domain_none
 
 
 class TestClean(BaseTest):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,11 +6,10 @@ from pytest_mock import MockerFixture
 
 from git_machete.cli import main
 from git_machete.utils.exceptions import ExitCode
-
-from .base_test import BaseTest
-from .cli_runner import (assert_argument_error,
-                         launch_command_capturing_output_and_exception)
-from .git_repository import create_repo
+from tests.base_test import BaseTest
+from tests.cli_runner import (assert_argument_error,
+                              launch_command_capturing_output_and_exception)
+from tests.git_repository import create_repo
 
 
 class TestCLI(BaseTest):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,11 +1,11 @@
 from git_machete.annotation import Annotation
 from git_machete.client.base import MacheteClient
 from git_machete.git import LocalBranchShortName
-
-from .base_test import BaseTest
-from .cli_runner import read_branch_layout_file, rewrite_branch_layout_file
-from .git_repository import (check_out, commit, create_repo_with_remote,
-                             new_branch, push)
+from tests.base_test import BaseTest
+from tests.cli_runner import (read_branch_layout_file,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (check_out, commit, create_repo_with_remote,
+                                  new_branch, push)
 
 
 class TestClient(BaseTest):

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,6 +1,6 @@
 
-from .base_test import BaseTest
-from .cli_runner import launch_command
+from tests.base_test import BaseTest
+from tests.cli_runner import launch_command
 
 
 # These are mostly smoke-tests which also provide coverage.

--- a/tests/test_delete_unmanaged.py
+++ b/tests/test_delete_unmanaged.py
@@ -1,15 +1,16 @@
 from pytest_mock import MockerFixture
 
-from .base_test import BaseTest
-from .cli_runner import (assert_success, launch_command,
-                         rewrite_branch_layout_file)
-from .git_repository import (add_file_and_commit, amend_commit, check_out,
-                             commit, create_repo, create_repo_with_remote,
-                             get_local_branches, new_branch, push,
-                             set_git_config_key)
-from .mockers import (fixed_author_and_committer_date_in_past,
-                      mock__run_cmd_and_forward_stdout, mock_input_returning)
-from .shell import execute
+from tests.base_test import BaseTest
+from tests.cli_runner import (assert_success, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (add_file_and_commit, amend_commit, check_out,
+                                  commit, create_repo, create_repo_with_remote,
+                                  get_local_branches, new_branch, push,
+                                  set_git_config_key)
+from tests.mockers import (fixed_author_and_committer_date_in_past,
+                           mock__run_cmd_and_forward_stdout,
+                           mock_input_returning)
+from tests.shell import execute
 
 
 class TestDeleteUnmanaged(BaseTest):

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,11 +1,11 @@
 from pytest_mock import MockerFixture
 
-from .base_test import BaseTest
-from .cli_runner import assert_success
-from .git_repository import (add_file_and_commit, create_repo_with_remote,
-                             new_branch, push)
-from .mockers import mock__run_cmd_and_forward_stdout
-from .shell import write_to_file
+from tests.base_test import BaseTest
+from tests.cli_runner import assert_success
+from tests.git_repository import (add_file_and_commit, create_repo_with_remote,
+                                  new_branch, push)
+from tests.mockers import mock__run_cmd_and_forward_stdout
+from tests.shell import write_to_file
 
 
 class TestDiff(BaseTest):

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -5,14 +5,14 @@ import textwrap
 from pytest_mock import MockerFixture
 
 from git_machete.utils.terminal import FullTerminalAnsiOutputCodes
-
-from .base_test import BaseTest
-from .cli_runner import (assert_failure, assert_success, launch_command,
-                         rewrite_branch_layout_file)
-from .git_repository import (check_out, commit, create_repo,
-                             create_repo_with_remote, merge, new_branch, push)
-from .mockers import mock_input_returning, overridden_environment
-from .shell import read_file
+from tests.base_test import BaseTest
+from tests.cli_runner import (assert_failure, assert_success, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (check_out, commit, create_repo,
+                                  create_repo_with_remote, merge, new_branch,
+                                  push)
+from tests.mockers import mock_input_returning, overridden_environment
+from tests.shell import read_file
 
 
 class TestDiscover(BaseTest):

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -3,11 +3,11 @@ import sys
 import pytest
 from pytest_mock import MockerFixture
 
-from .base_test import BaseTest
-from .cli_runner import assert_failure, assert_success, launch_command
-from .git_repository import create_repo, set_git_config_key
-from .mockers import overridden_environment
-from .shell import read_file
+from tests.base_test import BaseTest
+from tests.cli_runner import assert_failure, assert_success, launch_command
+from tests.git_repository import create_repo, set_git_config_key
+from tests.mockers import overridden_environment
+from tests.shell import read_file
 
 dummy_editor = "sh -c 'echo foo > $1' 'ignored_$0'"
 

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -3,12 +3,11 @@ from pathlib import Path
 from tempfile import mkdtemp
 
 from git_machete.utils.exceptions import UnderlyingGitException
-
-from .base_test import BaseTest
-from .cli_runner import assert_failure, launch_command
-from .git_repository import (commit, create_repo, get_git_version, new_branch,
-                             set_git_config_key)
-from .shell import execute
+from tests.base_test import BaseTest
+from tests.cli_runner import assert_failure, launch_command
+from tests.git_repository import (commit, create_repo, get_git_version,
+                                  new_branch, set_git_config_key)
+from tests.shell import execute
 
 
 class TestFile(BaseTest):

--- a/tests/test_fork_point.py
+++ b/tests/test_fork_point.py
@@ -3,17 +3,17 @@ import os
 from pytest_mock import MockerFixture
 
 from git_machete.utils.terminal import FullTerminalAnsiOutputCodes
-
-from .base_test import BaseTest
-from .cli_runner import (assert_failure, assert_success, launch_command,
-                         rewrite_branch_layout_file)
-from .git_repository import (add_remote, check_out, commit, create_repo,
-                             create_repo_with_remote, delete_branch, fetch,
-                             get_commit_hash, get_current_commit_hash, merge,
-                             new_branch, new_orphan_branch, pull, push,
-                             reset_to, set_git_config_key)
-from .mockers import fixed_author_and_committer_date_in_past
-from .shell import execute, remove_directory
+from tests.base_test import BaseTest
+from tests.cli_runner import (assert_failure, assert_success, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (add_remote, check_out, commit, create_repo,
+                                  create_repo_with_remote, delete_branch,
+                                  fetch, get_commit_hash,
+                                  get_current_commit_hash, merge, new_branch,
+                                  new_orphan_branch, pull, push, reset_to,
+                                  set_git_config_key)
+from tests.mockers import fixed_author_and_committer_date_in_past
+from tests.shell import execute, remove_directory
 
 
 class TestForkPoint(BaseTest):

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -4,13 +4,12 @@ import pytest
 
 from git_machete.git import (AnyBranchName, AnyRevision, FullCommitHash, Git,
                              LocalBranchShortName)
-
-from .base_test import BaseTest
-from .git_repository import (add_worktree, check_out, commit, create_repo,
-                             get_current_commit_hash, get_git_version,
-                             is_ancestor_or_equal, new_branch,
-                             new_orphan_branch, set_git_config_key)
-from .shell import read_file, write_to_file
+from tests.base_test import BaseTest
+from tests.git_repository import (add_worktree, check_out, commit, create_repo,
+                                  get_current_commit_hash, get_git_version,
+                                  is_ancestor_or_equal, new_branch,
+                                  new_orphan_branch, set_git_config_key)
+from tests.shell import read_file, write_to_file
 
 
 class TestGitOperations(BaseTest):
@@ -274,7 +273,7 @@ class TestGitOperations(BaseTest):
         # This tests the bug fix where multiple detached HEADs would overwrite each other with None key
         from tempfile import mkdtemp
 
-        from .shell import execute
+        from tests.shell import execute
         feature3_worktree = mkdtemp()
         execute(f"git worktree add -f --detach {feature3_worktree} feature-3")
 

--- a/tests/test_go.py
+++ b/tests/test_go.py
@@ -4,14 +4,13 @@ import pytest
 from pytest_mock import MockerFixture
 
 from git_machete.utils.paths import AbsPath
-
-from .base_test import BaseTest
-from .cli_runner import (assert_failure, assert_success, launch_command,
-                         rewrite_branch_layout_file)
-from .git_repository import (add_worktree, check_out, commit, create_repo,
-                             get_commit_hash, get_git_version, new_branch,
-                             new_orphan_branch)
-from .mockers import mock_input_returning
+from tests.base_test import BaseTest
+from tests.cli_runner import (assert_failure, assert_success, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (add_worktree, check_out, commit, create_repo,
+                                  get_commit_hash, get_git_version, new_branch,
+                                  new_orphan_branch)
+from tests.mockers import mock_input_returning
 
 
 class TestGo(BaseTest):

--- a/tests/test_go_interactive.py
+++ b/tests/test_go_interactive.py
@@ -9,11 +9,10 @@ from pytest_mock import MockerFixture
 
 from git_machete.utils.terminal import (AnsiInputCodes,
                                         FullTerminalAnsiOutputCodes)
-
-from .base_test import BaseTest
-from .cli_runner import (assert_failure, launch_command,
-                         rewrite_branch_layout_file)
-from .git_repository import check_out, commit, create_repo, new_branch
+from tests.base_test import BaseTest
+from tests.cli_runner import (assert_failure, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import check_out, commit, create_repo, new_branch
 
 AI = AnsiInputCodes
 KEY_ENTER = '\r'

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -4,11 +4,10 @@ from git_machete.generated_docs import long_docs
 from git_machete.help import (alias_by_command, command_groups,
                               commands_and_aliases)
 from git_machete.utils.exceptions import ExitCode
-
-from .base_test import BaseTest
-from .cli_runner import (launch_command,
-                         launch_command_capturing_output_and_exception)
-from .git_repository import create_repo, set_git_config_key
+from tests.base_test import BaseTest
+from tests.cli_runner import (launch_command,
+                              launch_command_capturing_output_and_exception)
+from tests.git_repository import create_repo, set_git_config_key
 
 
 class TestHelp(BaseTest):

--- a/tests/test_is_managed.py
+++ b/tests/test_is_managed.py
@@ -1,8 +1,8 @@
 import pytest
 
-from .base_test import BaseTest
-from .cli_runner import launch_command, rewrite_branch_layout_file
-from .git_repository import check_out, commit, create_repo, new_branch
+from tests.base_test import BaseTest
+from tests.cli_runner import launch_command, rewrite_branch_layout_file
+from tests.git_repository import check_out, commit, create_repo, new_branch
 
 
 class TestIsManaged(BaseTest):

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,8 +1,8 @@
-from .base_test import BaseTest
-from .cli_runner import (assert_failure, assert_success, launch_command,
-                         rewrite_branch_layout_file)
-from .git_repository import (check_out, commit, create_repo_with_remote,
-                             delete_branch, new_branch, push)
+from tests.base_test import BaseTest
+from tests.cli_runner import (assert_failure, assert_success, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (check_out, commit, create_repo_with_remote,
+                                  delete_branch, new_branch, push)
 
 
 class TestList(BaseTest):

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,11 +1,11 @@
 from pytest_mock import MockerFixture
 
-from .base_test import BaseTest
-from .cli_runner import assert_success, launch_command
-from .git_repository import (commit, create_repo, get_current_commit_hash,
-                             new_branch)
-from .mockers import (fixed_author_and_committer_date_in_past,
-                      mock__run_cmd_and_forward_stdout)
+from tests.base_test import BaseTest
+from tests.cli_runner import assert_success, launch_command
+from tests.git_repository import (commit, create_repo, get_current_commit_hash,
+                                  new_branch)
+from tests.mockers import (fixed_author_and_committer_date_in_past,
+                           mock__run_cmd_and_forward_stdout)
 
 
 class TestLog(BaseTest):

--- a/tests/test_reapply.py
+++ b/tests/test_reapply.py
@@ -1,9 +1,9 @@
-from .base_test import BaseTest
-from .cli_runner import (assert_failure, assert_success, launch_command,
-                         rewrite_branch_layout_file)
-from .git_repository import check_out, commit, create_repo, new_branch
-from .mockers import (fixed_author_and_committer_date_in_past,
-                      overridden_environment)
+from tests.base_test import BaseTest
+from tests.cli_runner import (assert_failure, assert_success, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import check_out, commit, create_repo, new_branch
+from tests.mockers import (fixed_author_and_committer_date_in_past,
+                           overridden_environment)
 
 
 class TestReapply(BaseTest):

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -1,13 +1,13 @@
 import subprocess
 import textwrap
 
-from .base_test import BaseTest
-from .cli_runner import (assert_failure, assert_success,
-                         rewrite_branch_layout_file)
-from .git_repository import (check_out, commit, create_repo,
-                             create_repo_with_remote, get_local_branches,
-                             new_branch, push)
-from .shell import popen
+from tests.base_test import BaseTest
+from tests.cli_runner import (assert_failure, assert_success,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (check_out, commit, create_repo,
+                                  create_repo_with_remote, get_local_branches,
+                                  new_branch, push)
+from tests.shell import popen
 
 
 class TestRename(BaseTest):

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -1,12 +1,12 @@
 import os
 
-from .base_test import BaseTest
-from .cli_runner import (assert_failure, assert_success, launch_command,
-                         rewrite_branch_layout_file)
-from .git_repository import (check_out, commit, create_repo,
-                             create_repo_with_remote, new_branch,
-                             new_orphan_branch, pull, push)
-from .shell import execute, remove_directory
+from tests.base_test import BaseTest
+from tests.cli_runner import (assert_failure, assert_success, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (check_out, commit, create_repo,
+                                  create_repo_with_remote, new_branch,
+                                  new_orphan_branch, pull, push)
+from tests.shell import execute, remove_directory
 
 
 class TestShow(BaseTest):

--- a/tests/test_slide_out.py
+++ b/tests/test_slide_out.py
@@ -3,19 +3,19 @@ import pytest
 from pytest_mock import MockerFixture
 
 from git_machete.utils.paths import AbsPath
-
-from .base_test import BaseTest
-from .cli_runner import (assert_failure, assert_success, launch_command,
-                         read_branch_layout_file, rewrite_branch_layout_file)
-from .git_repository import (add_worktree, amend_commit, check_out, commit,
-                             create_repo, create_repo_with_remote,
-                             delete_branch, delete_remote_branch,
-                             get_current_branch, get_current_commit_hash,
-                             get_git_version, get_local_branches, new_branch,
-                             push)
-from .mockers import (fixed_author_and_committer_date_in_past,
-                      mock_input_returning_y)
-from .shell import read_file, set_file_executable, write_to_file
+from tests.base_test import BaseTest
+from tests.cli_runner import (assert_failure, assert_success, launch_command,
+                              read_branch_layout_file,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (add_worktree, amend_commit, check_out,
+                                  commit, create_repo, create_repo_with_remote,
+                                  delete_branch, delete_remote_branch,
+                                  get_current_branch, get_current_commit_hash,
+                                  get_git_version, get_local_branches,
+                                  new_branch, push)
+from tests.mockers import (fixed_author_and_committer_date_in_past,
+                           mock_input_returning_y)
+from tests.shell import read_file, set_file_executable, write_to_file
 
 
 class TestSlideOut(BaseTest):

--- a/tests/test_squash.py
+++ b/tests/test_squash.py
@@ -1,11 +1,11 @@
 
-from .base_test import BaseTest
-from .cli_runner import assert_failure, assert_success
-from .git_repository import (check_out, commit, create_repo,
-                             get_current_commit_hash, new_branch)
-from .mockers import (fixed_author_and_committer_date_in_past,
-                      overridden_environment)
-from .shell import popen
+from tests.base_test import BaseTest
+from tests.cli_runner import assert_failure, assert_success
+from tests.git_repository import (check_out, commit, create_repo,
+                                  get_current_commit_hash, new_branch)
+from tests.mockers import (fixed_author_and_committer_date_in_past,
+                           overridden_environment)
+from tests.shell import popen
 
 
 class TestSquash(BaseTest):

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -7,21 +7,20 @@ from pytest_mock import MockerFixture
 
 from git_machete.utils.paths import AbsPath
 from git_machete.utils.terminal import FullTerminalAnsiOutputCodes
-
-from .base_test import BaseTest
-from .cli_runner import (assert_failure, assert_success, launch_command,
-                         rewrite_branch_layout_file)
-from .git_repository import (add_file_and_commit, add_remote, check_out,
-                             commit, commit_n_times, create_repo,
-                             create_repo_with_remote, delete_branch,
-                             delete_remote_branch, new_branch,
-                             new_orphan_branch, push, reset_to,
-                             set_git_config_key, unset_git_config_key)
-from .mockers import (fixed_author_and_committer_date_in_past,
-                      mock_input_returning, mock_input_returning_y,
-                      overridden_environment)
-from .shell import (execute, execute_ignoring_exit_code, popen,
-                    remove_directory, set_file_executable, write_to_file)
+from tests.base_test import BaseTest
+from tests.cli_runner import (assert_failure, assert_success, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (add_file_and_commit, add_remote, check_out,
+                                  commit, commit_n_times, create_repo,
+                                  create_repo_with_remote, delete_branch,
+                                  delete_remote_branch, new_branch,
+                                  new_orphan_branch, push, reset_to,
+                                  set_git_config_key, unset_git_config_key)
+from tests.mockers import (fixed_author_and_committer_date_in_past,
+                           mock_input_returning, mock_input_returning_y,
+                           overridden_environment)
+from tests.shell import (execute, execute_ignoring_exit_code, popen,
+                         remove_directory, set_file_executable, write_to_file)
 
 
 class TestStatus(BaseTest):

--- a/tests/test_traverse.py
+++ b/tests/test_traverse.py
@@ -10,21 +10,21 @@ from pytest_mock import MockerFixture
 
 from git_machete.utils.exceptions import UnderlyingGitException
 from git_machete.utils.terminal import FullTerminalAnsiOutputCodes
-
-from .base_test import BaseTest
-from .cli_runner import (assert_argument_error, assert_failure, assert_success,
-                         launch_command, rewrite_branch_layout_file)
-from .git_repository import (add_file_and_commit, add_remote, amend_commit,
-                             check_out, commit, create_repo,
-                             create_repo_with_remote, delete_branch,
-                             get_current_branch, get_git_version, merge,
-                             new_branch, push, remove_remote, reset_to,
-                             set_git_config_key, set_remote_url,
-                             wait_to_bump_commit_timestamp)
-from .mockers import (fixed_author_and_committer_date_in_past,
-                      mock_input_returning, mock_input_returning_y,
-                      overridden_environment)
-from .shell import write_to_file
+from tests.base_test import BaseTest
+from tests.cli_runner import (assert_argument_error, assert_failure,
+                              assert_success, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (add_file_and_commit, add_remote,
+                                  amend_commit, check_out, commit, create_repo,
+                                  create_repo_with_remote, delete_branch,
+                                  get_current_branch, get_git_version, merge,
+                                  new_branch, push, remove_remote, reset_to,
+                                  set_git_config_key, set_remote_url,
+                                  wait_to_bump_commit_timestamp)
+from tests.mockers import (fixed_author_and_committer_date_in_past,
+                           mock_input_returning, mock_input_returning_y,
+                           overridden_environment)
+from tests.shell import write_to_file
 
 
 class TestTraverse(BaseTest):

--- a/tests/test_traverse_github.py
+++ b/tests/test_traverse_github.py
@@ -2,16 +2,16 @@ import textwrap
 
 from pytest_mock import MockerFixture
 
-from .base_test import BaseTest
-from .cli_runner import (assert_failure, assert_success,
-                         rewrite_branch_layout_file)
-from .git_repository import (check_out, commit, create_repo_with_remote,
-                             new_branch, push)
-from .mockers import mock_input_returning
-from .mockers_code_hosting import mock_from_url
-from .mockers_github import (MockGitHubAPIState,
-                             mock_github_token_for_domain_fake, mock_pr_json,
-                             mock_urlopen)
+from tests.base_test import BaseTest
+from tests.cli_runner import (assert_failure, assert_success,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (check_out, commit, create_repo_with_remote,
+                                  new_branch, push)
+from tests.mockers import mock_input_returning
+from tests.mockers_code_hosting import mock_from_url
+from tests.mockers_github import (MockGitHubAPIState,
+                                  mock_github_token_for_domain_fake,
+                                  mock_pr_json, mock_urlopen)
 
 
 class TestTraverseGitHub(BaseTest):

--- a/tests/test_traverse_gitlab.py
+++ b/tests/test_traverse_gitlab.py
@@ -2,16 +2,16 @@ import textwrap
 
 from pytest_mock import MockerFixture
 
-from .base_test import BaseTest
-from .cli_runner import (assert_failure, assert_success,
-                         rewrite_branch_layout_file)
-from .git_repository import (check_out, commit, create_repo_with_remote,
-                             new_branch, push)
-from .mockers import mock_input_returning
-from .mockers_code_hosting import mock_from_url
-from .mockers_gitlab import (MockGitLabAPIState,
-                             mock_gitlab_token_for_domain_fake, mock_mr_json,
-                             mock_urlopen)
+from tests.base_test import BaseTest
+from tests.cli_runner import (assert_failure, assert_success,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (check_out, commit, create_repo_with_remote,
+                                  new_branch, push)
+from tests.mockers import mock_input_returning
+from tests.mockers_code_hosting import mock_from_url
+from tests.mockers_gitlab import (MockGitLabAPIState,
+                                  mock_gitlab_token_for_domain_fake,
+                                  mock_mr_json, mock_urlopen)
 
 
 class TestTraverseGitLab(BaseTest):

--- a/tests/test_traverse_worktrees.py
+++ b/tests/test_traverse_worktrees.py
@@ -6,17 +6,16 @@ from pytest_mock import MockerFixture
 
 from git_machete.utils.exceptions import UnderlyingGitException
 from git_machete.utils.paths import AbsPath
-
-from .base_test import BaseTest
-from .cli_runner import (assert_failure, assert_success, launch_command,
-                         rewrite_branch_layout_file)
-from .git_repository import (add_file_and_commit, add_worktree, check_out,
-                             commit, create_repo_with_remote,
-                             get_current_branch, get_git_version,
-                             get_worktree_dirs, new_branch, push,
-                             set_git_config_key)
-from .mockers import (fixed_author_and_committer_date_in_past,
-                      mock_input_returning)
+from tests.base_test import BaseTest
+from tests.cli_runner import (assert_failure, assert_success, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (add_file_and_commit, add_worktree, check_out,
+                                  commit, create_repo_with_remote,
+                                  get_current_branch, get_git_version,
+                                  get_worktree_dirs, new_branch, push,
+                                  set_git_config_key)
+from tests.mockers import (fixed_author_and_committer_date_in_past,
+                           mock_input_returning)
 
 # pytestmark is a special variable that pytest recognizes automatically.
 # It applies the specified marks to all test functions in this module.
@@ -31,7 +30,7 @@ class TestTraverseWorktrees(BaseTest):
 
     def test_traverse_with_worktrees(self) -> None:
         """Test that traverse can handle branches checked out in separate worktrees."""
-        from .shell import execute
+        from tests.shell import execute
 
         create_repo_with_remote()
         new_branch("develop")
@@ -791,7 +790,7 @@ class TestTraverseWorktrees(BaseTest):
     # subsequent `open(path, "w")` raised `NotADirectoryError`. The path is
     # now stored as absolute, so it survives any mid-traverse `chdir`.
     def test_traverse_auto_slide_out_in_worktree(self) -> None:
-        from .shell import execute
+        from tests.shell import execute
 
         create_repo_with_remote()
         new_branch("main")

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -2,20 +2,19 @@ from pytest_mock import MockerFixture
 
 from git_machete.utils.exceptions import UnderlyingGitException
 from git_machete.utils.terminal import FullTerminalAnsiOutputCodes
-
-from .base_test import BaseTest
-from .cli_runner import (assert_failure, assert_success, launch_command,
-                         rewrite_branch_layout_file)
-from .git_repository import (add_file_and_commit, check_out, commit,
-                             create_repo, get_commit_hash,
-                             get_current_commit_hash, get_git_version,
-                             is_ancestor_or_equal, new_branch,
-                             new_orphan_branch)
-from .mockers import (fixed_author_and_committer_date_in_past,
-                      mock_input_returning, mock_input_returning_y,
-                      overridden_environment)
-from .shell import (execute, execute_ignoring_exit_code, popen, read_file,
-                    set_file_executable, write_to_file)
+from tests.base_test import BaseTest
+from tests.cli_runner import (assert_failure, assert_success, launch_command,
+                              rewrite_branch_layout_file)
+from tests.git_repository import (add_file_and_commit, check_out, commit,
+                                  create_repo, get_commit_hash,
+                                  get_current_commit_hash, get_git_version,
+                                  is_ancestor_or_equal, new_branch,
+                                  new_orphan_branch)
+from tests.mockers import (fixed_author_and_committer_date_in_past,
+                           mock_input_returning, mock_input_returning_y,
+                           overridden_environment)
+from tests.shell import (execute, execute_ignoring_exit_code, popen, read_file,
+                         set_file_executable, write_to_file)
 
 
 class TestUpdate(BaseTest):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,8 +13,7 @@ from git_machete.utils.markup import _fmt
 from git_machete.utils.paths import AbsPath
 from git_machete.utils.terminal import (BasicTerminalAnsiOutputCodes,
                                         FullTerminalAnsiOutputCodes)
-
-from .base_test import BaseTest
+from tests.base_test import BaseTest
 
 
 class TestUtils(BaseTest):

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,7 +1,6 @@
 
 from git_machete import __version__
-
-from .cli_runner import assert_success
+from tests.cli_runner import assert_success
 
 
 class TestVersion:


### PR DESCRIPTION
Convert all `from .x import y` / `from ..x import y` relative imports under
`git_machete/` and `tests/` to their fully-qualified absolute equivalents
(`from git_machete.<...> import ...`, `from tests.<...> import ...`),
both at top level and inside function bodies.

Add `ci/checks/prohibit-relative-imports.sh` (wired into `run-all-checks.sh`)
to prevent the relative form from being reintroduced, and document the
convention in `AGENTS.md`.