### PR TITLE
Centralize git version thresholds in a dedicated `git_version_thresholds.py`

### DIFF
--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -520,7 +520,8 @@ def launch_internal(orig_args: List[str]) -> None:
         else:  # rejected by the parser
             raise UnexpectedMacheteException(f"Unknown command: `{cmd}`")
     finally:
-        # Has been fixed in git itself as of 2.35.0, but we still defend against pre-2.35 + the underlying-checkout-moves-cwd case:
+        # Has been fixed in git itself as of version `CWD_REMOVAL_HANDLED_BY_GIT`, but we still defend against older git
+        # + the underlying-checkout-moves-cwd case:
         # see https://github.com/git/git/blob/master/Documentation/RelNotes/2.35.0.txt#L81
         if initial_current_directory and not does_directory_exist(initial_current_directory):
             nearest_existing_parent_directory: AbsPath = initial_current_directory

--- a/git_machete/git.py
+++ b/git_machete/git.py
@@ -9,6 +9,13 @@ from typing import (Any, Dict, Iterator, List, Match, NamedTuple, Optional,
                     Set, Tuple)
 
 from git_machete.constants import MAX_COMMITS_FOR_SQUASH_MERGE_DETECTION
+from git_machete.git_version_thresholds import (PATCH_ID_UNSTABLE_OUTPUT_ORDER,
+                                                PUSH_FORCE_IF_INCLUDES,
+                                                PUSH_FORCE_WITH_LEASE,
+                                                REBASE_EMPTY_DROP,
+                                                RELIABLE_MULTI_BRANCH_REFLOG,
+                                                WORKTREE_COMMAND,
+                                                WORKTREE_REMOVE_COMMAND)
 from git_machete.utils._subproc import PopenResult
 from git_machete.utils.cmd import get_cmd_shell_repr, popen_cmd, run_cmd
 from git_machete.utils.collections import get_non_empty_lines
@@ -192,10 +199,10 @@ HEAD = AnyRevision.of("HEAD")
 
 # Explicitly suppress showing GPG signatures in `git log` operations to simplify log parsing.
 # This option must be passed as a configuration parameter because the `git log` command's `--no-show-signature` flag
-# does not exist prior to `git` version 2.10.0;
+# does not exist prior to `git` version `LOG_SHOW_SIGNATURE_CONFIG`;
 # `git` does not emit an error if it is passed via the `-c` flag a configuration setting that does not exist,
-# so compatibility with `git` versions earlier than version 2.10.0 is preserved,
-# even though the `log.showSignature` setting also does not exist prior to version 2.10.0.
+# so compatibility with `git` versions earlier than that is preserved,
+# even though the `log.showSignature` setting also does not exist prior to that version.
 # Fixes a bug documented in GitHub issue #1286.
 GIT_EXEC = ("git", "-c", "log.showSignature=false")
 
@@ -345,8 +352,7 @@ class Git:
         Returns the path to the main worktree (not a linked worktree).
         """
         if self.__main_worktree_root_dir is None:
-            if self.get_git_version() < (2, 5):
-                # git worktree command was introduced in git 2.5
+            if self.get_git_version() < WORKTREE_COMMAND:
                 # If worktrees aren't supported, just return the current root dir
                 self.__main_worktree_root_dir = self.get_current_worktree_root_dir()
             else:
@@ -407,8 +413,7 @@ class Git:
         and it lets `get_main_worktree_root_dir` reuse our parse output rather than running
         `git worktree list --porcelain` a second time when both getters are called together (as `status` does).
         """
-        if self.get_git_version() < (2, 5):
-            # git worktree command was introduced in git 2.5
+        if self.get_git_version() < WORKTREE_COMMAND:
             return {}
 
         result = self._popen_git("worktree", "list", "--porcelain")
@@ -460,7 +465,7 @@ class Git:
         self._run_git("worktree", "add", path, branch, flush_caches=False)
 
     def worktree_remove(self, path: Path) -> None:
-        if self.get_git_version() >= (2, 17):
+        if self.get_git_version() >= WORKTREE_REMOVE_COMMAND:
             self._run_git("worktree", "remove", "-f", path, flush_caches=False)
         else:
             import shutil
@@ -597,9 +602,9 @@ class Git:
     def push(self, remote: str, branch: LocalBranchShortName, *, force_with_lease: bool = False) -> None:  # noqa: KW
         if not force_with_lease:
             opt_force = []
-        elif self.get_git_version() >= (2, 30, 0):  # earliest version of git to support 'push --force-with-lease --force-if-includes'
+        elif self.get_git_version() >= PUSH_FORCE_IF_INCLUDES:
             opt_force = ["--force-with-lease", "--force-if-includes"]
