### PR TITLE
Print user-visible progress for each slide-out and reparenting step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,13 @@
 - Skip tests that require a minimum Git version with `@pytest.mark.skipif(get_git_version() < (X, Y), reason="...")`,
   not with an `if get_git_version() < (X, Y): return` early-return at the top of the test body.
   The decorator surfaces the skip in pytest's report (and in the JUnit XML CI uploads); the early-return silently masquerades as a pass.
+- Prefer `assert_success(cmd_and_args, expected_output)` over a bare `launch_command(cmd_and_args)` whenever a command is run for its effect.
+  A bare `launch_command` throws the command's entire output on the floor, so any regression in what it prints (a reworded message,
+  a wrong/missing branch name, a stray extra line, a wrong singular/plural) goes completely unnoticed - the call still "passes".
+  `assert_success` pins the *whole* output down, so it doubles as the regression test for that output.
+  Reserve a bare `launch_command` for the cases where asserting the full output is genuinely troublesome
+  (non-deterministic output such as commit hashes or `--verbose`/git-subprocess noise leaking into the captured text),
+  and even then prefer asserting whatever deterministic prefix/suffix you can.
 - Assert on the *full* command output rather than substring presence.
   Use `assert_success(cmd_and_args, expected_output)` (or, for ANSI/colored runs where `--color=always` produces escape codes,
   `raw_output = launch_command(...); assert raw_output == expected_ansi`) so the whole rendering is pinned down at once.
@@ -78,3 +85,7 @@
   the line-length limit is 140 (see `[flake8]` in `tox.ini`).
   Break on sentence or clause boundaries instead, so each line carries one thought rather than a fragment chopped by column count.
   Prefer one sentence per line; for a sentence that exceeds 140 columns, split at a natural clause boundary (semicolons, parentheticals, conjunctions, ...).
+- This matters especially for PR descriptions (and commit message bodies): never insert mid-sentence line breaks at a fixed column.
+  Write them in natural flow - one sentence per line, exactly like code comments - and let GitHub / the git client wrap them for display.
+  Note that a PR opened from a single commit inherits that commit's message verbatim, so a hard-wrapped commit body produces a hard-wrapped PR description;
+  keep the commit body unwrapped too.

--- a/git_machete/client/slide_out.py
+++ b/git_machete/client/slide_out.py
@@ -104,6 +104,11 @@ class SlideOutMacheteClient(MacheteClient):
             last_branch = branches_to_slide_out[-1]
             hook_invocations = [(nearest_surviving_ancestor(last_branch), last_branch, [])]
 
+        # Where each pivot's surviving children will be reattached - precomputed before the splice mutates the tree,
+        # purely so we can print a user-visible summary of the reparenting that's about to happen.
+        reattachments: List[Tuple[List[ManagedBranchName], Optional[ManagedBranchName]]] = [
+            (surviving_children(pivot), nearest_surviving_ancestor(pivot)) for pivot in pivots]
+
         # Preflight: refuse upfront if any of the branches that the rest of slide-out would later need to
         # `git checkout` is already held by another linked worktree. Without this check we'd write the layout
         # file, fire the post-hook, and only THEN bail out at the first `git checkout` - leaving the layout
@@ -127,7 +132,15 @@ class SlideOutMacheteClient(MacheteClient):
             self._git.expect_branch_not_held_by_other_worktree(branch)
 
         for branch in branches_to_slide_out:
+            print_fmt(f"Sliding out <b>{branch}</b>")
             self._state.splice_out(branch)
+
+        for reattach_children, reattach_parent in reattachments:
+            flat_children = ", ".join(f"<b>{child}</b>" for child in reattach_children)
+            if reattach_parent is not None:
+                print_fmt(f"Reattaching {flat_children} under <b>{reattach_parent}</b>")
+            else:
+                print_fmt(f"Reattaching {flat_children} as new root branches")
 
         # Update definition, fire post-hook, and perform the branch update
         self.save_branch_layout_file()

--- a/git_machete/client/slide_out.py
+++ b/git_machete/client/slide_out.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple
+from typing import Dict, List, NamedTuple, Optional
 
 from git_machete.client.base import MacheteClient
 from git_machete.client.state import ManagedBranchName
