### PR TITLE
Resolve config-backed CLI options on demand; keep parser side-effect-free

### DIFF
--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -213,7 +213,8 @@ def launch_internal(orig_args: List[str]) -> None:
         # Two reasons: (1) `parse_cmdline` may raise a `MacheteException`, whose message is rendered at `__init__`
         # against the *current* `markup.use_ansi_escapes_in_stdout` - without a reset, a stale value from a prior invocation
         # (most relevant in the test harness, where one Python process runs many `cli.launch` calls back-to-back) would leak in.
-        # (2) It keeps `parse_cmdline` itself side-effect-free; the actual `--color` override is applied below in `set_utils_global_variables`.
+        # (2) It keeps `parse_cmdline` itself side-effect-free;
+        # the actual `--color` override is applied below in `set_utils_global_variables`.
         markup.use_ansi_escapes_in_stdout = terminal.is_stdout_a_tty()
         markup.use_ansi_escapes_in_stderr = terminal.is_stderr_a_tty()
 
@@ -238,11 +239,10 @@ def launch_internal(orig_args: List[str]) -> None:
             print_fmt("Extra arguments after `--` are only allowed after `diff` and `log`")
             sys.exit(ExitCode.ARGUMENT_ERROR)
 
-        # `completion`, `help` and `version` don't use `cli_opts`, so skip the CLI-options population for them.
-        # Config keys that back tri-state options (`machete.traverse.push`, `machete.squashMergeDetection`) are read on demand
-        # in the client method that actually needs them, so a malformed value never blows up unrelated commands like `help` or `add`.
-        if cmd not in ("completion", "help", "version"):
-            _populate_cli_options(cli_opts, parsed)
+        # Config keys that back tri-state options (`machete.traverse.push`, `machete.squashMergeDetection`)
+        # are read on demand in the client method that actually needs them, so a malformed value never blows up
+        # unrelated commands like `help`, `version` or `add`.
+        _populate_cli_options(cli_opts, parsed)
 
         if cmd == "add":
             add_client = MacheteClient()

--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -24,12 +24,12 @@ from git_machete.client.status import StatusMacheteClient
 from git_machete.client.traverse import TraverseMacheteClient, TraverseReturnTo
 from git_machete.client.update import UpdateMacheteClient
 from git_machete.client.with_code_hosting import MacheteClientWithCodeHosting
-from git_machete.config import MacheteConfig, SquashMergeDetection
+from git_machete.config import SquashMergeDetection
 from git_machete.git import AnyRevision, LocalBranchShortName
 from git_machete.github import GITHUB_API_SPEC
 from git_machete.gitlab import GITLAB_API_SPEC
 from git_machete.help import alias_by_command, get_help_description, version
