### PR TITLE
Render `status` worktree labels when every linked worktree is in detached HEAD

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 - changed: `git machete slide-out` no longer requires the given branches to form a chain; any set of branches can be slid out at once, the only remaining restriction (unless `--no-rebase` is passed) being that at most one of them may have children that are not themselves being slid out
 - changed: shell completion for `git machete slide-out` now suggests all managed branches (excluding the ones already given on the command line), rather than only those forming a valid chain
 - deprecated: `git machete list slidable` (now equivalent to `git machete list managed`) and `git machete list slidable-after`, as `git machete slide-out`'s shell completion no longer relies on either
+- fixed: `git machete status` now renders `[<worktree>]` labels in repos whose linked worktrees are all in detached HEAD state, rather than treating the repo as single-worktree and suppressing every label
 
 ## New in git-machete 3.42.0
 

--- a/git_machete/client/status.py
+++ b/git_machete/client/status.py
@@ -482,22 +482,31 @@ class StatusMacheteClient(MacheteClient):
         repo we don't want a `[<this worktree>]` tag stuck on the current branch of every status output,
         since the user hasn't opted into the multi-worktree workflow and there's nothing to disambiguate.
         """
-        worktree_path_by_branch = self._git.get_worktree_root_dirs_by_branch()
-        if not worktree_path_by_branch:
+        branch_by_worktree_path = self._git.load_branch_by_worktree_root_dir()
+        if not branch_by_worktree_path:
             return {}
 
         main_path = self._git.get_main_worktree_root_dir()
         current_path = self._git.get_current_worktree_root_dir()
 
-        linked_paths = sorted({p for p in worktree_path_by_branch.values() if p != main_path})
+        # `.keys()` covers detached-HEAD linked worktrees too - this is what makes the gate fire
+        # in repos whose only linked worktree happens to be detached.
+        linked_paths = sorted({p for p in branch_by_worktree_path.keys() if p != main_path})
         if not linked_paths:
             return {}
 
         stripped = strip_longest_common_path_prefix([str(p) for p in linked_paths])
         label_by_linked_path = dict(zip(linked_paths, stripped))
 
+        # For the same-branch-in-multiple-worktrees foot-gun, multiple iterations write to
+        # `labels[branch]` - the last write wins. Since porcelain emits main first and linked
+        # after (and `load_branch_by_worktree_root_dir` preserves insertion order), the linked
+        # entry overwrites the main one - so the branch's label points at the linked worktree,
+        # which is the surprising one of the two locations and the more useful one to surface.
         labels: Dict[LocalBranchShortName, str] = {}
-        for branch, path in worktree_path_by_branch.items():
+        for path, branch in branch_by_worktree_path.items():
+            if branch is None:
+                continue
             if path == current_path:
                 labels[branch] = "<this worktree>"
             elif path == main_path:

--- a/git_machete/client/traverse.py
+++ b/git_machete/client/traverse.py
@@ -55,7 +55,23 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
                          interactively_slide_out_invalid_branches=interactively_slide_out_invalid_branches)
         self.__temporary_worktree_path: Optional[AbsPath] = None
         self.__dir_before_temporary_worktree: Optional[AbsPath] = None
-        self.__worktree_root_dir_for_branch: Dict[LocalBranchShortName, AbsPath] = {}
+        # Mirrors the shape of `Git.load_branch_by_worktree_root_dir`: keyed by path so we can update a
+        # worktree's branch in-place after a checkout and drop a worktree by path in one statement.
+        # Detached entries are kept with `value=None` so the snapshot mirrors what `git worktree list`
+        # actually sees - traverse doesn't currently *do* anything different for them, but tossing them
+        # out here would silently re-introduce the same blind spot that broke the status label gate.
+        self.__branch_by_worktree_root_dir: Dict[AbsPath, Optional[LocalBranchShortName]] = {}
+
+    def _find_worktree_for_branch(self, branch: LocalBranchShortName) -> Optional[AbsPath]:
+        # "Last entry wins" tiebreak for the same-branch-in-multiple-worktrees foot-gun: scan all
+        # entries and let later matches overwrite earlier ones. Porcelain emits the main worktree
+        # first and linked worktrees after, so this picks the linked worktree - which is the answer
+        # `expect_branch_not_held_by_other_worktree` is built around.
+        result: Optional[AbsPath] = None
+        for path, b in self.__branch_by_worktree_root_dir.items():
+            if b == branch:
+                result = path
+        return result
 
     def _update_worktrees_cache_after_checkout(self, checked_out_branch: LocalBranchShortName) -> None:
         """