@@ -6,6 +6,17 @@ from git_machete.config import SquashMergeDetection
 from git_machete.git import AnyRevision, LocalBranchShortName
 from git_machete.utils.exceptions import MacheteException
 from git_machete.utils.markup import green_ok, print_fmt
+
+
+class Reattachment(NamedTuple):
+    children: List[ManagedBranchName]
+    new_parent: Optional[ManagedBranchName]
+
+
+class HookInvocation(NamedTuple):
+    new_parent: Optional[ManagedBranchName]
+    slid_out_branch: ManagedBranchName
+    new_children: List[ManagedBranchName]
 
 
 class SlideOutMacheteClient(MacheteClient):
@@ -51,7 +62,16 @@ class SlideOutMacheteClient(MacheteClient):
         # Those surviving children are the ones that get reattached (and, unless `--no-rebase`, synced) to a new parent.
         # In the classic "slide out a chain b1 -> ... -> bN" case there's exactly one pivot (bN); the interior branches
         # have their only child slid out alongside them, so they contribute no surviving children.
-        pivots: List[ManagedBranchName] = [branch for branch in branches_to_slide_out if surviving_children(branch)]
+        # `reattachment_by_pivot` records, for each pivot, where its surviving children will be reattached. It's computed
+        # once here (before the splice mutates the tree) and reused for the down-fork-point check, the rebase target,
+        # the worktree preflight, the post-slide-out hook payloads and the user-visible summary.
+        pivots: List[ManagedBranchName] = []
+        reattachment_by_pivot: Dict[LocalBranchShortName, Reattachment] = {}
+        for branch in branches_to_slide_out:
+            children = surviving_children(branch)
+            if children:
+                pivots.append(branch)
+                reattachment_by_pivot[branch] = Reattachment(children, nearest_surviving_ancestor(branch))
 
         # The only restriction left in rebase/merge mode: all the children that need to be synced must hang off a single
         # slid-out branch, so there's an unambiguous branch to rebase/merge them onto. With `--no-rebase` the children are
@@ -67,7 +87,7 @@ class SlideOutMacheteClient(MacheteClient):
             # `--down-fork-point` conflicts with `--no-rebase` (rejected in the CLI), so the single-pivot rule above holds.
             if not pivots:
                 raise MacheteException("Branch to slide out must have a child branch if option `--down-fork-point` is passed")
-            pivot_children = surviving_children(pivots[0])
+            pivot_children = reattachment_by_pivot[pivots[0]].children
             if len(pivot_children) > 1:
                 raise MacheteException("Branch to slide out can't have more than one child branch "
                                        "if option `--down-fork-point` is passed")
@@ -75,39 +95,33 @@ class SlideOutMacheteClient(MacheteClient):
                 fork_point=opt_down_fork_point,
                 branch=pivot_children[0])
 
-        # Read the connections we need for the post-hook, checkout and rebase logic before mutating state.
         # The single-pivot rule guarantees at most one rebase target when rebasing.
         rebase_pivot: Optional[ManagedBranchName] = pivots[0] if pivots else None
-        new_parent: Optional[ManagedBranchName] = nearest_surviving_ancestor(rebase_pivot) if rebase_pivot is not None else None
-        new_children: List[ManagedBranchName] = surviving_children(rebase_pivot) if rebase_pivot is not None else []
+        new_parent: Optional[ManagedBranchName] = reattachment_by_pivot[rebase_pivot].new_parent if rebase_pivot is not None else None
+        new_children: List[ManagedBranchName] = reattachment_by_pivot[rebase_pivot].children if rebase_pivot is not None else []
 
         # Where to land if the current branch is one of the branches about to disappear from the layout:
         # its nearest surviving ancestor, or - failing that (it was effectively a root) - its first surviving child.
         current_branch = self._git.get_current_branch_or_none()
         landing_branch: Optional[LocalBranchShortName] = None
         if current_branch is not None and current_branch in slide_out_set:
-            ancestor = nearest_surviving_ancestor(current_branch)
-            if ancestor is not None:
-                landing_branch = ancestor
+            reattachment = reattachment_by_pivot.get(current_branch)
+            if reattachment is not None:
+                landing_branch = reattachment.new_parent or reattachment.children[0]
             else:
-                current_surviving_children = surviving_children(current_branch)
-                if current_surviving_children:
-                    landing_branch = current_surviving_children[0]
+                landing_branch = nearest_surviving_ancestor(current_branch)
 
         # Post-slide-out hook payloads, computed before the splice mutates the tree. The hook fires once per pivot
         # (the branch(es) whose children are reparented); if nothing has surviving children we preserve the historical
         # single firing for the last specified branch (with an empty downstream list).
-        hook_invocations: List[Tuple[Optional[ManagedBranchName], ManagedBranchName, List[ManagedBranchName]]]
+        hook_invocations: List[HookInvocation]
         if pivots:
-            hook_invocations = [(nearest_surviving_ancestor(pivot), pivot, surviving_children(pivot)) for pivot in pivots]
+            hook_invocations = [
+                HookInvocation(reattachment_by_pivot[pivot].new_parent, pivot, reattachment_by_pivot[pivot].children)
+                for pivot in pivots]
         else:
             last_branch = branches_to_slide_out[-1]
-            hook_invocations = [(nearest_surviving_ancestor(last_branch), last_branch, [])]
-
-        # Where each pivot's surviving children will be reattached - precomputed before the splice mutates the tree,
-        # purely so we can print a user-visible summary of the reparenting that's about to happen.
-        reattachments: List[Tuple[List[ManagedBranchName], Optional[ManagedBranchName]]] = [
-            (surviving_children(pivot), nearest_surviving_ancestor(pivot)) for pivot in pivots]
+            hook_invocations = [HookInvocation(nearest_surviving_ancestor(last_branch), last_branch, [])]
 
         # Preflight: refuse upfront if any of the branches that the rest of slide-out would later need to
         # `git checkout` is already held by another linked worktree. Without this check we'd write the layout
@@ -135,20 +149,21 @@ class SlideOutMacheteClient(MacheteClient):
             print_fmt(f"Sliding out <b>{branch}</b>")
             self._state.splice_out(branch)
 
-        for reattach_children, reattach_parent in reattachments:
-            flat_children = ", ".join(f"<b>{child}</b>" for child in reattach_children)
-            if reattach_parent is not None:
-                print_fmt(f"Reattaching {flat_children} under <b>{reattach_parent}</b>")
+        for reattachment in reattachment_by_pivot.values():
+            flat_children = ", ".join(f"<b>{child}</b>" for child in reattachment.children)
+            if reattachment.new_parent is not None:
+                print_fmt(f"Reattaching {flat_children} under <b>{reattachment.new_parent}</b>")
             else:
-                print_fmt(f"Reattaching {flat_children} as new root branches")
+                noun = "branch" if len(reattachment.children) == 1 else "branches"
+                print_fmt(f"Reattaching {flat_children} as new root {noun}")
 
         # Update definition, fire post-hook, and perform the branch update
         self.save_branch_layout_file()
-        for hook_new_parent, hook_slid_out_branch, hook_new_children in hook_invocations:
+        for hook_invocation in hook_invocations:
             self._run_post_slide_out_hook(
-                new_parent=hook_new_parent,
-                slid_out_branch=hook_slid_out_branch,
-                new_children=hook_new_children)
+                new_parent=hook_invocation.new_parent,
+                slid_out_branch=hook_invocation.slid_out_branch,
+                new_children=hook_invocation.new_children)
 
         # Check out the landing branch if we were on a slid-out branch (and there's somewhere to land);
         # otherwise stay on the current (slid-out) branch.

--- a/tests/test_slide_out.py
+++ b/tests/test_slide_out.py
@@ -152,6 +152,7 @@ class TestSlideOut(BaseTest):
         self.patch_symbol(mocker, 'builtins.input', mock_input_returning_y)
         assert_success(
             ["slide-out", "-n", "--delete"],
+            "Sliding out child_d\n"
             "Checking out child_b... OK\n"
             "Delete branch child_d (unmerged to HEAD)? (y, N, q)\n"
         )