-from git_machete.utils import cmd, debug_log, terminal
+from git_machete.utils import cmd, debug_log, markup, terminal
 from git_machete.utils.exceptions import (ExitCode, InteractionStopped,
                                           MacheteException,
                                           UnderlyingGitException,
@@ -183,18 +183,15 @@ def _populate_cli_options(
             cli_opts.opt_no_interactive_rebase = True
 
 
-def update_cli_options_using_config_keys(cli_opts: git_machete.options.CommandLineOptions) -> None:
-    config = MacheteConfig()
-    traverse_push = config.traverse_push()
-    if traverse_push is not None:
-        cli_opts.opt_push_tracked = cli_opts.opt_push_untracked = traverse_push
-    cli_opts.opt_squash_merge_detection = config.squash_merge_detection()
-
-
 def set_utils_global_variables(parsed: ParsedCmd) -> None:
-    # `--color` is already applied inside `parse_cmdline`
-    # so that any `MacheteException` raised during validation gets the right ANSI treatment;
-    # here we just propagate the debug / verbose flags.
+    # Side effects are concentrated here (rather than scattered through `parse_cmdline`)
+    # so that the parser stays free of global state mutation - it returns a plain `ParsedCmd` and lets the caller decide what to do with it.
+    # `--color` is applied here even though it means parser-level `MacheteException`s (mutex / "only valid with X subcommand")
+    # don't pick up `--color=always` / `--color=never` - those messages contain only minor markup (backticks)
+    # and the default `--color=auto` behavior (TTY-detected at module import) already does the right thing in practice.
+    color = parsed.opts.get("color")
+    markup.use_ansi_escapes_in_stdout = color == "always" or (color in {None, "auto"} and terminal.is_stdout_a_tty())
+    markup.use_ansi_escapes_in_stderr = color == "always" or (color in {None, "auto"} and terminal.is_stderr_a_tty())
     debug_log.debug_mode = "debug" in parsed.opts
     cmd.verbose_mode = "verbose" in parsed.opts
 
@@ -212,9 +209,17 @@ def launch_internal(orig_args: List[str]) -> None:
     try:
         cli_opts = git_machete.options.CommandLineOptions()
 
+        # Reset markup globals to the `--color=auto` baseline before parsing.
+        # Two reasons: (1) `parse_cmdline` may raise a `MacheteException`, whose message is rendered at `__init__`
+        # against the *current* `markup.use_ansi_escapes_in_stdout` - without a reset, a stale value from a prior invocation
+        # (most relevant in the test harness, where one Python process runs many `cli.launch` calls back-to-back) would leak in.
+        # (2) It keeps `parse_cmdline` itself side-effect-free; the actual `--color` override is applied below in `set_utils_global_variables`.
+        markup.use_ansi_escapes_in_stdout = terminal.is_stdout_a_tty()
+        markup.use_ansi_escapes_in_stderr = terminal.is_stderr_a_tty()
+
         parsed = parse_cmdline(orig_args)
 
-        # Set up `--debug` / `--verbose` first so that subsequent `git config` reads honor them.
+        # Set up `--debug` / `--verbose` (and refine `--color` against the parsed value) before any subsequent `git config` read.
         set_utils_global_variables(parsed)
 
         if "help" in parsed.opts:
@@ -233,10 +238,10 @@ def launch_internal(orig_args: List[str]) -> None:
             print_fmt("Extra arguments after `--` are only allowed after `diff` and `log`")
             sys.exit(ExitCode.ARGUMENT_ERROR)
 
-        # `completion`, `help` and `version` neither read git config nor use `cli_opts`, so skip the config/CLI population for them -
-        # in particular, `help` must keep working even when a config key like `machete.squashMergeDetection` carries an invalid value.
+        # `completion`, `help` and `version` don't use `cli_opts`, so skip the CLI-options population for them.
+        # Config keys that back tri-state options (`machete.traverse.push`, `machete.squashMergeDetection`) are read on demand
+        # in the client method that actually needs them, so a malformed value never blows up unrelated commands like `help` or `add`.
         if cmd not in ("completion", "help", "version"):
-            update_cli_options_using_config_keys(cli_opts)
             _populate_cli_options(cli_opts, parsed)
 
         if cmd == "add":

--- a/git_machete/cli_parser.py
+++ b/git_machete/cli_parser.py
@@ -19,7 +19,6 @@ from git_machete.cli_commands import (COMMAND_BY_NAME_OR_ALIAS, COMMON_OPTIONS,
                                       CommandSpec, MutexGroup, OptSpec,
                                       ParsedCmd, PositionalSpec,
                                       SubcommandSpec)
-from git_machete.utils import markup, terminal
 from git_machete.utils.exceptions import ExitCode, MacheteException
 
 _CLOSE_MATCH_CUTOFF = 0.6
@@ -43,7 +42,6 @@ def parse_cmdline(argv: List[str]) -> ParsedCmd:
         # Either there are no positionals at all (`git machete --help`) or the only "positional" we'd see is an unknown flag (e.g. `-q`).
         # Validate against common options only and return.
         opts, _, unknowns = _scan(direct, COMMON_OPTIONS)
-        _apply_color_setting(opts.get("color"))
         if unknowns:
             _fail_unrecognized(unknowns, command=None)
         return ParsedCmd(command=None, opts=opts, positionals={}, pass_through=pass_through)
@@ -61,9 +59,6 @@ def parse_cmdline(argv: List[str]) -> ParsedCmd:
     merged_options = COMMON_OPTIONS + all_command_options
     other_args = direct[:cmd_pos] + direct[cmd_pos + 1:]
     opts, positionals, unknowns = _scan(other_args, merged_options)
-    # Apply `--color` before any downstream validation step that might construct a `MacheteException`:
-    # the exception captures the current `markup.use_ansi_escapes_in_*` values at __init__ time and rendering is one-shot.
-    _apply_color_setting(opts.get("color"))
     if unknowns:
         _fail_unrecognized(unknowns, command=cmd.name)
 
@@ -299,20 +294,6 @@ def _visible_choices(positional: PositionalSpec) -> Tuple[str, ...]:
     if not positional.choices:  # pragma: no cover
         return ()
     return tuple(c for c in positional.choices if c not in positional.hidden_choices)
-
-
-def _apply_color_setting(color: Optional[str]) -> None:
-    """Honor `--color` for stdout / stderr ANSI emission.
-
-    Called from inside `parse_cmdline` (rather than waiting until the caller invokes `set_utils_global_variables`)
-    so that any `MacheteException` raised from the validation phase below
-    picks up the same flag values that the rest of the program will use.
-    The exception's `.msg` is rendered once at `__init__` time, so the globals must be correct BEFORE the raise.
-    """
-    use_in_stdout = color == "always" or (color in {None, "auto"} and terminal.is_stdout_a_tty())
-    use_in_stderr = color == "always" or (color in {None, "auto"} and terminal.is_stderr_a_tty())
-    markup.use_ansi_escapes_in_stdout = use_in_stdout
-    markup.use_ansi_escapes_in_stderr = use_in_stderr
 
 
 def _argument_error(message: str) -> NoReturn:

--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -656,7 +656,11 @@ class MacheteClient:
 
     # === Branch deletion ===
 
-    def delete_unmanaged(self, *, opt_squash_merge_detection: SquashMergeDetection, opt_yes: bool) -> None:
+    def delete_unmanaged(self, *, opt_squash_merge_detection: Optional[SquashMergeDetection], opt_yes: bool) -> None:
+        # CLI flag > `machete.squashMergeDetection` config key > built-in `SIMPLE` default - see `CommandLineOptions`.
+        # Internal callers (`clean`, `github sync`, `gitlab sync`) pass a concrete `SquashMergeDetection.NONE`, bypassing the fallback.
+        if opt_squash_merge_detection is None:
+            opt_squash_merge_detection = self._config.squash_merge_detection()
         print('Checking for unmanaged branches...')
         branches_to_delete = sorted(excluding(self._git.get_local_branches(), self.managed_branches))
         self._delete_branches(branches_to_delete=branches_to_delete,

--- a/git_machete/client/status.py
+++ b/git_machete/client/status.py
@@ -428,8 +428,11 @@ class StatusMacheteClient(MacheteClient):
             warn_when_branch_in_sync_but_fork_point_off: bool,
             opt_list_commits: bool,
             opt_list_commits_with_hashes: bool,
-            opt_squash_merge_detection: SquashMergeDetection
+            opt_squash_merge_detection: Optional[SquashMergeDetection]
     ) -> None:
+        # CLI flag > `machete.squashMergeDetection` config key > built-in `SIMPLE` default - see `CommandLineOptions`.
+        if opt_squash_merge_detection is None:
+            opt_squash_merge_detection = self._config.squash_merge_detection()
         maybe_space_before_branch_name = ' ' if self._config.status_extra_space_before_branch_name() else ''
         flags = StatusFlags(
             maybe_space_before_branch_name=maybe_space_before_branch_name,

--- a/git_machete/client/traverse.py
+++ b/git_machete/client/traverse.py
@@ -152,16 +152,26 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
             opt_merge: bool,
             opt_no_edit_merge: bool,
             opt_no_interactive_rebase: bool,
-            opt_push_tracked: bool,
-            opt_push_untracked: bool,
+            opt_push_tracked: Optional[bool],
+            opt_push_untracked: Optional[bool],
             opt_return_to: TraverseReturnTo,
-            opt_squash_merge_detection: SquashMergeDetection,
+            opt_squash_merge_detection: Optional[SquashMergeDetection],
             opt_start_from: str,
             opt_stop_after: Optional[LocalBranchShortName],
             opt_sync_github_prs: bool,
             opt_sync_gitlab_mrs: bool,
             opt_yes: bool
     ) -> None:
+        # Resolve tri-state CLI options against git config (CLI flag > config key > built-in default).
+        # See `git_machete.options.CommandLineOptions` for the rationale behind the `None` sentinels.
+        traverse_push_config = self._config.traverse_push()
+        if opt_push_tracked is None:
+            opt_push_tracked = traverse_push_config if traverse_push_config is not None else True
+        if opt_push_untracked is None:
+            opt_push_untracked = traverse_push_config if traverse_push_config is not None else True
+        if opt_squash_merge_detection is None:
+            opt_squash_merge_detection = self._config.squash_merge_detection()
+
         self._git.expect_no_operation_in_progress()
         self.expect_at_least_one_managed_branch()
         start_from = TraverseStartFrom.from_string_or_branch(opt_start_from, self._git.get_local_branches())

--- a/git_machete/git.py
+++ b/git_machete/git.py
@@ -366,17 +366,18 @@ class Git:
 
     def get_main_worktree_git_dir(self) -> AbsPath:
         if not self.__main_worktree_git_dir:
-            try:
-                git_dir: AbsPath = self.__rev_parse_path("--git-dir")
-                git_dir_parts = PyPath(git_dir).parts
-                if len(git_dir_parts) >= 3 and git_dir_parts[-3] == '.git' and git_dir_parts[-2] == 'worktrees':
-                    self.__main_worktree_git_dir = AbsPath(Path.join_paths(*git_dir_parts[:-2]))
-                    debug(f'git dir pointing to {git_dir} - we are in a worktree; '
-                          f'using {self.__main_worktree_git_dir} as the effective git dir instead')
-                else:
-                    self.__main_worktree_git_dir = git_dir
-            except UnderlyingGitException:
-                raise UnderlyingGitException("Not a git repository")
+            # `git rev-parse --git-dir` returns the *current* worktree's git dir
+            # (`.git/worktrees/<name>` inside a linked worktree, just `.git` otherwise);
+            # piggybacking on `get_current_worktree_git_dir` lets the underlying command be served from cache
+            # on the second call rather than rerun.
+            git_dir = self.get_current_worktree_git_dir()
+            git_dir_parts = PyPath(git_dir).parts
+            if len(git_dir_parts) >= 3 and git_dir_parts[-3] == '.git' and git_dir_parts[-2] == 'worktrees':
+                self.__main_worktree_git_dir = AbsPath(Path.join_paths(*git_dir_parts[:-2]))
+                debug(f'git dir pointing to {git_dir} - we are in a worktree; '
+                      f'using {self.__main_worktree_git_dir} as the effective git dir instead')
+            else:
+                self.__main_worktree_git_dir = git_dir
         return self.__main_worktree_git_dir
 
     def get_main_worktree_git_subpath(self, *fragments: str) -> AbsPath:

--- a/git_machete/options.py
+++ b/git_machete/options.py
@@ -34,14 +34,19 @@ class CommandLineOptions:
         self.opt_override_to: Optional[str] = None
         self.opt_override_to_inferred: bool = False
         self.opt_override_to_parent: bool = False
-        self.opt_push_tracked: bool = True
-        self.opt_push_untracked: bool = True
+        # Tri-state: `None` means "user did not pass any `--push*`/`--no-push*` flag",
+        # leaving the effective value to be resolved against `machete.traverse.push` (or the built-in default of `True`)
+        # at the use site inside the client.
+        self.opt_push_tracked: Optional[bool] = None
+        self.opt_push_untracked: Optional[bool] = None
         self.opt_related: bool = False
         self.opt_removed_from_remote: bool = False
         self.opt_repoint_tracking: bool = False
         self.opt_return_to: str = "stay"
         self.opt_roots: List[LocalBranchShortName] = list()
-        self.opt_squash_merge_detection: SquashMergeDetection = SquashMergeDetection.SIMPLE
+        # Tri-state: `None` means "user did not pass `--squash-merge-detection`/`--no-detect-squash-merges`",
+        # leaving the effective value to be resolved against `machete.squashMergeDetection` (default `SIMPLE`) at the use site.
+        self.opt_squash_merge_detection: Optional[SquashMergeDetection] = None
         self.opt_start_from: str = "here"
         self.opt_stat: bool = False
         self.opt_stop_after: Optional[LocalBranchShortName] = None

--- a/git_machete/utils/markup.py
+++ b/git_machete/utils/markup.py
@@ -20,7 +20,7 @@ from git_machete.utils.terminal import (BasicTerminalAnsiOutputCodes,
 
 # === Mutable runtime flags ===
 #
-# Whether to emit ANSI escapes on stdout / stderr. Set by `cli.py` based on `--color` and TTY detection;
+# Whether to emit ANSI escapes on stdout / stderr. Set by `cli.set_utils_global_variables` (based on `--color` and TTY detection);
 # read by `print_fmt`, `input_fmt`, and - indirectly via `_fmt` - by `MacheteException` / `UnderlyingGitException`.
 use_ansi_escapes_in_stdout: bool = sys.stdout.isatty()
 use_ansi_escapes_in_stderr: bool = sys.stderr.isatty()

--- a/tests/test_no_duplicate_commands.py
+++ b/tests/test_no_duplicate_commands.py
@@ -1,0 +1,67 @@
+"""Regression test guarding against duplicate command invocations in `--verbose` mode.
+
+Caches inside `git_machete.git.Git` are supposed to make every underlying git command
+run at most once per top-level CLI invocation. When that contract is accidentally broken
+(e.g. by an extra `Git` / `MacheteConfig` instance constructed somewhere in the dispatch path,
+or by a getter that bypasses its memoization), the duplicate becomes visible in `-v` output.
+
+We assert on the verbose log rather than on a mocked spy so that the test exercises the same
+output path the user sees - the line format `_subproc._run_cmd` / `_popen_cmd` print is exactly
+the one a human would read to investigate a wasted git call.
+"""
+
+from collections import Counter
+from typing import List
+
+from tests.base_test import BaseTest
+from tests.cli_runner import launch_command, rewrite_branch_layout_file
+from tests.git_repository import commit, create_repo, new_branch
+
+
+def _extract_verbose_commands(output: str) -> List[str]:
+    """Pull out the command lines emitted by `verbose_mode` in `git_machete.utils.cmd`.
+
+    `print_command` writes each invocation on its own line as `escape_markup(get_cmd_shell_repr(...))`.
+    All `git` calls go through `GIT_EXEC = ("git", "-c", "log.showSignature=false")`, and `machete-status-branch`
+    hook invocations are emitted with their `ASCII_ONLY=...` env prefix - both shapes are matched here.
+    The status tree itself (printed to stdout) starts with whitespace / tree-drawing characters,
+    so the prefix filter is enough to skip it.
+    """
+    commands: List[str] = []
+    for line in output.splitlines():
+        if line.startswith("git -c log.showSignature=false ") or line.startswith("ASCII_ONLY="):
+            commands.append(line)
+    return commands
+
+
+class TestNoDuplicateCommands(BaseTest):
+
+    def test_status_does_not_run_any_underlying_command_twice(self) -> None:
+        # A minimal but non-trivial layout (root + child) so `status` exercises both
+        # the parent-of-child fork-point logic and the per-branch reflog lookup.
+        create_repo()
+        commit("Initial commit on master.")
+        new_branch("develop")
+        commit("Commit on develop.")
+
+        rewrite_branch_layout_file(
+            """
+            master
+            \tdevelop
+            """
+        )
+
+        output = launch_command("status", "--verbose")
+
+        commands = _extract_verbose_commands(output)
+        # Sanity check: if the filter ever stops matching the actual log format, every other assertion below would trivially pass.
+        assert commands, (
+            "No verbose command lines were captured - the `-v` output format likely changed; "
+            "update `_extract_verbose_commands` to match.\n"
+            f"Raw output was:\n{output}")
+
+        duplicates = {cmd: count for cmd, count in Counter(commands).items() if count > 1}
+        assert not duplicates, (
+            "The following underlying commands were executed more than once during `git machete status -v`; "
+            "each should be served from a `Git` cache after its first invocation:\n" +
+            "\n".join(f"  {count}x: {cmd}" for cmd, count in duplicates.items()))

--- a/tests/test_traverse.py
+++ b/tests/test_traverse.py
@@ -560,6 +560,14 @@ class TestTraverse(BaseTest):
             """,
         )
 
+    def test_traverse_with_explicit_squash_merge_detection_flag(self) -> None:
+        # Covers the branch in `traverse()` where `--squash-merge-detection` was passed on the command line,
+        # bypassing the on-demand fallback to the `machete.squashMergeDetection` git config key.
+        # We only care that the flag is consumed without errors - the actual squash-detection semantics
+        # are exercised by the dedicated tests in `test_status.py`.
+        self.setup_standard_tree()
+        launch_command("traverse", "-Wy", "--squash-merge-detection=none")
+
     def test_traverse_push_config_key(self) -> None:
         self.setup_standard_tree()
         set_git_config_key('machete.traverse.push', 'false')


### PR DESCRIPTION
`machete.traverse.push` and `machete.squashMergeDetection` are no longer pre-flattened into `CommandLineOptions` at startup.
The corresponding `opt_push_tracked` / `opt_push_untracked` / `opt_squash_merge_detection` fields are now tri-state (`Optional`),
and the three client entry points that take them (`traverse`, `status`, `delete_unmanaged`) resolve
`CLI flag > config key > built-in default` on demand via `self._config`. This matches how every other config key
(`worktree.useTopLevelMacheteFile`, `status.extraSpaceBeforeBranchName`, `traverse.fetch.<remote>`,
`traverse.whenBranchNotCheckedOutInAnyWorktree`, ...) has always been read.

Side effects of the consolidation:
- `update_cli_options_using_config_keys` and the throwaway `Git` / `MacheteConfig` it built in `cli.py` are gone;
  this removes the duplicate `git config --list --null` call observed under `git machete --debug <cmd>`.
- A bad value for `machete.squashMergeDetection` now fails only when a command (`status`, `traverse`,
  `delete-unmanaged`) actually consults the key, not on every non-help/version/completion command.

Separately, `cli_parser._apply_color_setting` is gone. `parse_cmdline` no longer mutates
`markup.use_ansi_escapes_in_*`; `launch_internal` sets a `--color=auto` baseline before parsing
and `set_utils_global_variables` refines it with the actual `--color` value after parsing.
Trade-off: `MacheteException`s raised during parser-time validation
(mutex groups with custom messages, "<thing> is only valid with <subcommand>") no longer honor
`--color=always` / `--color=never` - those messages contain only minor markup (backticks)
and `--color=auto` is the default anyway.