-        elif self.get_git_version() >= (1, 8, 5):  # earliest version of git to support 'push --force-with-lease'
+        elif self.get_git_version() >= PUSH_FORCE_WITH_LEASE:
             opt_force = ["--force-with-lease"]
         else:
             opt_force = ["--force"]
@@ -738,7 +743,11 @@ class Git:
     # so we need to check .git/worktrees/<worktree>/<file> rather than .git/<file>
 
     def is_am_in_progress(self) -> bool:
-        # As of git 2.24.1, this is how 'cmd_rebase()' in builtin/rebase.c checks whether am is in progress.
+        # This mirrors how git itself detects an in-progress `git am`: it writes a `rebase-apply/applying` marker file
+        # for a standalone `git am` (vs `rebase-apply/rebasing` when am is driven by rebase), and checks for that exact
+        # file before letting a rebase start. The marker and the check are stable across our whole supported range -
+        # `cmd_rebase()` in builtin/rebase.c on git 2.54.0, and git-rebase.sh back on git 1.8.0 - so this needs no
+        # version guard.
         return os.path.isfile(self.get_current_worktree_git_subpath("rebase-apply", "applying"))
 
     def is_bisect_in_progress(self) -> bool:
@@ -919,9 +928,9 @@ class Git:
             self.__reflogs_cached[any_branch_name] += [GitReflogEntry(hash=FullCommitHash.of(hash), reflog_subject=subject)]
 
     def get_reflog(self, branch: AnyBranchName) -> List[GitReflogEntry]:
-        # git version 2.14.2 fixed a bug that caused fetching reflog of more than
+        # Git version `RELIABLE_MULTI_BRANCH_REFLOG` fixed a bug that made fetching reflog of more than
         # one branch at the same time unreliable in certain cases
-        if self.get_git_version() >= (2, 14, 2):
+        if self.get_git_version() >= RELIABLE_MULTI_BRANCH_REFLOG:
             if self.__reflogs_cached is None:
                 self.__load_all_reflogs()
             assert self.__reflogs_cached is not None
@@ -1229,7 +1238,7 @@ class Git:
             # Line uncovered by tests as we actually always pass a non-empty patch to this method.
             return None
         # The output of patch-id is "<patch-id> <commit-hash>".
-        # Here the bug introduced in git patch-id v2.46.1 (issue #1329) doesn't affect us
+        # Here the bug introduced in git patch-id in version `PATCH_ID_UNSTABLE_OUTPUT_ORDER` (issue #1329) doesn't affect us
         # as we only care about the patch-id, not commit-hash.
         return FullPatchId.of(lines[0].split(' ')[0])
 
@@ -1240,8 +1249,8 @@ class Git:
         patch_id_output = self._popen_git("patch-id", input=patches).stdout
 
         patch_id_for_commit: Dict[FullCommitHash, FullPatchId] = {}
-        # See issue #1329 for why git v2.46.1 (but not <=2.46.0 or >=2.46.2) needs a special treatment
-        if self.get_git_version() == (2, 46, 1):
+        # See issue #1329 for why git version `PATCH_ID_UNSTABLE_OUTPUT_ORDER` (but not <=2.46.0 or >=2.46.2) needs a special treatment
+        if self.get_git_version() == PATCH_ID_UNSTABLE_OUTPUT_ORDER:
             commit_hashes = [line.replace('commit ', '') for line in patches.splitlines()
                              if re.fullmatch('commit [0-9a-f]{40}', line)]  # noqa: FS003
             for line, commit_hash in zip(patch_id_output.splitlines(), commit_hashes):
@@ -1303,7 +1312,7 @@ class Git:
         try:
             if not opt_no_interactive_rebase:
                 rebase_opts.append("--interactive")
-            if self.get_git_version() >= (2, 26, 0):
+            if self.get_git_version() >= REBASE_EMPTY_DROP:
                 rebase_opts.append("--empty=drop")
             self._run_git("rebase", *rebase_opts, "--onto", onto, from_exclusive, branch, flush_caches=True)
         finally:

--- a/git_machete/git_version_thresholds.py
+++ b/git_machete/git_version_thresholds.py
@@ -1,0 +1,63 @@
+from typing import Tuple
+
+GitVersion = Tuple[int, int, int]
+
+# Centralized catalog of the `git` version thresholds that matter for git-machete's behavior.
+#
+# Each constant marks the *earliest* `git` version at (or from) which a given CLI feature/flag exists
+# or a given upstream bug is fixed (the lone exception is `PATCH_ID_UNSTABLE_OUTPUT_ORDER`, which marks
+# a single buggy version - see its comment).
+# Keeping them here (rather than as bare `(2, 5)`-style tuples sprinkled across `git_machete/` and `tests/`)
+# means the "why this number" rationale lives in exactly one place, and a bump only has to happen once.
+#
+# A couple of these constants are not consumed by any runtime version check; they exist purely to document a
+# compatibility boundary that the code relies on implicitly (the minimum supported version, and the version below
+# which a config-parameter workaround is needed instead of a CLI flag). Such constants are marked with
+# `# noqa: F841` so the unused-name linters don't flag them - they're documentation, not dead code.
+
+# Minimum `git` version git-machete declares support for (see the "Git compatibility" section of README.md;
+# exercised in CI via the oldest image in .circleci/config.yml).
+# git-machete has advertised compatibility with `git >= 1.8.0` since git-machete 2.13.0 (it was `>= 2.0.0` before that).
+# The floor is `git branch --set-upstream-to` (used unconditionally in git.py's `set_upstream_to`): that flag was
+# introduced in git 1.8.0 - alongside the deprecation of the reversed-argument `git branch --set-upstream` - and
+# git-machete carries no fallback for older git, so 1.8.0 is a hard feature boundary.
+MINIMUM_SUPPORTED_GIT_VERSION: GitVersion = (1, 8, 0)  # noqa: F841
+
+# Earliest version to support `git push --force-with-lease`.
+PUSH_FORCE_WITH_LEASE: GitVersion = (1, 8, 5)
+
+# `git worktree` command was introduced here; below this version git-machete degrades to treating the
+# current checkout as the only worktree.
+WORKTREE_COMMAND: GitVersion = (2, 5, 0)
+
+# `log.showSignature` config setting (and the `--no-show-signature` flag) do not exist before this version.
+# We suppress GPG signatures in `git log` output by passing `-c log.showSignature=false` rather than the flag,
+# precisely so that we stay compatible with pre-2.10.0 `git` (which silently ignores an unknown `-c` setting).
+# See the `GIT_EXEC` definition in git_machete/git.py and GitHub issue #1286.
+LOG_SHOW_SIGNATURE_CONFIG: GitVersion = (2, 10, 0)  # noqa: F841
+
+# This version fixed a bug that made fetching the reflog of more than one branch at a time unreliable.
+# At/above it we batch-load all reflogs in one go; below it we fetch each branch's reflog separately.
+RELIABLE_MULTI_BRANCH_REFLOG: GitVersion = (2, 14, 2)
+
+# `git worktree remove` was introduced here; below this version git-machete removes a linked worktree
+# by hand (`rmtree` + `git worktree prune`).
+WORKTREE_REMOVE_COMMAND: GitVersion = (2, 17, 0)
+
+# Earliest version to accept `git rebase --empty=drop` (the flag git-machete passes so that
+# interactive rebases drop commits that became empty, matching the non-interactive default).
+REBASE_EMPTY_DROP: GitVersion = (2, 26, 0)
+
+# Earliest version to support `git push --force-with-lease --force-if-includes`.
+PUSH_FORCE_IF_INCLUDES: GitVersion = (2, 30, 0)
+
+# As of this version `git` itself keeps the process's CWD valid when the underlying checkout removes it,
+# so git-machete's own "current directory no longer exists" fallback (in git_machete/cli.py) is only needed
+# to defend against older `git`.
+# See https://github.com/git/git/blob/master/Documentation/RelNotes/2.35.0.txt#L81
+CWD_REMOVAL_HANDLED_BY_GIT: GitVersion = (2, 35, 0)
+
+# This *single* version of `git patch-id` emits its output in a different order than every neighboring version
+# (the bug exists in 2.46.1 but not in <=2.46.0 or >=2.46.2), so it needs a dedicated code path that pairs each
+# patch-id with the right commit hash. See GitHub issue #1329.
+PATCH_ID_UNSTABLE_OUTPUT_ORDER: GitVersion = (2, 46, 1)

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 from tempfile import mkdtemp
 
+from git_machete.git_version_thresholds import WORKTREE_COMMAND
 from git_machete.utils.exceptions import UnderlyingGitException
 from tests.base_test import BaseTest
 from tests.cli_runner import assert_failure, launch_command
@@ -31,7 +32,7 @@ class TestFile(BaseTest):
         branch_layout_file_path_relative_to_git_dir = '/'.join(branch_layout_file_path[-2:]).rstrip('\n')
         assert branch_layout_file_path_relative_to_git_dir == '.git/machete'
 