@@ -390,6 +391,8 @@ class TestSlideOut(BaseTest):
         self.patch_symbol(mocker, 'builtins.input', mock_input_returning_y)
         assert_success(
             ['slide-out', '-n', 'branch-1', '--delete'],
+            "Sliding out branch-1\n"
+            "Reattaching branch-2 under branch-0\n"
             "Delete branch branch-1 (unmerged to HEAD)? (y, N, q)\n"
         )
 
@@ -522,7 +525,11 @@ class TestSlideOut(BaseTest):
         rewrite_branch_layout_file(body)
 
         check_out('master')
-        assert_success(['slide-out', 'a', 'b'], "")
+        assert_success(
+            ['slide-out', 'a', 'b'],
+            "Sliding out a\n"
+            "Sliding out b\n"
+        )
 
         assert read_branch_layout_file().splitlines() == ["master", "    c"]
 
@@ -920,9 +927,9 @@ class TestSlideOut(BaseTest):
 
         delete_branch('branch-1')
 
-        # The explicit slide-out should produce no output (no warning, no error)
+        # The explicit slide-out should succeed cleanly (no warning, no error)
         # and remove the (now-orphaned-in-git) branch from the layout.
-        assert_success(["slide-out", "branch-1"], "")
+        assert_success(["slide-out", "branch-1"], "Sliding out branch-1\n")
 
         expected_layout = ["branch-0", "    branch-2"]
         assert read_branch_layout_file().splitlines() == expected_layout

--- a/tests/test_slide_out.py
+++ b/tests/test_slide_out.py
@@ -78,8 +78,15 @@ class TestSlideOut(BaseTest):
         # Slide-out a single interior branch with one downstream. (child_c)
         # This rebases the single downstream onto the new upstream. (child_b -> child_d)
 
