### PR TITLE
Centralize RST color roles/styles in conf.py via `rst_prolog`

### DIFF
--- a/docs/generate_py_docs.py
+++ b/docs/generate_py_docs.py
@@ -40,7 +40,7 @@ def resolve_includes(rst_content: str, docs_source_dir: str) -> str:
     return rst_content
 
 
-HEADER = 0
+BEFORE_HEADING = 0
 USAGE = 1
 NORMAL = 2
 SHELL_BLOCK = 3
@@ -49,7 +49,7 @@ SECTION = 5
 
 
 def rst2txt(rst: str) -> str:
-    state = HEADER
+    state = BEFORE_HEADING
     result = []
     indent = " " * 3
 

--- a/docs/source/cli/advance.rst
+++ b/docs/source/cli/advance.rst
@@ -1,9 +1,3 @@
-.. raw:: html
-
-    <style> .green {color:green} </style>
-
-.. role:: green
-
 .. _advance:
 
 advance

--- a/docs/source/cli/fork-point.rst
+++ b/docs/source/cli/fork-point.rst
@@ -1,12 +1,3 @@
-.. raw:: html
-
-    <style> .green {color:green} </style>
-    <style> .yellow {color:#FFBF00} </style>
-
-.. role:: green
-.. role:: yellow
-
-
 .. _fork-point:
 
 fork-point

--- a/docs/source/cli/status.rst
+++ b/docs/source/cli/status.rst
@@ -1,15 +1,3 @@
-.. raw:: html
-
-    <style> .green {color:green} </style>
-    <style> .gray {color:dimgray} </style>
-    <style> .red {color:red} </style>
-    <style> .yellow {color:#FFBF00} </style>
-
-.. role:: green
-.. role:: gray
-.. role:: red
-.. role:: yellow
-
 .. _status:
 
 status

--- a/docs/source/cli/traverse.rst
+++ b/docs/source/cli/traverse.rst
@@ -1,15 +1,3 @@
-.. raw:: html
-
-    <style> .green {color:green} </style>
-    <style> .gray {color:dimgray} </style>
-    <style> .red {color:red} </style>
-    <style> .yellow {color:#FFBF00} </style>
-
-.. role:: green
-.. role:: gray
-.. role:: red
-.. role:: yellow
-
 .. _traverse:
 
 traverse

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,6 +25,26 @@ extensions = ["sphinx_book_theme"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['cli']
 
+# Prepended to every processed source file.
+# Defines the inline color styles and roles used across the CLI docs.
+# The `raw:: html` block is silently ignored by non-HTML builders (man, text, etc.),
+# and unused roles in a given file are harmless.
+rst_prolog = """
+.. raw:: html
+
+    <style>
+        .green  { color: green }
+        .gray   { color: dimgray }
+        .red    { color: red }
+        .yellow { color: #FFBF00 }
+    </style>
+
+.. role:: green
+.. role:: gray
+.. role:: red
+.. role:: yellow
+"""
+
 # -- Options for HTML output -------------------------------------------------
 
 html_theme = "sphinx_book_theme"


### PR DESCRIPTION
The `<style>` block and `:green:`/`:gray:`/`:red:`/`:yellow:` role definitions
used to be duplicated at the top of `cli/status.rst`, `cli/traverse.rst`,
`cli/fork-point.rst` and `cli/advance.rst`. Move them to a single `rst_prolog`
in `docs/source/conf.py`, which Sphinx prepends to every parsed source file.

Resolves #213.