@@ -65,13 +81,7 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
         Only the current worktree's entry needs to be updated - linked worktrees don't change when we checkout in a different worktree.
         """
         current_worktree_root_dir = self._git.get_current_worktree_root_dir()
-
-        for branch, path in self.__worktree_root_dir_for_branch.items():
-            if path == current_worktree_root_dir:
-                del self.__worktree_root_dir_for_branch[branch]
-                break
-
-        self.__worktree_root_dir_for_branch[checked_out_branch] = current_worktree_root_dir
+        self.__branch_by_worktree_root_dir[current_worktree_root_dir] = checked_out_branch
 
     def _remove_temporary_worktree(self) -> None:
         if self.__temporary_worktree_path is not None:
@@ -79,10 +89,7 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
             prev_dir = self.__dir_before_temporary_worktree
             self.__temporary_worktree_path = None
             self.__dir_before_temporary_worktree = None
-            for branch, path in list(self.__worktree_root_dir_for_branch.items()):   # pragma: no branch; break is always hit
-                if path == temp_path:
-                    del self.__worktree_root_dir_for_branch[branch]
-                    break
+            self.__branch_by_worktree_root_dir.pop(temp_path, None)
             assert prev_dir is not None
             print_fmt(f"Removing the temporary worktree; changing directory back to <b>{prev_dir}</b>")
             self._git.chdir(prev_dir)
@@ -104,7 +111,7 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
         # Clean up temporary worktree from previous branch before switching
         self._remove_temporary_worktree()
 
-        target_worktree_root_dir = self.__worktree_root_dir_for_branch.get(target_branch)
+        target_worktree_root_dir = self._find_worktree_for_branch(target_branch)
         current_worktree_root_dir = self._git.get_current_worktree_root_dir()
 
         if target_worktree_root_dir is None:
@@ -120,7 +127,7 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
                 self.__dir_before_temporary_worktree = current_worktree_root_dir
                 self._git.chdir(temp_worktree_path)
                 self.__temporary_worktree_path = temp_worktree_path
-                self.__worktree_root_dir_for_branch[target_branch] = temp_worktree_path
+                self.__branch_by_worktree_root_dir[temp_worktree_path] = target_branch
             else:
                 if config_value == TraverseWhenBranchNotCheckedOutInAnyWorktree.CD_INTO_MAIN_WORKTREE:
                     main_worktree_root_dir = self._git.get_main_worktree_root_dir()
@@ -202,7 +209,7 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
 
         # Fetch worktrees once at the start to avoid repeated git worktree list calls
         self.__temporary_worktree_path = None
-        self.__worktree_root_dir_for_branch = self._git.get_worktree_root_dirs_by_branch()
+        self.__branch_by_worktree_root_dir = self._git.load_branch_by_worktree_root_dir()
 
         try:
             if start_from == TraverseStartFrom.ROOT:
@@ -567,7 +574,7 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
 
             # Warn if the initial directory doesn't correspond to the final checked out branch's worktree
             final_branch = self._git.get_current_branch()
-            final_worktree_path = self.__worktree_root_dir_for_branch.get(final_branch)
+            final_worktree_path = self._find_worktree_for_branch(final_branch)
             if final_worktree_path and initial_worktree_root != final_worktree_path:
                 # Final branch is checked out in a worktree different from where we started
                 normalized_path = AbsPath(final_worktree_path)

--- a/git_machete/git.py
+++ b/git_machete/git.py
@@ -356,10 +356,10 @@ class Git:
                 # If worktrees aren't supported, just return the current root dir
                 self.__main_worktree_root_dir = self.get_current_worktree_root_dir()
             else:
-                # `get_worktree_root_dirs_by_branch` parses the same porcelain output and sets
+                # `load_branch_by_worktree_root_dir` parses the same porcelain output and sets
                 # `__main_worktree_root_dir` as a side effect on its way past the first entry,
                 # so reuse it here rather than running `git worktree list --porcelain` a second time.
-                self.get_worktree_root_dirs_by_branch()
+                self.load_branch_by_worktree_root_dir()
                 if self.__main_worktree_root_dir is None:
                     # Should not happen in practice: `git worktree list --porcelain` always emits at least the main worktree.
                     # If it did, we'd have already raised inside `__parse_worktree_list_porcelain`.
@@ -387,53 +387,67 @@ class Git:
         # Let's use /-style paths even on Windows, for consistency with what git itself returns.
         return self.get_main_worktree_git_dir().join_fragments(*fragments)
 
-    def get_worktree_root_dirs_by_branch(self) -> Dict[LocalBranchShortName, AbsPath]:
+    def load_branch_by_worktree_root_dir(self) -> Dict[AbsPath, Optional[LocalBranchShortName]]:
         """
