### PR TITLE
Set `HOMEBREW_NO_ASK=1` and `HOMEBREW_NO_AUTO_UPDATE=1` for CircleCI macOS `brew install`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,12 @@ jobs:
     executor: macos_executor
     steps:
       - checkout: {method: blobless}
-      - run: brew install fish zsh
+      # `HOMEBREW_NO_ASK=1` opts out of Homebrew's "ask before install" confirmation prompt
+      # (enabled by default for `HOMEBREW_DEVELOPER`/`HOMEBREW_ASK`, only when stdin/stdout are TTYs).
+      # CircleCI's macOS executor allocates a pty for `run` steps, so without this opt-out
+      # `brew install` hangs on `Do you want to proceed with the installation? [y/n]` until the step is killed.
+      # `HOMEBREW_NO_AUTO_UPDATE=1` skips the (slow, unrelated) auto-update of outdated formulae before our install.
+      - run: HOMEBREW_NO_ASK=1 HOMEBREW_NO_AUTO_UPDATE=1 brew install fish zsh
       - run: pip install tox
       # TODO (#1005): make zsh completion tests pass on macOS machine on CI
       - run: tox -e test-completions -- -vv -k "not zsh"
@@ -298,7 +303,7 @@ only_special_branches: &only_special_branches
   filters:
     branches:
       only:
-        - "/.*(aur|ci[/-]|cross-platform|dependabot.pip|deploy|dry.run|hotfix|macos|nix|publish|release|windows).*/"
+        - "/.*(aur|ci[/-]|cross-platform|dependabot.pip|deploy|dry.run|homebrew|hotfix|macos|nix|publish|release|windows).*/"
         - "develop"
         - "master"
 


### PR DESCRIPTION
Recent Homebrew versions enable an "ask before install" confirmation prompt by default for `HOMEBREW_DEVELOPER`/`HOMEBREW_ASK` users when stdin/stdout are TTYs.
CircleCI's macOS executor allocates a pty for `run` steps, so `brew install fish zsh` started hanging on `Do you want to proceed with the installation? [y/n]` until the step was killed (`SIGTERM`).
`HOMEBREW_NO_ASK=1` is the documented opt-out, and `HOMEBREW_NO_AUTO_UPDATE=1` additionally skips the slow, unrelated auto-update of outdated formulae before our install.

[Sample failing pipeline](https://app.circleci.com/pipelines/gh/VirtusLab/git-machete/6855/workflows/2dc4c42a-4385-4695-9366-fc79a1715a72/jobs/53532?utm_campaign=workflowcompleted_failed&utm_medium=notification&utm_content=link&utm_source=email):

```
You have 16 outdated formulae and 1 outdated cask installed.

==> Would install 2 formulae:
fish zsh
==> Downloading https://ghcr.io/v2/homebrew/core/fish/manifests/4.7.1
######################################################################## 100.0%
==> Would install 1 dependency for fish:
pcre2
==> Downloading https://ghcr.io/v2/homebrew/core/zsh/manifests/5.9.1
######################################################################## 100.0%
==> Would install 2 dependencies for zsh:
ncurses
pcre2
==> Do you want to proceed with the installation? [y/n]
Error: SIGTERM
/opt/homebrew/Library/Homebrew/ask.rb:18:in 'Exception#initialize'
/opt/homebrew/Library/Homebrew/ask.rb:18:in 'SignalException#initialize'
/opt/homebrew/Library/Homebrew/ask.rb:18:in 'Interrupt#initialize'
/opt/homebrew/Library/Homebrew/ask.rb:18:in 'IO#getc'
/opt/homebrew/Library/Homebrew/ask.rb:18:in 'IO#getch'
/opt/homebrew/Library/Homebrew/ask.rb:18:in 'block in Homebrew::Ask.confirm?'
/opt/homebrew/Library/Homebrew/ask.rb:16:in 'Kernel#loop'
/opt/homebrew/Library/Homebrew/ask.rb:16:in 'Homebrew::Ask.confirm?'
/opt/homebrew/Library/Homebrew/install.rb:747:in 'Homebrew::Install.ask_input'
/opt/homebrew/Library/Homebrew/install.rb:558:in 'Homebrew::Install.ask_formulae'
/opt/homebrew/Library/Homebrew/cmd/install.rb:326:in 'Homebrew::Cmd::InstallCmd#run'
/opt/homebrew/Library/Homebrew/brew.rb:114:in '<main>'
Please report this issue:
  https://docs.brew.sh/Troubleshooting

Too long with no output (exceeded 10m0s): context deadline exceeded
```