-        if get_git_version() >= (2, 5):  # `git worktree` command was introduced in git version 2.5
+        if get_git_version() >= WORKTREE_COMMAND:  # `git worktree` command was introduced in git version 2.5
             # check branch layout file path when inside a worktree using the default `True` value
             # for the `machete.worktree.useTopLevelMacheteFile` key
             execute("git worktree add -f -b snickers_feature snickers_worktree develop")

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -4,6 +4,7 @@ import pytest
 
 from git_machete.git import (AnyBranchName, AnyRevision, FullCommitHash, Git,
                              LocalBranchShortName)
+from git_machete.git_version_thresholds import WORKTREE_COMMAND
 from tests.base_test import BaseTest
 from tests.git_repository import (add_worktree, check_out, commit, create_repo,
                                   get_current_commit_hash, get_git_version,
@@ -199,7 +200,7 @@ class TestGitOperations(BaseTest):
         # should raise an UnexpectedMacheteException.
         git.get_reflog(AnyBranchName.of("feature@foo"))
 
-    @pytest.mark.skipif(get_git_version() < (2, 5), reason="git worktree command was introduced in git 2.5")
+    @pytest.mark.skipif(get_git_version() < WORKTREE_COMMAND, reason="git worktree command was introduced in git 2.5")
     def test_get_worktree_root_dirs_by_branch(self) -> None:
         create_repo()
         new_branch("main")

--- a/tests/test_go.py
+++ b/tests/test_go.py
@@ -3,6 +3,7 @@ import os
 import pytest
 from pytest_mock import MockerFixture
 
+from git_machete.git_version_thresholds import WORKTREE_COMMAND
 from git_machete.utils.paths import AbsPath
 from tests.base_test import BaseTest
 from tests.cli_runner import (assert_failure, assert_success, launch_command,
@@ -484,7 +485,7 @@ class TestGo(BaseTest):
           * git machete gitlab checkout-mrs --mine"""
         assert_failure(["g", "root"], expected_error_message)
 
-    @pytest.mark.skipif(get_git_version() < (2, 5), reason="git worktree command was introduced in git 2.5")
+    @pytest.mark.skipif(get_git_version() < WORKTREE_COMMAND, reason="git worktree command was introduced in git 2.5")
     def test_go_with_worktree(self) -> None:
         """`go down` fails with an actionable machete-level error (not the raw `git checkout` error)
         when the target branch is already checked out in a linked worktree, and the user's cwd is

--- a/tests/test_slide_out_worktrees.py
+++ b/tests/test_slide_out_worktrees.py
@@ -2,6 +2,7 @@ import textwrap
 
 import pytest
 
+from git_machete.git_version_thresholds import WORKTREE_COMMAND
 from git_machete.utils.paths import AbsPath
 from tests.base_test import BaseTest
 from tests.cli_runner import (assert_failure, read_branch_layout_file,
@@ -13,7 +14,7 @@ from tests.git_repository import (add_worktree, check_out, commit, create_repo,
 # It applies the specified marks to all test functions in this module.
 # This skips all tests in this file if git version < 2.5 (when worktree was introduced).
 pytestmark = pytest.mark.skipif(  # noqa: F841
-    get_git_version() < (2, 5),
+    get_git_version() < WORKTREE_COMMAND,
     reason="git worktree command was introduced in git 2.5"
 )
 

--- a/tests/test_status_worktrees.py
+++ b/tests/test_status_worktrees.py
@@ -4,6 +4,7 @@ import shutil
 import pytest
 from pytest_mock import MockerFixture
 
+from git_machete.git_version_thresholds import WORKTREE_COMMAND
 from git_machete.utils.paths import AbsPath
 from git_machete.utils.terminal import FullTerminalAnsiOutputCodes
 from tests.base_test import BaseTest
@@ -13,7 +14,7 @@ from tests.git_repository import (add_worktree, check_out, commit, create_repo,
                                   get_git_version, new_branch)
 
 pytestmark = pytest.mark.skipif(  # noqa: F841
-    get_git_version() < (2, 5),
+    get_git_version() < WORKTREE_COMMAND,
     reason="git worktree command was introduced in git 2.5"
 )
 

--- a/tests/test_traverse.py
+++ b/tests/test_traverse.py
@@ -8,6 +8,8 @@ from typing import ClassVar, Optional, Tuple
 import pytest
 from pytest_mock import MockerFixture
 
+from git_machete.git_version_thresholds import (CWD_REMOVAL_HANDLED_BY_GIT,
+                                                REBASE_EMPTY_DROP)
 from git_machete.utils.exceptions import UnderlyingGitException
 from git_machete.utils.terminal import FullTerminalAnsiOutputCodes
 from tests.base_test import BaseTest
@@ -1784,7 +1786,7 @@ class TestTraverse(BaseTest):
 
             Reached branch without-directory which has no successor; nothing left to update
             """
-        if get_git_version() >= (2, 35, 0):
+        if get_git_version() >= CWD_REMOVAL_HANDLED_BY_GIT:
             # See https://github.com/git/git/blob/master/Documentation/RelNotes/2.35.0.txt#L81 for the fix
             assert_success(
                 ["traverse", "-y"],
@@ -2014,7 +2016,7 @@ class TestTraverse(BaseTest):
         )
 
     # The expected error message includes `--empty=drop` which is only passed on git >= 2.26.0.
-    @pytest.mark.skipif(get_git_version() < (2, 26, 0), reason="--empty=drop is only passed to git rebase since git 2.26.0")
+    @pytest.mark.skipif(get_git_version() < REBASE_EMPTY_DROP, reason="--empty=drop is only passed to git rebase since git 2.26.0")
     def test_traverse_rebase_conflict(self) -> None:
         create_repo()
         with fixed_author_and_committer_date_in_past():

--- a/tests/test_traverse_worktrees.py
+++ b/tests/test_traverse_worktrees.py
@@ -4,6 +4,8 @@ import subprocess
 import pytest
 from pytest_mock import MockerFixture
 
+from git_machete.git_version_thresholds import (REBASE_EMPTY_DROP,
+                                                WORKTREE_COMMAND)
 from git_machete.utils.exceptions import UnderlyingGitException
 from git_machete.utils.paths import AbsPath
 from tests.base_test import BaseTest
@@ -21,7 +23,7 @@ from tests.mockers import (fixed_author_and_committer_date_in_past,
 # It applies the specified marks to all test functions in this module.
 # This skips all tests in this file if git version < 2.5 (when worktree was introduced).
 pytestmark = pytest.mark.skipif(  # noqa: F841
-    get_git_version() < (2, 5),
+    get_git_version() < WORKTREE_COMMAND,
     reason="git worktree command was introduced in git 2.5"
 )
 
@@ -753,7 +755,7 @@ class TestTraverseWorktrees(BaseTest):
         assert "git-machete-worktree-" not in " ".join(get_worktree_dirs())
 
     # The expected error message includes `--empty=drop` which is only passed on git >= 2.26.0.
-    @pytest.mark.skipif(get_git_version() < (2, 26, 0), reason="--empty=drop is only passed to git rebase since git 2.26.0")
+    @pytest.mark.skipif(get_git_version() < REBASE_EMPTY_DROP, reason="--empty=drop is only passed to git rebase since git 2.26.0")
     def test_traverse_rebase_conflict_in_worktree(self) -> None:
         create_repo_with_remote()
         with fixed_author_and_committer_date_in_past():

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,5 +1,6 @@
 from pytest_mock import MockerFixture
 
+from git_machete.git_version_thresholds import REBASE_EMPTY_DROP
 from git_machete.utils.exceptions import UnderlyingGitException
 from git_machete.utils.terminal import FullTerminalAnsiOutputCodes
 from tests.base_test import BaseTest
@@ -110,7 +111,7 @@ class TestUpdate(BaseTest):
         # Let's substitute the editor opened by git for interactive rebase to-do list
         # so that the test can run in a fully automated manner.
         with overridden_environment(GIT_SEQUENCE_EDITOR=":"):
-            if get_git_version() >= (2, 26, 0):
+            if get_git_version() >= REBASE_EMPTY_DROP:
                 launch_command("update")
             else:
                 with fixed_author_and_committer_date_in_past():


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1715

## Chain of upstream PRs as of 2026-06-02

* PR #1714:
  `master` ← `develop`

  * PR #1715:
    `develop` ← `refactor/slide-out-wt-tests`

    * **PR #1716 (THIS ONE)**:
      `refactor/slide-out-wt-tests` ← `refactor/git-thresholds`

<!-- end git-machete generated -->

Replace the bare version-tuple comparisons (`(2, 5)`, `(2, 14, 2)`, `(2, 26, 0)`, ...)
scattered across `git_machete/` and `tests/` with named constants in one module, each
documenting the feature added or upstream bug fixed at that `git` version.

Also records the boundaries that have no runtime check but matter implicitly: the 1.8.0
minimum (tied to `git branch --set-upstream-to`) and the 2.10.0 `log.showSignature`
config-parameter workaround. These carry `# noqa: F841` as documentation-only constants.