-        launch_command("go", "up")
-        launch_command("slide-out", "-n")
+        assert_success(["go", "up"], "Checking out child_c... OK\n")
+        assert_success(
+            ["slide-out", "-n"],
+            "Sliding out child_c\n"
+            "Reattaching child_d under child_b\n"
+            "Checking out child_b... OK\n"
+            "Checking out child_d... OK\n"
+            "Rebasing child_d onto child_b...\n"
+        )
 
         assert_success(
             ["status", "-l"],
@@ -102,8 +109,8 @@ class TestSlideOut(BaseTest):
 
         # Slide-out an interior branch with multiple downstreams (slide_root).
         # This rebases all the downstreams onto the new upstream (develop -> [child_a, child_b]).
-        launch_command("go", "up")
-        launch_command("go", "up")
+        assert_success(["go", "up"], "Checking out child_b... OK\n")
+        assert_success(["go", "up"], "Checking out slide_root... OK\n")
 
         assert_success(
             ["status", "-l"],
@@ -125,7 +132,17 @@ class TestSlideOut(BaseTest):
         )
 
         self.patch_symbol(mocker, 'builtins.input', mock_input_returning_y)
-        launch_command("slide-out", "-n", "--delete", "--merge")
+        assert_success(
+            ["slide-out", "-n", "--delete", "--merge"],
+            "Sliding out slide_root\n"
+            "Reattaching child_a, child_b under develop\n"
+            "Checking out develop... OK\n"
+            "Checking out child_a... OK\n"
+            "Merging develop into child_a...\n"
+            "Checking out child_b... OK\n"
+            "Merging develop into child_b...\n"
+            "Delete branch slide_root (merged to HEAD)? (y, N, q)\n"
+        )
 
         assert_success(
             ["status", "-l"],
@@ -147,7 +164,11 @@ class TestSlideOut(BaseTest):
 
         # Slide-out and delete a terminal branch (child_d).
         # This just slices the branch off the tree.
-        launch_command("go", "down")
+        assert_success(
+            ["go", "down"],
+            "Checking out child_d... OK\n"
+            "Tip: run git machete go (without a direction) to pick a branch interactively.\n"
+        )
         assert "child_d" in get_local_branches()
         self.patch_symbol(mocker, 'builtins.input', mock_input_returning_y)
         assert_success(
@@ -190,7 +211,7 @@ class TestSlideOut(BaseTest):
             """
         rewrite_branch_layout_file(body)
 
-        launch_command("slide-out", "branch-1")
+        assert_success(["slide-out", "branch-1"], "Sliding out branch-1\n")
         # Branch should not be changed by slide-out if the current branch has NOT been slid out
         assert get_current_branch() == "branch-2"
 
@@ -213,7 +234,13 @@ class TestSlideOut(BaseTest):
 
         write_to_file(".git/hooks/machete-post-slide-out", '#!/bin/sh\necho "$@" > machete-post-slide-out-output')
         set_file_executable(".git/hooks/machete-post-slide-out")
-        launch_command("slide-out", "-n", "branch-1")
+        assert_success(
+            ["slide-out", "-n", "branch-1"],
+            "Sliding out branch-1\n"
+            "Reattaching branch-2 under branch-0\n"
+            "Checking out branch-2... OK\n"
+            "Rebasing branch-2 onto branch-0...\n"
+        )
         assert "branch-0 branch-1 branch-2" == read_file("machete-post-slide-out-output").strip()
 
         write_to_file(".git/hooks/machete-post-slide-out", "#!/bin/sh\nexit 1")
@@ -249,7 +276,13 @@ class TestSlideOut(BaseTest):
         set_file_executable(".git/hooks/machete-post-slide-out")
 
         check_out('master')
-        launch_command("slide-out", "--no-rebase", "a", "b")
+        assert_success(
+            ["slide-out", "--no-rebase", "a", "b"],
+            "Sliding out a\n"
+            "Sliding out b\n"
+            "Reattaching x under master\n"
+            "Reattaching y under master\n"
+        )
         assert read_file("machete-post-slide-out-output").splitlines() == ["master a x", "master b y"]
 
     def test_slide_out_root_branch_with_post_slide_out_hook(self) -> None:
@@ -276,7 +309,11 @@ class TestSlideOut(BaseTest):
                       '"$#" "$1" "$2" "$3" "$4" > machete-post-slide-out-output'
         write_to_file(".git/hooks/machete-post-slide-out", hook_script)
         set_file_executable(".git/hooks/machete-post-slide-out")
-        launch_command("slide-out", "-n", "root")
+        assert_success(
+            ["slide-out", "-n", "root"],
+            "Sliding out root\n"
+            "Reattaching child-1, child-2 as new root branches\n"
+        )
         # Hook receives: "" (empty new_upstream), "root" (slid out branch), "child-1" "child-2" (new downstreams)
         hook_output = read_file("machete-post-slide-out-output").strip()
         assert hook_output == "argc=4 arg1=[] arg2=[root] arg3=[child-1] arg4=[child-2]", \
@@ -354,9 +391,14 @@ class TestSlideOut(BaseTest):
                         branch-3
             """
         rewrite_branch_layout_file(body)
-        launch_command(
-            'slide-out', '-n', 'branch-1', 'branch-2', '-d',
-            hash_of_second_commit_on_branch_3)
+        assert_success(
+            ['slide-out', '-n', 'branch-1', 'branch-2', '-d', hash_of_second_commit_on_branch_3],
+            "Sliding out branch-1\n"
+            "Sliding out branch-2\n"
+            "Reattaching branch-3 under branch-0\n"
+            "Checking out branch-3... OK\n"
+            "Rebasing branch-3 onto branch-0...\n"
+        )
 
         expected_status_output = (
             """
@@ -559,7 +601,11 @@ class TestSlideOut(BaseTest):
             """
         rewrite_branch_layout_file(body)
 
-        launch_command('slide-out', '-n', 'branch-3', 'branch-2a')
+        assert_success(
+            ['slide-out', '-n', 'branch-3', 'branch-2a'],
+            "Sliding out branch-3\n"
+            "Sliding out branch-2a\n"
+        )
 
         assert read_branch_layout_file().splitlines() == [
             "branch-0",
@@ -594,7 +640,13 @@ class TestSlideOut(BaseTest):
         rewrite_branch_layout_file(body)
 
         check_out('master')
-        launch_command('slide-out', '--no-rebase', 'a', 'b')
+        assert_success(
+            ['slide-out', '--no-rebase', 'a', 'b'],
+            "Sliding out a\n"
+            "Sliding out b\n"
+            "Reattaching x under master\n"
+            "Reattaching y under master\n"
+        )
 
         assert read_branch_layout_file().splitlines() == [
             "master",
@@ -738,7 +790,11 @@ class TestSlideOut(BaseTest):
         branch_2_commit_before = get_current_commit_hash()
 
         # Slide out branch-1 with --no-rebase, branch-2 should not be rebased
-        launch_command("slide-out", "branch-1", "--no-rebase")
+        assert_success(
+            ["slide-out", "branch-1", "--no-rebase"],
+            "Sliding out branch-1\n"
+            "Reattaching branch-2 under root\n"
+        )
 
         # Verify that branch-2 is now a child of root in the layout
         expected_layout = ["root", "    branch-2"]
@@ -811,7 +867,12 @@ class TestSlideOut(BaseTest):
 
         # Slide out the root branch
         check_out("root")
-        launch_command("slide-out")
+        assert_success(
+            ["slide-out"],
+            "Sliding out root\n"
+            "Reattaching child-1, child-3 as new root branches\n"
+            "Checking out child-1... OK\n"
+        )
 
         # Verify that child-1 and child-3 are now root branches in the layout
         expected_layout = ["child-1", "    child-2", "child-3"]
@@ -833,13 +894,12 @@ class TestSlideOut(BaseTest):
         assert child_3_commit_before == child_3_commit_after
 
     def test_slide_out_root_branch_with_no_rebase(self) -> None:
-        """Test that root branches can be slid out with --no-rebase flag (though it's redundant)."""
+        """Test that a root branch with a single child can be slid out with --no-rebase flag (though it's redundant)."""
         create_repo()
         new_branch("root")
         commit("root commit")
         new_branch("child-1")
         commit("child-1 commit")
-        check_out("root")
         new_branch("child-2")
         commit("child-2 commit")
 
@@ -847,7 +907,7 @@ class TestSlideOut(BaseTest):
             """
             root
                 child-1
-                child-2
+                    child-2
             """
         rewrite_branch_layout_file(body)
 
@@ -859,10 +919,15 @@ class TestSlideOut(BaseTest):
 
         # Slide out the root branch with --no-rebase
         check_out("root")
-        launch_command("slide-out", "--no-rebase")
+        assert_success(
+            ["slide-out", "--no-rebase"],
+            "Sliding out root\n"
+            "Reattaching child-1 as new root branch\n"
+            "Checking out child-1... OK\n"
+        )
 
-        # Verify that child-1 and child-2 are now root branches in the layout
-        expected_layout = ["child-1", "child-2"]
+        # Verify that child-1 became a root branch (keeping child-2 underneath) in the layout
+        expected_layout = ["child-1", "    child-2"]
         assert read_branch_layout_file().splitlines() == expected_layout
 
         # Verify we're on child-1 (first downstream)
@@ -893,7 +958,7 @@ class TestSlideOut(BaseTest):
 
         # Slide out root-2 (which has no downstreams)
         check_out("root-2")
-        launch_command("slide-out")
+        assert_success(["slide-out"], "Sliding out root-2\n")
 
         # Verify that only root-1 remains in the layout
         expected_layout = ["root-1"]


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1718

## Chain of upstream PRs as of 2026-06-05

* PR #1718:
  `develop` ← `improve/relax-slide-out`

  * **PR #1719 (THIS ONE)**:
    `improve/relax-slide-out` ← `improve/slide-out-output`

<!-- end git-machete generated -->

Until now `slide-out` only printed the checkout of the branch we land on, so sliding out multiple branches at once gave almost no feedback about what happened.
It now prints `Sliding out <branch>` as each branch leaves the layout, and `Reattaching <children> under <new-parent>` (or `as new root branches` when the children become roots) for each slid-out branch whose surviving children get reparented.