-        Returns a dict mapping branch names to their worktree paths.
-        The main worktree's current branch is included if it's on a branch.
-        Branches not checked out in any worktree are not in the dict.
-        Worktrees in detached HEAD state are not included (since they can't be looked up by branch name).
+        Returns a dict mapping every (non-stale) worktree path - main *and* linked - to the branch
+        checked out there, or to `None` for detached-HEAD worktrees. Stale worktrees (the admin entry
+        survives `rm -rf <worktree>` until `git worktree prune` / `git worktree repair` reconciles it)
+        are filtered out so we never render labels (or `cd` suggestions) for a directory that no longer
+        exists.
 
-        Same-branch-in-multiple-worktrees (only reachable via `git worktree add -f`, which is what the test harness
-        uses to set up some scenarios; vanilla `git worktree add` refuses with `fatal: '<branch>' is already used
-        by worktree at <path>`) collapses to "last entry from the porcelain output wins". The porcelain output puts
-        the main worktree first and linked worktrees after it, so this picks the linked entry over the main one -
-        which happens to be the more useful answer for our callers (they typically want "where else is this branch
-        held besides the main worktree") and also matches a human's intuition. We don't bother special-casing it
-        because the state is one git itself disallows by default.
+        Keying by path - rather than the natural-feeling "branch -> path" inverse - lets detached
+        worktrees stay first-class entries (with `branch=None`) rather than getting filtered out for
+        having no key. That in turn lets the worktree-label gate in `status` answer "is there *any*
+        linked worktree?" by simply asking `path in dict.keys()`, without first having to reason
+        about HEAD state - i.e. a repo with N linked worktrees all in detached HEAD looks correctly
+        like a multi-worktree repo for the purpose of label gating, rather than collapsing into the
+        single-worktree shape.
 
-        Uncached on purpose: in practice each CLI invocation calls this at most once per logical operation
-        (`status` reads it once for the worktree-label render; `traverse` reads it once on startup and then
-        owns a local copy that it mutates incrementally as it adds/removes worktrees). Adding a cache here
-        would just buy invalidation bookkeeping (every `worktree add` / `worktree remove` / `checkout` would
-        have to remember to clear it) without saving any real git calls.
+        Same-branch-in-multiple-worktrees (only reachable via `git worktree add -f`;
+        vanilla `git worktree add` refuses with `fatal: '<branch>' is already used by worktree at <path>`)
+        is represented honestly here - each worktree path is a distinct key, so both entries coexist.
+        The "last entry from the porcelain output wins" tiebreak still applies wherever a caller
+        needs to collapse the relation back to a single answer per branch:
+        since Python dicts preserve insertion order and porcelain emits the main worktree
+        first, a final-write-wins loop or a last-match scan picks the linked entry over the main one
+        (matching the spirit of `expect_branch_not_held_by_other_worktree` - "refuse to hold a branch
+        in a worktree besides the main one"). We don't special-case the foot-gun any harder since
+        vanilla `git worktree add` blocks the path that would produce it.
 
-        The main worktree path *is* cached on `__main_worktree_root_dir` (populated as a side effect of the
-        parse below) - that one's safe because the main worktree path doesn't change during a CLI invocation,
-        and it lets `get_main_worktree_root_dir` reuse our parse output rather than running
-        `git worktree list --porcelain` a second time when both getters are called together (as `status` does).
+        Uncached on purpose: in practice each CLI invocation calls this at most once per logical
+        operation (`status` reads it once for the worktree-label render; `traverse` reads it once on
+        startup and then owns a local copy that it mutates incrementally as it adds/removes worktrees).
+        Adding a cache here would just buy invalidation bookkeeping (every `worktree add` / `worktree
+        remove` / `checkout` would have to remember to clear it) without saving any real git calls.
+
+        The main worktree path *is* cached on `__main_worktree_root_dir` (populated as a side effect of
+        the parse below) - that one's safe because the main worktree path doesn't change during a CLI
+        invocation, and it lets `get_main_worktree_root_dir` reuse our parse output rather than running
+        `git worktree list --porcelain` a second time when both getters are called together (as `status`
+        does).
         """
         if self.get_git_version() < WORKTREE_COMMAND:
             return {}
 
         result = self._popen_git("worktree", "list", "--porcelain")
-        worktrees: Dict[LocalBranchShortName, AbsPath] = {}
+        worktrees: Dict[AbsPath, Optional[LocalBranchShortName]] = {}
 
         latest_worktree_path: Optional[AbsPath] = None
         latest_branch: Optional[LocalBranchShortName] = None
-        is_detached: bool = False
         is_first_entry: bool = True
 
         def complete_entry() -> None:
-            # Drop detached-HEAD entries (can't be looked up by branch name) and stale ones whose working dir
-            # was removed/moved out-of-band - `git worktree list` still emits the admin entry until
-            # `git worktree prune` / `git worktree repair` reconciles it, but rendering `[<basename>]` for a
-            # directory that no longer exists would just send the user `cd`-ing into a void. We check the path
-            # ourselves rather than relying on `--porcelain`'s `prunable` annotation, which wasn't emitted by
-            # older git versions (the annotation was added to porcelain output well after worktrees themselves).
-            if (latest_worktree_path and latest_branch is not None and
-                    not is_detached and os.path.isdir(latest_worktree_path)):
-                worktrees[latest_branch] = latest_worktree_path
+            # Drop stale entries whose working dir was removed/moved out-of-band - `git worktree list`
+            # keeps emitting the admin entry until `git worktree prune` / `git worktree repair`
+            # reconciles it, but recording `[<basename>]` for a directory that no longer exists would
+            # just send the user `cd`-ing into a void. We check the path ourselves rather than relying
+            # on `--porcelain`'s `prunable` annotation, which wasn't emitted by older git versions
+            # (the annotation was added to porcelain output well after worktrees themselves).
+            # Detached-HEAD entries are NOT dropped: they're recorded with `latest_branch=None` so the
+            # status label gate can still see that the worktree exists (and `traverse` can still warn
+            # about a `cd` away from the initial worktree even if HEAD there is detached).
+            if latest_worktree_path and os.path.isdir(latest_worktree_path):
+                worktrees[latest_worktree_path] = latest_branch
 
         for line in result.stdout.strip().splitlines():
             if line.startswith('worktree '):
@@ -447,15 +461,12 @@ class Git:
                 # Format: "branch refs/heads/<branch-name>"
                 branch_ref = line[len('branch '):]
                 latest_branch = LocalBranchFullName.of(branch_ref).to_short_name()
-                is_detached = False
             elif line.startswith('detached'):
-                is_detached = True
                 latest_branch = None
             elif line == '':
                 complete_entry()
                 latest_worktree_path = None
                 latest_branch = None
-                is_detached = False
 
         complete_entry()
 
@@ -783,7 +794,15 @@ class Git:
         post-hook ends up fired only to have `git checkout` then bail out with `fatal: '<branch>' is already used
         by worktree at <path>` (see https://github.com/VirtusLab/git-machete/issues/1711).
         """
-        target_worktree_root_dir = self.get_worktree_root_dirs_by_branch().get(branch)
+        # "Last porcelain entry wins" tiebreak for the same-branch-in-two-worktrees foot-gun: the
+        # final matching path overwrites earlier ones, and porcelain emits the main worktree first
+        # and linked worktrees after, so we end up picking the linked entry over the main one - i.e.
+        # we refuse the operation when the user is in main with a copy of `branch` *also* held by
+        # some linked worktree, but accept it when the user is already standing in that linked one.
+        target_worktree_root_dir: Optional[AbsPath] = None
+        for path, b in self.load_branch_by_worktree_root_dir().items():
+            if b == branch:
+                target_worktree_root_dir = path
         if target_worktree_root_dir is not None and target_worktree_root_dir != self.get_current_worktree_root_dir():
             raise MacheteException(
                 f"Branch <b>{branch}</b> is already checked out in another worktree at <b>{target_worktree_root_dir}</b>.\n"

--- a/tests/git_repository.py
+++ b/tests/git_repository.py
@@ -166,6 +166,22 @@ def add_worktree(branch: str) -> str:
     return worktree_path
 
 
+def add_detached_worktree() -> str:
+    """
+    Create a new worktree with detached HEAD (no branch ref) in a temporary directory.
+    Returns the path to the created worktree.
+    """
+    worktree_path = mkdtemp()
+    execute(f"git worktree add -f --detach {worktree_path}")
+    return worktree_path
+
+
+def detach_head() -> None:
+    """Detach HEAD at its current position in the current worktree (so the worktree no longer has
+    a checked-out branch, but the working tree's contents stay the same)."""
+    execute("git checkout --detach HEAD")
+
+
 def get_worktree_dirs() -> List[str]:
     lines = popen("git worktree list --porcelain").splitlines()
     return [line[len("worktree "):] for line in lines if line.startswith("worktree ")]

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,16 +1,19 @@
 import os
+from tempfile import mkdtemp
+from typing import Dict, Optional
 
 import pytest
 
 from git_machete.git import (AnyBranchName, AnyRevision, FullCommitHash, Git,
                              LocalBranchShortName)
 from git_machete.git_version_thresholds import WORKTREE_COMMAND
+from git_machete.utils.paths import AbsPath
 from tests.base_test import BaseTest
 from tests.git_repository import (add_worktree, check_out, commit, create_repo,
                                   get_current_commit_hash, get_git_version,
                                   is_ancestor_or_equal, new_branch,
                                   new_orphan_branch, set_git_config_key)
-from tests.shell import read_file, write_to_file
+from tests.shell import execute, read_file, write_to_file
 
 
 class TestGitOperations(BaseTest):
@@ -201,7 +204,12 @@ class TestGitOperations(BaseTest):
         git.get_reflog(AnyBranchName.of("feature@foo"))
 
     @pytest.mark.skipif(get_git_version() < WORKTREE_COMMAND, reason="git worktree command was introduced in git 2.5")
-    def test_get_worktree_root_dirs_by_branch(self) -> None:
+    def test_load_branch_by_worktree_root_dir(self) -> None:
+        """Direct unit test of `Git.load_branch_by_worktree_root_dir`. Walks through every interesting
+        permutation of (main vs linked) X (on-branch vs detached) and asserts the full returned dict
+        each time, pinning down both the keying direction (path -> Optional[branch]) and the contract
+        that detached-HEAD worktrees stay first-class entries with `value=None` rather than being
+        filtered out for lack of a branch name."""
         create_repo()
         new_branch("main")
         commit("main commit")
@@ -215,87 +223,84 @@ class TestGitOperations(BaseTest):
         git = Git()
         main_worktree_path = git.get_current_worktree_root_dir()
 
+        def by_real_path(d: Dict[AbsPath, Optional[LocalBranchShortName]]) -> Dict[str, Optional[LocalBranchShortName]]:
+            # macOS resolves `mkdtemp` paths under `/private/...`, so the porcelain output and the
+            # `add_worktree` return value can disagree by a `/private` prefix. Normalize both sides
+            # to `os.path.realpath` so each step can assert on the full mapping in one go.
+            return {os.path.realpath(p): b for p, b in d.items()}
+
+        main = LocalBranchShortName.of("main")
+        feature1 = LocalBranchShortName.of("feature-1")
+        feature2 = LocalBranchShortName.of("feature-2")
+
         # Test 1: Main worktree on a branch, no linked worktrees
         check_out("main")
-        worktrees = git.get_worktree_root_dirs_by_branch()
-        assert len(worktrees) == 1
-        assert worktrees.get(LocalBranchShortName.of("main")) == main_worktree_path
-        assert git.get_worktree_root_dirs_by_branch().get(LocalBranchShortName.of("main")) == main_worktree_path
-        assert git.get_worktree_root_dirs_by_branch().get(LocalBranchShortName.of("feature-1")) is None
+        assert by_real_path(git.load_branch_by_worktree_root_dir()) == {
+            os.path.realpath(main_worktree_path): main,
+        }
 
-        # Test 2: Create linked worktrees
+        # Test 2: Add two linked worktrees, each on its own branch
         feature1_worktree = add_worktree("feature-1")
         feature2_worktree = add_worktree("feature-2")
 
-        worktrees = git.get_worktree_root_dirs_by_branch()
-        assert len(worktrees) == 3
-        assert worktrees.get(LocalBranchShortName.of("main")) == main_worktree_path
-        # On macOS, paths may have /private prefix, so use realpath to normalize
-        feature1_path = worktrees.get(LocalBranchShortName.of("feature-1"))
-        assert feature1_path is not None
-        assert os.path.realpath(feature1_path) == os.path.realpath(feature1_worktree)
-        feature2_path = worktrees.get(LocalBranchShortName.of("feature-2"))
-        assert feature2_path is not None
-        assert os.path.realpath(feature2_path) == os.path.realpath(feature2_worktree)
-        assert git.get_worktree_root_dirs_by_branch().get(LocalBranchShortName.of("feature-3")) is None
+        assert by_real_path(git.load_branch_by_worktree_root_dir()) == {
+            os.path.realpath(main_worktree_path): main,
+            os.path.realpath(feature1_worktree): feature1,
+            os.path.realpath(feature2_worktree): feature2,
+        }
 
-        # Test 3: Main worktree in detached HEAD (should NOT be in dict)
-        main_commit = git.get_commit_hash_by_revision(LocalBranchShortName.of("main"))
+        # Test 3: Detach HEAD in the main worktree. The entry stays in the snapshot, but with
+        # `value=None` to signal "this worktree exists, but no branch is checked out here".
+        main_commit = git.get_commit_hash_by_revision(main)
         assert main_commit is not None
-        check_out(main_commit)  # Detach HEAD in main worktree
+        check_out(main_commit)
 
-        worktrees = git.get_worktree_root_dirs_by_branch()
-        assert len(worktrees) == 2  # Only feature-1 and feature-2, not the detached main
-        assert LocalBranchShortName.of("main") not in worktrees
-        feature1_path = worktrees.get(LocalBranchShortName.of("feature-1"))
-        assert feature1_path is not None
-        assert os.path.realpath(feature1_path) == os.path.realpath(feature1_worktree)
-        feature2_path = worktrees.get(LocalBranchShortName.of("feature-2"))
-        assert feature2_path is not None
-        assert os.path.realpath(feature2_path) == os.path.realpath(feature2_worktree)
+        assert by_real_path(git.load_branch_by_worktree_root_dir()) == {
+            os.path.realpath(main_worktree_path): None,
+            os.path.realpath(feature1_worktree): feature1,
+            os.path.realpath(feature2_worktree): feature2,
+        }
 
-        # Test 4: Linked worktree in detached HEAD (should NOT be in dict)
+        # Test 4: Detach HEAD in a linked worktree too. Both detached entries coexist as distinct
+        # rows - one per worktree path - rather than collapsing onto each other.
         initial_dir = os.getcwd()
         os.chdir(feature1_worktree)
-        feature1_commit = git.get_commit_hash_by_revision(LocalBranchShortName.of("feature-1"))
+        feature1_commit = git.get_commit_hash_by_revision(feature1)
         assert feature1_commit is not None
-        check_out(feature1_commit)  # Detach HEAD in feature-1 worktree
+        check_out(feature1_commit)
         os.chdir(initial_dir)
 
-        worktrees = git.get_worktree_root_dirs_by_branch()
-        assert len(worktrees) == 1  # Only feature-2, not main (detached) or feature-1 (detached)
-        assert LocalBranchShortName.of("main") not in worktrees
-        assert LocalBranchShortName.of("feature-1") not in worktrees
-        feature2_path = worktrees.get(LocalBranchShortName.of("feature-2"))
-        assert feature2_path is not None
-        assert os.path.realpath(feature2_path) == os.path.realpath(feature2_worktree)
+        assert by_real_path(git.load_branch_by_worktree_root_dir()) == {
+            os.path.realpath(main_worktree_path): None,
+            os.path.realpath(feature1_worktree): None,
+            os.path.realpath(feature2_worktree): feature2,
+        }
 
-        # Test 5: Create another worktree in detached HEAD to ensure they don't overwrite each other
-        # This tests the bug fix where multiple detached HEADs would overwrite each other with None key
-        from tempfile import mkdtemp
-
-        from tests.shell import execute
+        # Test 5: Add a *third* detached worktree (pointing at the `feature-3` commit but not on the
+        # branch) - three coexisting `None`-value rows confirm that detached entries are addressed
+        # per-worktree rather than collapsing under any shared "no branch here" key.
         feature3_worktree = mkdtemp()
         execute(f"git worktree add -f --detach {feature3_worktree} feature-3")
 
-        worktrees = git.get_worktree_root_dirs_by_branch()
-        # Should still be 1 (only feature-2), detached worktrees should not be included
-        assert len(worktrees) == 1
-        assert LocalBranchShortName.of("feature-3") not in worktrees
+        assert by_real_path(git.load_branch_by_worktree_root_dir()) == {
+            os.path.realpath(main_worktree_path): None,
+            os.path.realpath(feature1_worktree): None,
+            os.path.realpath(feature2_worktree): feature2,
+            os.path.realpath(feature3_worktree): None,
+        }
 
-        # Test 6: Check out branch in the detached worktree, should now appear
+        # Test 6: Re-checkout `feature-1` in its (currently detached) linked worktree - the entry
+        # flips from None back to the branch name without changing keys.
         os.chdir(feature1_worktree)
-        check_out("feature-1")  # Back on branch
+        check_out("feature-1")
         os.chdir(initial_dir)
 
-        worktrees = git.get_worktree_root_dirs_by_branch()
-        assert len(worktrees) == 2  # feature-1 and feature-2
-        feature1_path = worktrees.get(LocalBranchShortName.of("feature-1"))
-        assert feature1_path is not None
-        assert os.path.realpath(feature1_path) == os.path.realpath(feature1_worktree)
-        feature2_path = worktrees.get(LocalBranchShortName.of("feature-2"))
-        assert feature2_path is not None
-        assert os.path.realpath(feature2_path) == os.path.realpath(feature2_worktree)
+        assert by_real_path(git.load_branch_by_worktree_root_dir()) == {
+            os.path.realpath(main_worktree_path): None,
+            os.path.realpath(feature1_worktree): feature1,
+            os.path.realpath(feature2_worktree): feature2,
+            os.path.realpath(feature3_worktree): None,
+        }
 
     def test_merge_base_cache_loading_and_saving(self) -> None:
         """Test merge-base cache with various edge cases."""

--- a/tests/test_status_worktrees.py
+++ b/tests/test_status_worktrees.py
@@ -10,7 +10,8 @@ from git_machete.utils.terminal import FullTerminalAnsiOutputCodes
 from tests.base_test import BaseTest
 from tests.cli_runner import (assert_success, launch_command,
                               rewrite_branch_layout_file)
-from tests.git_repository import (add_worktree, check_out, commit, create_repo,
+from tests.git_repository import (add_detached_worktree, add_worktree,
+                                  check_out, commit, create_repo, detach_head,
                                   get_git_version, new_branch)
 
 pytestmark = pytest.mark.skipif(  # noqa: F841
@@ -317,6 +318,107 @@ class TestStatusWorktrees(BaseTest):
             """,
         )
 
+    def test_status_labels_fire_when_the_only_linked_worktree_is_detached(self) -> None:
+        """A linked worktree in detached HEAD state must count for the worktree-label gate just like
+        an on-branch linked worktree does: the user has opted into the multi-worktree workflow either
+        way, so labels need to render so they can tell from `status` that they're not in a
+        single-worktree repo. The detached worktree itself gets no label row (no branch to label),
+        but every *other* managed branch checked out somewhere should carry the usual label.
+
+        The precise trigger of the regression this test guards against is "every linked worktree is
+        in detached HEAD state". The main worktree is not special: it can be on a branch (as here)
+        or itself detached - see `test_status_labels_fire_when_main_worktree_is_detached` for the
+        latter half of that matrix. As soon as a single linked worktree has a non-detached HEAD the
+        gate passes and labels render - which is why a status-worktree suite exercising only
+        on-branch linked worktrees would miss this case entirely.
+        """
+        create_repo()
+        new_branch("master")
+        commit()
+        check_out("master")
+        new_branch("develop")
+        commit()
+
+        rewrite_branch_layout_file(
+            """
+            master
+              develop
+            """
+        )
+
+        check_out("master")
+        add_detached_worktree()
+
+        # `master` is current/main -> `<this worktree>`; `develop` is not checked out anywhere,
+        # so no label. The detached linked worktree has no branch to label, but its mere existence
+        # must still fire the gate so the user knows from `status` that they're in a multi-worktree
+        # repo.
+        assert_success(
+            ["status"],
+            """
+              master * [<this worktree>]
+              |
+              o-develop
+            """,
+        )
+
+    def test_status_labels_fire_when_main_worktree_is_detached(self) -> None:
+        """The companion to `test_status_labels_fire_when_the_only_linked_worktree_is_detached`: this
+        time the *main* worktree is the one in detached HEAD, the layout has multiple linked worktrees
+        in mixed HEAD state (one on a branch, one detached), and labels must still render for the
+        on-branch linked worktree. The detached main worktree's path-keyed entry sits in the snapshot
+        with `branch=None`, so it doesn't end up labeled (no branch to label), but it doesn't suppress
+        the gate either - sibling on-branch linked worktrees keep their basename labels.
+
+        No branch carries the `<this worktree>` or `<main worktree>` literals here: with main detached,
+        no managed branch is checked out in either the current worktree or the main worktree, so the
+        two literal-label arms of the rendering loop are dead code for this scenario. The on-branch
+        linked worktree's basename label is the only label that surfaces.
+        """
+        create_repo()
+        new_branch("master")
+        commit()
+        check_out("master")
+        new_branch("develop")
+        commit()
+        check_out("master")
+        new_branch("feature")
+        commit()
+
+        rewrite_branch_layout_file(
+            """
+            master
+              develop
+              feature
+            """
+        )
+
+        check_out("master")
+        develop_worktree = add_worktree("develop")
+        add_detached_worktree()
+        # Detach main last - we needed master checked out earlier so the linked worktrees could
+        # be added without `master` being the foot-gun "same branch in two worktrees" target.
+        detach_head()
+
+        develop_label = os.path.basename(AbsPath(develop_worktree))
+        # Sanity-check: with two sibling linked worktrees under `mkdtemp`, the stripped label is
+        # just the trailing component (no remaining `/` after stripping the common prefix).
+        assert "/" not in develop_label
+
+        # `master` has no `*` (current HEAD is detached, no current branch), no label (not held by
+        # any worktree in the snapshot - both its prior locations are now detached). `develop`
+        # carries the linked basename label; `feature` is unchecked-out, so no label.
+        assert_success(
+            ["status"],
+            f"""
+              master
+              |
+              o-develop [{develop_label}]
+              |
+              o-feature
+            """,
+        )
+
     def test_status_no_labels_in_single_worktree_repo(self) -> None:
         """In a repo with no linked worktrees, the feature must not kick in - otherwise every plain
         `git machete status` would suddenly carry a `[<this worktree>]` tag on the current branch,
@@ -352,12 +454,13 @@ class TestStatusWorktrees(BaseTest):
         by worktree at <path>`), but `-f` overrides that, and the test harness's `add_worktree` uses `-f` so it can
         set up arbitrary scenarios. This test pins down what `status` does when the foot-gun fires:
 
-        `get_worktree_root_dirs_by_branch` collapses the branch->path mapping to "last porcelain entry wins". Since
-        `git worktree list --porcelain` puts the main worktree first and linked worktrees after it, the linked entry
-        wins - so a branch checked out in both main and a linked worktree is labeled as the *linked* one regardless
-        of where the user is standing. That's why the `master` row below carries `[<linked basename>]` when status
-        is run from main (even though `master` *is also* in the current/main worktree), and `[<this worktree>]`
-        when run from the linked worktree (where the "last wins" winner happens to coincide with `current_path`).
+        `_compute_worktree_label_by_branch`'s rendering loop iterates `load_branch_by_worktree_root_dir`'s
+        path-keyed dict in porcelain order (main first, linked after) and lets later writes to `labels[branch]`
+        overwrite earlier ones. So a branch checked out in both main and a linked worktree is labeled as the
+        *linked* one regardless of where the user is standing. That's why the `master` row below carries
+        `[<linked basename>]` when status is run from main (even though `master` *is also* in the current/main
+        worktree), and `[<this worktree>]` when run from the linked worktree (where the "last wins" winner
+        happens to coincide with `current_path`).
 
         We don't try to be cleverer than that - the underlying state is one git itself disallows by default,
         and any in-band warning would just add noise for the much commoner unmanaged-branch-in-linked-worktree case.


### PR DESCRIPTION
<!-- start git-machete generated -->

## Tree of downstream PRs as of 2026-06-10

* **PR #1721 (THIS ONE)**:
  `develop` ← `fix/worktree-detached-missing`

    * PR #1722:
      `fix/worktree-detached-missing` ← `refactor/traverse-no-wt-mapping`

<!-- end git-machete generated -->

`git machete status` was suppressing every `[<worktree>]` label (the feature added by #1706) in repos whose only linked worktree(s) happened to be in detached HEAD state, making such a multi-worktree repo look indistinguishable from a single-worktree one.

The worktree snapshot returned by `get_worktree_root_dirs_by_branch` was keyed by branch name, so detached entries (no branch to key by) had to be silently dropped from the dict before `status` saw it. The label-gate in `_compute_worktree_label_by_branch` then computed `linked_paths` from the values of that dict, filtered out the main worktree's path, and bailed out when the result was empty - which is exactly what "every linked worktree is detached" produces.

Flip the keying direction of the snapshot from `Dict[branch, path]` to `Dict[path, Optional[branch]]` (and rename to `get_branch_by_worktree_root_dir` to match). Detached worktrees now survive as first-class entries with `branch=None`, the label gate becomes correct without any explicit detached-HEAD logic in the status layer, and the same-branch-in-multiple-worktrees foot-gun is represented honestly (each worktree path is a distinct key, with the "last porcelain entry wins" tiebreak preserved via dict-insertion-order iteration).

Callers updated for the new shape: `_compute_worktree_label_by_branch` iterates `(path, branch)` and derives `linked_paths` from `.keys()`; `expect_branch_not_held_by_other_worktree` scans with a last-write-wins loop so the same-branch-in-two-worktrees behavior is unchanged; `TraverseMacheteClient` flips its mirror field accordingly, with two of the four mutations becoming simpler (path-keyed pop and in-place update) and the two by-branch lookups factored into a small `_find_worktree_for_branch` helper.

A regression test (`test_status_labels_fire_when_only_linked_worktree_is_detached`) pins the user-visible contract, and the direct unit test of the parser is rewritten to assert the full path-keyed dict at every step, walking all (main vs linked) X (on-branch vs detached) permutations.