### PR TITLE
Set isort `line_length` to 140 to match flake8 and reformat imports

### DIFF
--- a/git_machete/cli.py
+++ b/git_machete/cli.py
@@ -30,12 +30,8 @@ from git_machete.github import GITHUB_API_SPEC
 from git_machete.gitlab import GITLAB_API_SPEC
 from git_machete.help import alias_by_command, get_help_description, version
 from git_machete.utils import cmd, debug_log, markup, terminal
-from git_machete.utils.exceptions import (ExitCode, InteractionStopped,
-                                          MacheteException,
-                                          UnderlyingGitException,
-                                          UnexpectedMacheteException)
-from git_machete.utils.fs import (does_directory_exist,
-                                  get_current_directory_or_none)
+from git_machete.utils.exceptions import ExitCode, InteractionStopped, MacheteException, UnderlyingGitException, UnexpectedMacheteException
+from git_machete.utils.fs import does_directory_exist, get_current_directory_or_none
 from git_machete.utils.markup import print_fmt, warn
 from git_machete.utils.paths import AbsPath
 

--- a/git_machete/cli_commands.py
+++ b/git_machete/cli_commands.py
@@ -8,8 +8,7 @@ Keeping types + data together (rather than splitting types into the parser modul
 keeps `cli_parser.py → cli_commands.py` as a one-way dependency and removes the need for any forward references or parameterization.
 """
 
-from typing import (Any, Callable, Dict, FrozenSet, List, NamedTuple, Optional,
-                    Tuple)
+from typing import Any, Callable, Dict, FrozenSet, List, NamedTuple, Optional, Tuple
 
 from git_machete.help import commands_and_aliases
 

--- a/git_machete/cli_parser.py
+++ b/git_machete/cli_parser.py
@@ -15,9 +15,7 @@ import itertools
 import sys
 from typing import Any, Dict, Iterable, List, NoReturn, Optional, Tuple
 
-from git_machete.cli_commands import (COMMAND_BY_NAME_OR_ALIAS, COMMON_OPTIONS,
-                                      CommandSpec, MutexGroup, OptSpec,
-                                      ParsedCmd, PositionalSpec,
+from git_machete.cli_commands import (COMMAND_BY_NAME_OR_ALIAS, COMMON_OPTIONS, CommandSpec, MutexGroup, OptSpec, ParsedCmd, PositionalSpec,
                                       SubcommandSpec)
 from git_machete.utils.exceptions import ExitCode, MacheteException
 

--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -3,24 +3,19 @@ import shlex
 import sys
 import textwrap
 from enum import Enum, auto
-from typing import (Callable, Dict, Iterator, List, NoReturn, Optional,
-                    Sequence, Tuple, TypeVar)
+from typing import Callable, Dict, Iterator, List, NoReturn, Optional, Sequence, Tuple, TypeVar
 
 from git_machete.client import branch_layout
 from git_machete.client.state import MacheteState, ManagedBranchName
 from git_machete.config import MacheteConfig, SquashMergeDetection
-from git_machete.constants import (INITIAL_COMMIT_COUNT_FOR_LOG,
-                                   TOTAL_COMMIT_COUNT_FOR_LOG)
-from git_machete.git import (HEAD, AnyBranchName, AnyRevision, BranchPair,
-                             ForkPointOverrideData, FullCommitHash, Git,
-                             LocalBranchShortName, RemoteBranchShortName,
-                             SyncToRemoteStatus)
+from git_machete.constants import INITIAL_COMMIT_COUNT_FOR_LOG, TOTAL_COMMIT_COUNT_FOR_LOG
+from git_machete.git import (HEAD, AnyBranchName, AnyRevision, BranchPair, ForkPointOverrideData, FullCommitHash, Git, LocalBranchShortName,
+                             RemoteBranchShortName, SyncToRemoteStatus)
 from git_machete.utils import fs
 from git_machete.utils.cmd import run_cmd
 from git_machete.utils.collections import excluding, get_second, tupled
 from git_machete.utils.debug_log import debug
-from git_machete.utils.exceptions import (InteractionStopped, MacheteException,
-                                          UnexpectedMacheteException)
+from git_machete.utils.exceptions import InteractionStopped, MacheteException, UnexpectedMacheteException
 from git_machete.utils.markup import input_fmt, pretty_choices, print_fmt, warn
 from git_machete.utils.paths import AbsPath, Path
 

--- a/git_machete/client/go_interactive.py
+++ b/git_machete/client/go_interactive.py
@@ -9,18 +9,13 @@ except ImportError:  # pragma: no cover; Windows-specific
     termios = None  # type: ignore[assignment]
     tty = None  # type: ignore[assignment]
 
-from git_machete.client.status import (StatusData, StatusFlags,
-                                       StatusMacheteClient)
+from git_machete.client.status import StatusData, StatusFlags, StatusMacheteClient
 from git_machete.git import LocalBranchShortName
 from git_machete.utils import terminal
 from git_machete.utils.collections import index_or_none
-from git_machete.utils.exceptions import (MacheteException,
-                                          UnexpectedMacheteException)
+from git_machete.utils.exceptions import MacheteException, UnexpectedMacheteException
 from git_machete.utils.markup import green_ok, print_fmt, warn
-from git_machete.utils.terminal import (AnsiInputCodes,
-                                        BasicTerminalAnsiOutputCodes,
-                                        FullTerminalAnsiOutputCodes,
-                                        is_terminal_fully_fledged)
+from git_machete.utils.terminal import AnsiInputCodes, BasicTerminalAnsiOutputCodes, FullTerminalAnsiOutputCodes, is_terminal_fully_fledged
 
 AI = AnsiInputCodes
 

--- a/git_machete/client/go_show.py
+++ b/git_machete/client/go_show.py
@@ -3,8 +3,7 @@ from typing import List, Optional, Sequence
 from git_machete.client.base import MacheteClient, PickRoot
 from git_machete.client.state import ManagedBranchName
 from git_machete.git import LocalBranchShortName
-from git_machete.utils.exceptions import (MacheteException,
-                                          UnexpectedMacheteException)
+from git_machete.utils.exceptions import MacheteException, UnexpectedMacheteException
 from git_machete.utils.markup import green_ok, print_fmt
 
 

--- a/git_machete/client/squash.py
+++ b/git_machete/client/squash.py
@@ -2,8 +2,7 @@ import os
 from typing import List, Optional
 
 from git_machete.client.base import MacheteClient
-from git_machete.git import (AnyRevision, FullCommitHash, GitFormatPatterns,
-                             GitLogEntry)
+from git_machete.git import AnyRevision, FullCommitHash, GitFormatPatterns, GitLogEntry
 from git_machete.utils.exceptions import MacheteException
 from git_machete.utils.markup import print_fmt
 

--- a/git_machete/client/status.py
+++ b/git_machete/client/status.py
@@ -10,8 +10,7 @@ from git_machete.annotation import Annotation
 from git_machete.client.base import MacheteClient
 from git_machete.client.state import ManagedBranchName
 from git_machete.config import SquashMergeDetection
-from git_machete.git import (BranchPair, FullCommitHash, GitLogEntry,
-                             LocalBranchShortName, SyncToRemoteStatus)
+from git_machete.git import BranchPair, FullCommitHash, GitLogEntry, LocalBranchShortName, SyncToRemoteStatus
 from git_machete.utils import markup
 from git_machete.utils._subproc import PopenResult
 from git_machete.utils.cmd import popen_cmd

--- a/git_machete/client/traverse.py
+++ b/git_machete/client/traverse.py
@@ -7,11 +7,9 @@ from git_machete.annotation import Annotation, Qualifiers
 from git_machete.client.base import PickRoot
 from git_machete.client.with_code_hosting import MacheteClientWithCodeHosting
 from git_machete.code_hosting import CodeHostingSpec, PullRequest
-from git_machete.config import (SquashMergeDetection,
-                                TraverseWhenBranchNotCheckedOutInAnyWorktree)
+from git_machete.config import SquashMergeDetection, TraverseWhenBranchNotCheckedOutInAnyWorktree
 from git_machete.git import LocalBranchShortName, SyncToRemoteStatus
-from git_machete.utils.exceptions import (MacheteException, ParsableEnum,
-                                          UnexpectedMacheteException)
+from git_machete.utils.exceptions import MacheteException, ParsableEnum, UnexpectedMacheteException
 from git_machete.utils.markup import green_ok, pretty_choices, print_fmt, warn
 from git_machete.utils.paths import AbsPath
 

--- a/git_machete/client/with_code_hosting.py
+++ b/git_machete/client/with_code_hosting.py
@@ -5,22 +5,16 @@ from typing import Dict, Iterator, List, Optional, Set, Tuple
 from git_machete.annotation import Annotation, Qualifiers
 from git_machete.client.state import ManagedBranchName
 from git_machete.client.status import StatusMacheteClient
-from git_machete.code_hosting import (CodeHostingApi, CodeHostingSpec,
-                                      OrganizationAndRepository,
-                                      OrganizationAndRepositoryAndRemote,
+from git_machete.code_hosting import (CodeHostingApi, CodeHostingSpec, OrganizationAndRepository, OrganizationAndRepositoryAndRemote,
                                       PullRequest, is_matching_remote_url)
 from git_machete.config import PRDescriptionIntroStyle, SquashMergeDetection
-from git_machete.git import (GitFormatPatterns, GitLogEntry,
-                             LocalBranchShortName, RemoteBranchShortName,
-                             SyncToRemoteStatus)
+from git_machete.git import GitFormatPatterns, GitLogEntry, LocalBranchShortName, RemoteBranchShortName, SyncToRemoteStatus
 from git_machete.utils import date
 from git_machete.utils.collections import find_or_none, get_non_empty_lines
 from git_machete.utils.debug_log import debug
-from git_machete.utils.exceptions import (MacheteException,
-                                          UnexpectedMacheteException)
+from git_machete.utils.exceptions import MacheteException, UnexpectedMacheteException
 from git_machete.utils.fs import slurp_file
-from git_machete.utils.markup import (colored_yes_no, green_ok, pretty_choices,
-                                      print_fmt, warn)
+from git_machete.utils.markup import colored_yes_no, green_ok, pretty_choices, print_fmt, warn
 from git_machete.utils.paths import AbsPath
 
 

--- a/git_machete/git.py
+++ b/git_machete/git.py
@@ -5,24 +5,16 @@ import string
 import sys
 from enum import Enum, auto
 from pathlib import Path as PyPath
-from typing import (Any, Dict, Iterator, List, Match, NamedTuple, Optional,
-                    Set, Tuple)
+from typing import Any, Dict, Iterator, List, Match, NamedTuple, Optional, Set, Tuple
 
 from git_machete.constants import MAX_COMMITS_FOR_SQUASH_MERGE_DETECTION
-from git_machete.git_version_thresholds import (PATCH_ID_UNSTABLE_OUTPUT_ORDER,
-                                                PUSH_FORCE_IF_INCLUDES,
-                                                PUSH_FORCE_WITH_LEASE,
-                                                REBASE_EMPTY_DROP,
-                                                RELIABLE_MULTI_BRANCH_REFLOG,
-                                                WORKTREE_COMMAND,
-                                                WORKTREE_REMOVE_COMMAND)
+from git_machete.git_version_thresholds import (PATCH_ID_UNSTABLE_OUTPUT_ORDER, PUSH_FORCE_IF_INCLUDES, PUSH_FORCE_WITH_LEASE,
+                                                REBASE_EMPTY_DROP, RELIABLE_MULTI_BRANCH_REFLOG, WORKTREE_COMMAND, WORKTREE_REMOVE_COMMAND)
 from git_machete.utils._subproc import PopenResult
 from git_machete.utils.cmd import get_cmd_shell_repr, popen_cmd, run_cmd
 from git_machete.utils.collections import get_non_empty_lines
 from git_machete.utils.debug_log import debug, hex_repr
-from git_machete.utils.exceptions import (MacheteException,
-                                          UnderlyingGitException,
-                                          UnexpectedMacheteException)
+from git_machete.utils.exceptions import MacheteException, UnderlyingGitException, UnexpectedMacheteException
 from git_machete.utils.fs import is_executable, slurp_file
 from git_machete.utils.markup import escape_markup, print_fmt
 from git_machete.utils.paths import AbsPath, Path

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -8,16 +8,12 @@ import urllib.error
 import urllib.request
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
-from git_machete.code_hosting import (CodeHostingApi, CodeHostingGitConfigKeys,
-                                      CodeHostingSpec,
-                                      OrganizationAndRepository,
-                                      OrganizationAndRepositoryAndGitUrl,
-                                      PullRequest)
+from git_machete.code_hosting import (CodeHostingApi, CodeHostingGitConfigKeys, CodeHostingSpec, OrganizationAndRepository,
+                                      OrganizationAndRepositoryAndGitUrl, PullRequest)
 from git_machete.git import LocalBranchShortName
 from git_machete.utils.cmd import popen_cmd
 from git_machete.utils.debug_log import compact_dict, debug
-from git_machete.utils.exceptions import (MacheteException,
-                                          UnexpectedMacheteException)
+from git_machete.utils.exceptions import MacheteException, UnexpectedMacheteException
 from git_machete.utils.fs import slurp_file
 from git_machete.utils.markup import warn
 from git_machete.utils.paths import AbsPath

--- a/git_machete/gitlab.py
+++ b/git_machete/gitlab.py
@@ -9,17 +9,13 @@ import urllib.parse
 import urllib.request
 from typing import Any, Dict, List, NamedTuple, Optional
 
-from git_machete.code_hosting import (CodeHostingApi, CodeHostingGitConfigKeys,
-                                      CodeHostingSpec,
-                                      OrganizationAndRepository,
-                                      OrganizationAndRepositoryAndGitUrl,
-                                      PullRequest)
+from git_machete.code_hosting import (CodeHostingApi, CodeHostingGitConfigKeys, CodeHostingSpec, OrganizationAndRepository,
+                                      OrganizationAndRepositoryAndGitUrl, PullRequest)
 from git_machete.git import LocalBranchShortName
 from git_machete.utils.cmd import popen_cmd
 from git_machete.utils.collections import map_truthy_only
 from git_machete.utils.debug_log import compact_dict, debug
-from git_machete.utils.exceptions import (MacheteException,
-                                          UnexpectedMacheteException)
+from git_machete.utils.exceptions import MacheteException, UnexpectedMacheteException
 from git_machete.utils.fs import slurp_file
 from git_machete.utils.paths import AbsPath
 

--- a/git_machete/utils/collections.py
+++ b/git_machete/utils/collections.py
@@ -1,8 +1,7 @@
 """Generic collection / iteration helpers."""
 
 import itertools
-from typing import (Any, Callable, Iterable, List, Optional, Sequence, Tuple,
-                    TypeVar)
+from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, TypeVar
 
 T = TypeVar('T')
 U = TypeVar('U')

--- a/git_machete/utils/markup.py
+++ b/git_machete/utils/markup.py
@@ -15,8 +15,7 @@ from typing import Any, List, Optional, Tuple
 
 from git_machete.utils import terminal
 from git_machete.utils.collections import map_truthy_only
-from git_machete.utils.terminal import (BasicTerminalAnsiOutputCodes,
-                                        FullTerminalAnsiOutputCodes)
+from git_machete.utils.terminal import BasicTerminalAnsiOutputCodes, FullTerminalAnsiOutputCodes
 
 # === Mutable runtime flags ===
 #

--- a/tests/completion_e2e/test_completion_e2e.py
+++ b/tests/completion_e2e/test_completion_e2e.py
@@ -5,9 +5,7 @@ from typing import Dict
 import pytest
 
 from tests.cli_runner import rewrite_branch_layout_file
-from tests.git_repository import (check_out, commit, create_repo,
-                                  get_current_commit_hash, new_branch,
-                                  set_git_config_key)
+from tests.git_repository import check_out, commit, create_repo, get_current_commit_hash, new_branch, set_git_config_key
 from tests.shell import popen
 
 test_cases: Dict[str, str] = {

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -2,13 +2,9 @@
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success,
-                              read_branch_layout_file,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (check_out, commit, create_repo,
-                                  create_repo_with_remote, delete_branch,
-                                  get_commit_hash, get_current_commit_hash,
-                                  new_branch, push)
+from tests.cli_runner import assert_failure, assert_success, read_branch_layout_file, rewrite_branch_layout_file
+from tests.git_repository import (check_out, commit, create_repo, create_repo_with_remote, delete_branch, get_commit_hash,
+                                  get_current_commit_hash, new_branch, push)
 from tests.mockers import mock_input_returning, mock_input_returning_y
 
 

--- a/tests/test_advance.py
+++ b/tests/test_advance.py
@@ -6,14 +6,10 @@ from pytest_mock import MockerFixture
 from git_machete.utils.exceptions import ExitCode, UnderlyingGitException
 from git_machete.utils.terminal import FullTerminalAnsiOutputCodes
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success, launch_command,
-                              launch_command_capturing_output_and_exception,
+from tests.cli_runner import (assert_failure, assert_success, launch_command, launch_command_capturing_output_and_exception,
                               rewrite_branch_layout_file)
-from tests.git_repository import (check_out, commit, create_repo,
-                                  create_repo_with_remote, fetch,
-                                  get_commit_hash, get_current_commit_hash,
-                                  new_branch, push, reset_to,
-                                  wait_to_bump_commit_timestamp)
+from tests.git_repository import (check_out, commit, create_repo, create_repo_with_remote, fetch, get_commit_hash, get_current_commit_hash,
+                                  new_branch, push, reset_to, wait_to_bump_commit_timestamp)
 from tests.mockers import mock_input_returning, mock_input_returning_y
 
 

--- a/tests/test_anno.py
+++ b/tests/test_anno.py
@@ -2,14 +2,10 @@ from pytest_mock import MockerFixture
 
 from tests import mockers_github, mockers_gitlab
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_argument_error, assert_success,
-                              launch_command, rewrite_branch_layout_file)
-from tests.git_repository import (add_remote, check_out, commit, create_repo,
-                                  create_repo_with_remote, new_branch)
-from tests.mockers_github import (MockGitHubAPIState,
-                                  mock_github_token_for_domain_fake)
-from tests.mockers_gitlab import (MockGitLabAPIState,
-                                  mock_gitlab_token_for_domain_fake)
+from tests.cli_runner import assert_argument_error, assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import add_remote, check_out, commit, create_repo, create_repo_with_remote, new_branch
+from tests.mockers_github import MockGitHubAPIState, mock_github_token_for_domain_fake
+from tests.mockers_gitlab import MockGitLabAPIState, mock_gitlab_token_for_domain_fake
 
 
 class TestAnno(BaseTest):

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,12 +1,8 @@
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_success, launch_command,
-                              read_branch_layout_file,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (add_remote, check_out, commit, create_repo,
-                                  create_repo_with_remote, get_local_branches,
-                                  new_branch, push)
+from tests.cli_runner import assert_success, launch_command, read_branch_layout_file, rewrite_branch_layout_file
+from tests.git_repository import add_remote, check_out, commit, create_repo, create_repo_with_remote, get_local_branches, new_branch, push
 from tests.mockers import mock_input_returning_y
 from tests.mockers_github import mock_github_token_for_domain_none
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,8 +7,7 @@ from pytest_mock import MockerFixture
 from git_machete.cli import main
 from git_machete.utils.exceptions import ExitCode
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_argument_error,
-                              launch_command_capturing_output_and_exception)
+from tests.cli_runner import assert_argument_error, launch_command_capturing_output_and_exception
 from tests.git_repository import create_repo
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,10 +2,8 @@ from git_machete.annotation import Annotation
 from git_machete.client.base import MacheteClient
 from git_machete.git import LocalBranchShortName
 from tests.base_test import BaseTest
-from tests.cli_runner import (read_branch_layout_file,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (check_out, commit, create_repo_with_remote,
-                                  new_branch, push)
+from tests.cli_runner import read_branch_layout_file, rewrite_branch_layout_file
+from tests.git_repository import check_out, commit, create_repo_with_remote, new_branch, push
 
 
 class TestClient(BaseTest):

--- a/tests/test_delete_unmanaged.py
+++ b/tests/test_delete_unmanaged.py
@@ -1,15 +1,10 @@
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_success, launch_command,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (add_file_and_commit, amend_commit, check_out,
-                                  commit, create_repo, create_repo_with_remote,
-                                  get_local_branches, new_branch, push,
-                                  set_git_config_key)
-from tests.mockers import (fixed_author_and_committer_date_in_past,
-                           mock__run_cmd_and_forward_stdout,
-                           mock_input_returning)
+from tests.cli_runner import assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import (add_file_and_commit, amend_commit, check_out, commit, create_repo, create_repo_with_remote,
+                                  get_local_branches, new_branch, push, set_git_config_key)
+from tests.mockers import fixed_author_and_committer_date_in_past, mock__run_cmd_and_forward_stdout, mock_input_returning
 from tests.shell import execute
 
 

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -2,8 +2,7 @@ from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
 from tests.cli_runner import assert_success
-from tests.git_repository import (add_file_and_commit, create_repo_with_remote,
-                                  new_branch, push)
+from tests.git_repository import add_file_and_commit, create_repo_with_remote, new_branch, push
 from tests.mockers import mock__run_cmd_and_forward_stdout
 from tests.shell import write_to_file
 

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -6,11 +6,8 @@ from pytest_mock import MockerFixture
 
 from git_machete.utils.terminal import FullTerminalAnsiOutputCodes
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success, launch_command,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (check_out, commit, create_repo,
-                                  create_repo_with_remote, merge, new_branch,
-                                  push)
+from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import check_out, commit, create_repo, create_repo_with_remote, merge, new_branch, push
 from tests.mockers import mock_input_returning, overridden_environment
 from tests.shell import read_file
 

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -6,8 +6,7 @@ from git_machete.git_version_thresholds import WORKTREE_COMMAND
 from git_machete.utils.exceptions import UnderlyingGitException
 from tests.base_test import BaseTest
 from tests.cli_runner import assert_failure, launch_command
-from tests.git_repository import (commit, create_repo, get_git_version,
-                                  new_branch, set_git_config_key)
+from tests.git_repository import commit, create_repo, get_git_version, new_branch, set_git_config_key
 from tests.shell import execute
 
 

--- a/tests/test_fork_point.py
+++ b/tests/test_fork_point.py
@@ -4,13 +4,9 @@ from pytest_mock import MockerFixture
 
 from git_machete.utils.terminal import FullTerminalAnsiOutputCodes
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success, launch_command,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (add_remote, check_out, commit, create_repo,
-                                  create_repo_with_remote, delete_branch,
-                                  fetch, get_commit_hash,
-                                  get_current_commit_hash, merge, new_branch,
-                                  new_orphan_branch, pull, push, reset_to,
+from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import (add_remote, check_out, commit, create_repo, create_repo_with_remote, delete_branch, fetch,
+                                  get_commit_hash, get_current_commit_hash, merge, new_branch, new_orphan_branch, pull, push, reset_to,
                                   set_git_config_key)
 from tests.mockers import fixed_author_and_committer_date_in_past
 from tests.shell import execute, remove_directory

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -4,15 +4,12 @@ from typing import Dict, Optional
 
 import pytest
 
-from git_machete.git import (AnyBranchName, AnyRevision, FullCommitHash, Git,
-                             LocalBranchShortName)
+from git_machete.git import AnyBranchName, AnyRevision, FullCommitHash, Git, LocalBranchShortName
 from git_machete.git_version_thresholds import WORKTREE_COMMAND
 from git_machete.utils.paths import AbsPath
 from tests.base_test import BaseTest
-from tests.git_repository import (add_worktree, check_out, commit, create_repo,
-                                  get_current_commit_hash, get_git_version,
-                                  is_ancestor_or_equal, new_branch,
-                                  new_orphan_branch, set_git_config_key)
+from tests.git_repository import (add_worktree, check_out, commit, create_repo, get_current_commit_hash, get_git_version,
+                                  is_ancestor_or_equal, new_branch, new_orphan_branch, set_git_config_key)
 from tests.shell import execute, read_file, write_to_file
 
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -9,19 +9,13 @@ from pytest_mock import MockerFixture
 from git_machete.code_hosting import OrganizationAndRepository
 from git_machete.github import GitHubApi, GitHubToken
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success, launch_command,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (add_remote, check_out, commit, create_repo,
-                                  create_repo_with_remote, delete_branch,
-                                  new_branch, push, set_git_config_key,
-                                  unset_git_config_key)
-from tests.mockers import (fake_executables_on_path, mock_input_returning_y,
-                           overridden_environment, temporary_home_directory)
+from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import (add_remote, check_out, commit, create_repo, create_repo_with_remote, delete_branch, new_branch, push,
+                                  set_git_config_key, unset_git_config_key)
+from tests.mockers import fake_executables_on_path, mock_input_returning_y, overridden_environment, temporary_home_directory
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_github import (MockGitHubAPIState,
-                                  mock_github_token_for_domain_fake,
-                                  mock_github_token_for_domain_none,
-                                  mock_pr_json, mock_urlopen)
+from tests.mockers_github import (MockGitHubAPIState, mock_github_token_for_domain_fake, mock_github_token_for_domain_none, mock_pr_json,
+                                  mock_urlopen)
 from tests.shell import write_to_file
 
 # A `gh` fake that fails its very first call (`gh --version`), so callers

--- a/tests/test_github_anno_prs.py
+++ b/tests/test_github_anno_prs.py
@@ -1,16 +1,10 @@
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success, launch_command,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (add_remote, amend_commit, check_out, commit,
-                                  create_repo, create_repo_with_remote,
-                                  delete_branch, new_branch, push,
-                                  remove_remote, reset_to, set_git_config_key,
-                                  wait_to_bump_commit_timestamp)
-from tests.mockers_github import (MockGitHubAPIState,
-                                  mock_github_token_for_domain_fake,
-                                  mock_pr_json, mock_urlopen)
+from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import (add_remote, amend_commit, check_out, commit, create_repo, create_repo_with_remote, delete_branch,
+                                  new_branch, push, remove_remote, reset_to, set_git_config_key, wait_to_bump_commit_timestamp)
+from tests.mockers_github import MockGitHubAPIState, mock_github_token_for_domain_fake, mock_pr_json, mock_urlopen
 
 
 class TestGitHubAnnoPRs(BaseTest):

--- a/tests/test_github_checkout_prs.py
+++ b/tests/test_github_checkout_prs.py
@@ -6,17 +6,12 @@ from pytest_mock import MockerFixture
 from git_machete.code_hosting import OrganizationAndRepository
 from git_machete.github import GitHubApi
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success, launch_command,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (add_remote, check_out, commit, create_repo,
-                                  create_repo_with_remote, delete_branch,
-                                  new_branch, push, remove_remote,
-                                  set_git_config_key, set_remote_url)
+from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import (add_remote, check_out, commit, create_repo, create_repo_with_remote, delete_branch, new_branch, push,
+                                  remove_remote, set_git_config_key, set_remote_url)
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_github import (MockGitHubAPIState,
-                                  mock_github_token_for_domain_fake,
-                                  mock_github_token_for_domain_none,
-                                  mock_pr_json, mock_urlopen)
+from tests.mockers_github import (MockGitHubAPIState, mock_github_token_for_domain_fake, mock_github_token_for_domain_none, mock_pr_json,
+                                  mock_urlopen)
 from tests.shell import execute
 
 

--- a/tests/test_github_create_pr.py
+++ b/tests/test_github_create_pr.py
@@ -4,21 +4,14 @@ import textwrap
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success, launch_command,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (add_remote, amend_commit, check_out, commit,
-                                  create_repo, create_repo_with_remote,
-                                  delete_branch, delete_remote_branch,
-                                  new_branch, push, remove_remote, reset_to,
-                                  set_git_config_key,
+from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import (add_remote, amend_commit, check_out, commit, create_repo, create_repo_with_remote, delete_branch,
+                                  delete_remote_branch, new_branch, push, remove_remote, reset_to, set_git_config_key,
                                   wait_to_bump_commit_timestamp)
-from tests.mockers import (fixed_author_and_committer_date_in_past,
-                           mock_input_returning, mock_input_returning_y)
+from tests.mockers import fixed_author_and_committer_date_in_past, mock_input_returning, mock_input_returning_y
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_github import (MockGitHubAPIState,
-                                  mock_github_token_for_domain_fake,
-                                  mock_github_token_for_domain_none,
-                                  mock_pr_json, mock_urlopen)
+from tests.mockers_github import (MockGitHubAPIState, mock_github_token_for_domain_fake, mock_github_token_for_domain_none, mock_pr_json,
+                                  mock_urlopen)
 from tests.shell import execute, write_to_file
 
 

--- a/tests/test_github_restack_pr.py
+++ b/tests/test_github_restack_pr.py
@@ -3,16 +3,11 @@ import textwrap
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (amend_commit, commit,
-                                  create_repo_with_remote, new_branch, push,
-                                  reset_to, set_git_config_key)
+from tests.cli_runner import assert_failure, assert_success, rewrite_branch_layout_file
+from tests.git_repository import amend_commit, commit, create_repo_with_remote, new_branch, push, reset_to, set_git_config_key
 from tests.mockers import fixed_author_and_committer_date_in_past
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_github import (MockGitHubAPIState,
-                                  mock_github_token_for_domain_fake,
-                                  mock_pr_json, mock_urlopen)
+from tests.mockers_github import MockGitHubAPIState, mock_github_token_for_domain_fake, mock_pr_json, mock_urlopen
 
 
 class TestGitHubRestackPR(BaseTest):

--- a/tests/test_github_retarget_pr.py
+++ b/tests/test_github_retarget_pr.py
@@ -3,16 +3,11 @@ import textwrap
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success, launch_command,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (add_remote, check_out, commit, create_repo,
-                                  create_repo_with_remote, new_branch, push,
-                                  remove_remote, set_git_config_key,
-                                  unset_git_config_key)
+from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import (add_remote, check_out, commit, create_repo, create_repo_with_remote, new_branch, push, remove_remote,
+                                  set_git_config_key, unset_git_config_key)
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_github import (MockGitHubAPIState,
-                                  mock_github_token_for_domain_fake,
-                                  mock_pr_json, mock_urlopen)
+from tests.mockers_github import MockGitHubAPIState, mock_github_token_for_domain_fake, mock_pr_json, mock_urlopen
 
 
 class TestGitHubRetargetPR(BaseTest):

--- a/tests/test_github_sync.py
+++ b/tests/test_github_sync.py
@@ -1,15 +1,11 @@
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_success, launch_command,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (check_out, commit, create_repo_with_remote,
-                                  get_local_branches, new_branch, push)
+from tests.cli_runner import assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import check_out, commit, create_repo_with_remote, get_local_branches, new_branch, push
 from tests.mockers import mock_input_returning_y
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_github import (MockGitHubAPIState,
-                                  mock_github_token_for_domain_fake,
-                                  mock_pr_json, mock_urlopen)
+from tests.mockers_github import MockGitHubAPIState, mock_github_token_for_domain_fake, mock_pr_json, mock_urlopen
 
 
 class TestGitHubSync(BaseTest):

--- a/tests/test_github_update_pr_descriptions.py
+++ b/tests/test_github_update_pr_descriptions.py
@@ -4,16 +4,11 @@ from typing import Any, Dict, List
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success, launch_command,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (check_out, commit, create_repo_with_remote,
-                                  delete_branch, new_branch, push,
-                                  set_git_config_key)
+from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import check_out, commit, create_repo_with_remote, delete_branch, new_branch, push, set_git_config_key
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_github import (MockGitHubAPIState,
-                                  mock_github_token_for_domain_fake,
-                                  mock_github_token_for_domain_none,
-                                  mock_pr_json, mock_urlopen)
+from tests.mockers_github import (MockGitHubAPIState, mock_github_token_for_domain_fake, mock_github_token_for_domain_none, mock_pr_json,
+                                  mock_urlopen)
 
 
 class TestGitHubUpdatePRDescriptions(BaseTest):

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -9,19 +9,13 @@ from pytest_mock import MockerFixture
 from git_machete.code_hosting import OrganizationAndRepository
 from git_machete.gitlab import GitLabApi, GitLabToken
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success, launch_command,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (add_remote, check_out, commit, create_repo,
-                                  create_repo_with_remote, delete_branch,
-                                  new_branch, push, set_git_config_key,
-                                  unset_git_config_key)
-from tests.mockers import (fake_executables_on_path, mock_input_returning_y,
-                           overridden_environment, temporary_home_directory)
+from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import (add_remote, check_out, commit, create_repo, create_repo_with_remote, delete_branch, new_branch, push,
+                                  set_git_config_key, unset_git_config_key)
+from tests.mockers import fake_executables_on_path, mock_input_returning_y, overridden_environment, temporary_home_directory
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_gitlab import (MockGitLabAPIState,
-                                  mock_gitlab_token_for_domain_fake,
-                                  mock_gitlab_token_for_domain_none,
-                                  mock_mr_json, mock_urlopen)
+from tests.mockers_gitlab import (MockGitLabAPIState, mock_gitlab_token_for_domain_fake, mock_gitlab_token_for_domain_none, mock_mr_json,
+                                  mock_urlopen)
 from tests.shell import write_to_file
 
 # A `glab` fake that fails on every invocation, so callers of

--- a/tests/test_gitlab_anno_mrs.py
+++ b/tests/test_gitlab_anno_mrs.py
@@ -1,16 +1,10 @@
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success, launch_command,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (add_remote, amend_commit, check_out, commit,
-                                  create_repo, create_repo_with_remote,
-                                  delete_branch, new_branch, push,
-                                  remove_remote, reset_to, set_git_config_key,
-                                  wait_to_bump_commit_timestamp)
-from tests.mockers_gitlab import (MockGitLabAPIState,
-                                  mock_gitlab_token_for_domain_fake,
-                                  mock_mr_json, mock_urlopen)
+from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import (add_remote, amend_commit, check_out, commit, create_repo, create_repo_with_remote, delete_branch,
+                                  new_branch, push, remove_remote, reset_to, set_git_config_key, wait_to_bump_commit_timestamp)
+from tests.mockers_gitlab import MockGitLabAPIState, mock_gitlab_token_for_domain_fake, mock_mr_json, mock_urlopen
 
 
 class TestGitLabAnnoMRs(BaseTest):

--- a/tests/test_gitlab_checkout_mrs.py
+++ b/tests/test_gitlab_checkout_mrs.py
@@ -6,17 +6,12 @@ from pytest_mock import MockerFixture
 from git_machete.code_hosting import OrganizationAndRepository
 from git_machete.gitlab import GitLabApi
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success, launch_command,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (add_remote, check_out, commit, create_repo,
-                                  create_repo_with_remote, delete_branch,
-                                  new_branch, push, set_git_config_key,
-                                  set_remote_url)
+from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import (add_remote, check_out, commit, create_repo, create_repo_with_remote, delete_branch, new_branch, push,
+                                  set_git_config_key, set_remote_url)
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_gitlab import (MockGitLabAPIState,
-                                  mock_gitlab_token_for_domain_fake,
-                                  mock_gitlab_token_for_domain_none,
-                                  mock_mr_json, mock_urlopen)
+from tests.mockers_gitlab import (MockGitLabAPIState, mock_gitlab_token_for_domain_fake, mock_gitlab_token_for_domain_none, mock_mr_json,
+                                  mock_urlopen)
 from tests.shell import execute
 
 

--- a/tests/test_gitlab_create_mr.py
+++ b/tests/test_gitlab_create_mr.py
@@ -4,21 +4,14 @@ import textwrap
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success, launch_command,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (add_remote, amend_commit, check_out, commit,
-                                  create_repo, create_repo_with_remote,
-                                  delete_branch, delete_remote_branch,
-                                  new_branch, push, remove_remote, reset_to,
-                                  set_git_config_key,
+from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import (add_remote, amend_commit, check_out, commit, create_repo, create_repo_with_remote, delete_branch,
+                                  delete_remote_branch, new_branch, push, remove_remote, reset_to, set_git_config_key,
                                   wait_to_bump_commit_timestamp)
-from tests.mockers import (fixed_author_and_committer_date_in_past,
-                           mock_input_returning, mock_input_returning_y)
+from tests.mockers import fixed_author_and_committer_date_in_past, mock_input_returning, mock_input_returning_y
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_gitlab import (MockGitLabAPIState,
-                                  mock_gitlab_token_for_domain_fake,
-                                  mock_gitlab_token_for_domain_none,
-                                  mock_mr_json, mock_urlopen)
+from tests.mockers_gitlab import (MockGitLabAPIState, mock_gitlab_token_for_domain_fake, mock_gitlab_token_for_domain_none, mock_mr_json,
+                                  mock_urlopen)
 from tests.shell import execute, write_to_file
 
 

--- a/tests/test_gitlab_restack_mr.py
+++ b/tests/test_gitlab_restack_mr.py
@@ -3,16 +3,11 @@ import textwrap
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (amend_commit, commit,
-                                  create_repo_with_remote, new_branch, push,
-                                  reset_to, set_git_config_key)
+from tests.cli_runner import assert_failure, assert_success, rewrite_branch_layout_file
+from tests.git_repository import amend_commit, commit, create_repo_with_remote, new_branch, push, reset_to, set_git_config_key
 from tests.mockers import fixed_author_and_committer_date_in_past
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_gitlab import (MockGitLabAPIState,
-                                  mock_gitlab_token_for_domain_fake,
-                                  mock_mr_json, mock_urlopen)
+from tests.mockers_gitlab import MockGitLabAPIState, mock_gitlab_token_for_domain_fake, mock_mr_json, mock_urlopen
 
 
 class TestGitLabRestackMR(BaseTest):

--- a/tests/test_gitlab_retarget_mr.py
+++ b/tests/test_gitlab_retarget_mr.py
@@ -3,16 +3,11 @@ import textwrap
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success, launch_command,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (add_remote, check_out, commit, create_repo,
-                                  create_repo_with_remote, new_branch, push,
-                                  remove_remote, set_git_config_key,
-                                  set_remote_url)
+from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import (add_remote, check_out, commit, create_repo, create_repo_with_remote, new_branch, push, remove_remote,
+                                  set_git_config_key, set_remote_url)
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_gitlab import (MockGitLabAPIState,
-                                  mock_gitlab_token_for_domain_fake,
-                                  mock_mr_json, mock_urlopen)
+from tests.mockers_gitlab import MockGitLabAPIState, mock_gitlab_token_for_domain_fake, mock_mr_json, mock_urlopen
 
 
 class TestGitLabRetargetMR(BaseTest):

--- a/tests/test_gitlab_update_mr_descriptions.py
+++ b/tests/test_gitlab_update_mr_descriptions.py
@@ -4,16 +4,11 @@ from typing import Any, Dict, List
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success, launch_command,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (check_out, commit, create_repo_with_remote,
-                                  delete_branch, new_branch, push,
-                                  set_git_config_key)
+from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import check_out, commit, create_repo_with_remote, delete_branch, new_branch, push, set_git_config_key
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_gitlab import (MockGitLabAPIState,
-                                  mock_gitlab_token_for_domain_fake,
-                                  mock_gitlab_token_for_domain_none,
-                                  mock_mr_json, mock_urlopen)
+from tests.mockers_gitlab import (MockGitLabAPIState, mock_gitlab_token_for_domain_fake, mock_gitlab_token_for_domain_none, mock_mr_json,
+                                  mock_urlopen)
 
 
 class TestGitLabUpdateMRDescriptions(BaseTest):

--- a/tests/test_go.py
+++ b/tests/test_go.py
@@ -6,10 +6,8 @@ from pytest_mock import MockerFixture
 from git_machete.git_version_thresholds import WORKTREE_COMMAND
 from git_machete.utils.paths import AbsPath
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success, launch_command,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (add_worktree, check_out, commit, create_repo,
-                                  get_commit_hash, get_git_version, new_branch,
+from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import (add_worktree, check_out, commit, create_repo, get_commit_hash, get_git_version, new_branch,
                                   new_orphan_branch)
 from tests.mockers import mock_input_returning
 

--- a/tests/test_go_interactive.py
+++ b/tests/test_go_interactive.py
@@ -7,11 +7,9 @@ from typing import Any, Tuple, Type
 import pytest
 from pytest_mock import MockerFixture
 
-from git_machete.utils.terminal import (AnsiInputCodes,
-                                        FullTerminalAnsiOutputCodes)
+from git_machete.utils.terminal import AnsiInputCodes, FullTerminalAnsiOutputCodes
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, launch_command,
-                              rewrite_branch_layout_file)
+from tests.cli_runner import assert_failure, launch_command, rewrite_branch_layout_file
 from tests.git_repository import check_out, commit, create_repo, new_branch
 
 AI = AnsiInputCodes

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,12 +1,10 @@
 from typing import List
 
 from git_machete.generated_docs import long_docs
-from git_machete.help import (alias_by_command, command_groups,
-                              commands_and_aliases)
+from git_machete.help import alias_by_command, command_groups, commands_and_aliases
 from git_machete.utils.exceptions import ExitCode
 from tests.base_test import BaseTest
-from tests.cli_runner import (launch_command,
-                              launch_command_capturing_output_and_exception)
+from tests.cli_runner import launch_command, launch_command_capturing_output_and_exception
 from tests.git_repository import create_repo, set_git_config_key
 
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,8 +1,6 @@
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success, launch_command,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (check_out, commit, create_repo_with_remote,
-                                  delete_branch, new_branch, push)
+from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import check_out, commit, create_repo_with_remote, delete_branch, new_branch, push
 
 
 class TestList(BaseTest):

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -2,10 +2,8 @@ from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
 from tests.cli_runner import assert_success, launch_command
-from tests.git_repository import (commit, create_repo, get_current_commit_hash,
-                                  new_branch)
-from tests.mockers import (fixed_author_and_committer_date_in_past,
-                           mock__run_cmd_and_forward_stdout)
+from tests.git_repository import commit, create_repo, get_current_commit_hash, new_branch
+from tests.mockers import fixed_author_and_committer_date_in_past, mock__run_cmd_and_forward_stdout
 
 
 class TestLog(BaseTest):

--- a/tests/test_reapply.py
+++ b/tests/test_reapply.py
@@ -1,9 +1,7 @@
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success, launch_command,
-                              rewrite_branch_layout_file)
+from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
 from tests.git_repository import check_out, commit, create_repo, new_branch
-from tests.mockers import (fixed_author_and_committer_date_in_past,
-                           overridden_environment)
+from tests.mockers import fixed_author_and_committer_date_in_past, overridden_environment
 
 
 class TestReapply(BaseTest):

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -2,11 +2,8 @@ import subprocess
 import textwrap
 
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (check_out, commit, create_repo,
-                                  create_repo_with_remote, get_local_branches,
-                                  new_branch, push)
+from tests.cli_runner import assert_failure, assert_success, rewrite_branch_layout_file
+from tests.git_repository import check_out, commit, create_repo, create_repo_with_remote, get_local_branches, new_branch, push
 from tests.shell import popen
 
 

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -1,11 +1,8 @@
 import os
 
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success, launch_command,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (check_out, commit, create_repo,
-                                  create_repo_with_remote, new_branch,
-                                  new_orphan_branch, pull, push)
+from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import check_out, commit, create_repo, create_repo_with_remote, new_branch, new_orphan_branch, pull, push
 from tests.shell import execute, remove_directory
 
 

--- a/tests/test_slide_out.py
+++ b/tests/test_slide_out.py
@@ -3,16 +3,10 @@ import pytest
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success, launch_command,
-                              read_branch_layout_file,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (amend_commit, check_out, commit, create_repo,
-                                  create_repo_with_remote, delete_branch,
-                                  delete_remote_branch, get_current_branch,
-                                  get_current_commit_hash, get_local_branches,
-                                  new_branch, push)
-from tests.mockers import (fixed_author_and_committer_date_in_past,
-                           mock_input_returning_y)
+from tests.cli_runner import assert_failure, assert_success, launch_command, read_branch_layout_file, rewrite_branch_layout_file
+from tests.git_repository import (amend_commit, check_out, commit, create_repo, create_repo_with_remote, delete_branch,
+                                  delete_remote_branch, get_current_branch, get_current_commit_hash, get_local_branches, new_branch, push)
+from tests.mockers import fixed_author_and_committer_date_in_past, mock_input_returning_y
 from tests.shell import read_file, set_file_executable, write_to_file
 
 

--- a/tests/test_slide_out_worktrees.py
+++ b/tests/test_slide_out_worktrees.py
@@ -5,10 +5,8 @@ import pytest
 from git_machete.git_version_thresholds import WORKTREE_COMMAND
 from git_machete.utils.paths import AbsPath
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, read_branch_layout_file,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (add_worktree, check_out, commit, create_repo,
-                                  get_git_version, new_branch)
+from tests.cli_runner import assert_failure, read_branch_layout_file, rewrite_branch_layout_file
+from tests.git_repository import add_worktree, check_out, commit, create_repo, get_git_version, new_branch
 
 # pytestmark is a special variable that pytest recognizes automatically.
 # It applies the specified marks to all test functions in this module.

--- a/tests/test_squash.py
+++ b/tests/test_squash.py
@@ -1,10 +1,8 @@
 
 from tests.base_test import BaseTest
 from tests.cli_runner import assert_failure, assert_success
-from tests.git_repository import (check_out, commit, create_repo,
-                                  get_current_commit_hash, new_branch)
-from tests.mockers import (fixed_author_and_committer_date_in_past,
-                           overridden_environment)
+from tests.git_repository import check_out, commit, create_repo, get_current_commit_hash, new_branch
+from tests.mockers import fixed_author_and_committer_date_in_past, overridden_environment
 from tests.shell import popen
 
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -8,19 +8,12 @@ from pytest_mock import MockerFixture
 from git_machete.utils.paths import AbsPath
 from git_machete.utils.terminal import FullTerminalAnsiOutputCodes
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success, launch_command,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (add_file_and_commit, add_remote, check_out,
-                                  commit, commit_n_times, create_repo,
-                                  create_repo_with_remote, delete_branch,
-                                  delete_remote_branch, new_branch,
-                                  new_orphan_branch, push, reset_to,
-                                  set_git_config_key, unset_git_config_key)
-from tests.mockers import (fixed_author_and_committer_date_in_past,
-                           mock_input_returning, mock_input_returning_y,
-                           overridden_environment)
-from tests.shell import (execute, execute_ignoring_exit_code, popen,
-                         remove_directory, set_file_executable, write_to_file)
+from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import (add_file_and_commit, add_remote, check_out, commit, commit_n_times, create_repo, create_repo_with_remote,
+                                  delete_branch, delete_remote_branch, new_branch, new_orphan_branch, push, reset_to, set_git_config_key,
+                                  unset_git_config_key)
+from tests.mockers import fixed_author_and_committer_date_in_past, mock_input_returning, mock_input_returning_y, overridden_environment
+from tests.shell import execute, execute_ignoring_exit_code, popen, remove_directory, set_file_executable, write_to_file
 
 
 class TestStatus(BaseTest):

--- a/tests/test_status_worktrees.py
+++ b/tests/test_status_worktrees.py
@@ -8,11 +8,9 @@ from git_machete.git_version_thresholds import WORKTREE_COMMAND
 from git_machete.utils.paths import AbsPath
 from git_machete.utils.terminal import FullTerminalAnsiOutputCodes
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_success, launch_command,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (add_detached_worktree, add_worktree,
-                                  check_out, commit, create_repo, detach_head,
-                                  get_git_version, new_branch)
+from tests.cli_runner import assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import (add_detached_worktree, add_worktree, check_out, commit, create_repo, detach_head, get_git_version,
+                                  new_branch)
 
 pytestmark = pytest.mark.skipif(  # noqa: F841
     get_git_version() < WORKTREE_COMMAND,

--- a/tests/test_traverse.py
+++ b/tests/test_traverse.py
@@ -8,24 +8,15 @@ from typing import ClassVar, Optional, Tuple
 import pytest
 from pytest_mock import MockerFixture
 
-from git_machete.git_version_thresholds import (CWD_REMOVAL_HANDLED_BY_GIT,
-                                                REBASE_EMPTY_DROP)
+from git_machete.git_version_thresholds import CWD_REMOVAL_HANDLED_BY_GIT, REBASE_EMPTY_DROP
 from git_machete.utils.exceptions import UnderlyingGitException
 from git_machete.utils.terminal import FullTerminalAnsiOutputCodes
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_argument_error, assert_failure,
-                              assert_success, launch_command,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (add_file_and_commit, add_remote,
-                                  amend_commit, check_out, commit, create_repo,
-                                  create_repo_with_remote, delete_branch,
-                                  get_current_branch, get_git_version, merge,
-                                  new_branch, push, remove_remote, reset_to,
-                                  set_git_config_key, set_remote_url,
-                                  wait_to_bump_commit_timestamp)
-from tests.mockers import (fixed_author_and_committer_date_in_past,
-                           mock_input_returning, mock_input_returning_y,
-                           overridden_environment)
+from tests.cli_runner import assert_argument_error, assert_failure, assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import (add_file_and_commit, add_remote, amend_commit, check_out, commit, create_repo, create_repo_with_remote,
+                                  delete_branch, get_current_branch, get_git_version, merge, new_branch, push, remove_remote, reset_to,
+                                  set_git_config_key, set_remote_url, wait_to_bump_commit_timestamp)
+from tests.mockers import fixed_author_and_committer_date_in_past, mock_input_returning, mock_input_returning_y, overridden_environment
 from tests.shell import write_to_file
 
 

--- a/tests/test_traverse_github.py
+++ b/tests/test_traverse_github.py
@@ -3,15 +3,11 @@ import textwrap
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (check_out, commit, create_repo_with_remote,
-                                  new_branch, push)
+from tests.cli_runner import assert_failure, assert_success, rewrite_branch_layout_file
+from tests.git_repository import check_out, commit, create_repo_with_remote, new_branch, push
 from tests.mockers import mock_input_returning
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_github import (MockGitHubAPIState,
-                                  mock_github_token_for_domain_fake,
-                                  mock_pr_json, mock_urlopen)
+from tests.mockers_github import MockGitHubAPIState, mock_github_token_for_domain_fake, mock_pr_json, mock_urlopen
 
 
 class TestTraverseGitHub(BaseTest):

--- a/tests/test_traverse_gitlab.py
+++ b/tests/test_traverse_gitlab.py
@@ -3,15 +3,11 @@ import textwrap
 from pytest_mock import MockerFixture
 
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (check_out, commit, create_repo_with_remote,
-                                  new_branch, push)
+from tests.cli_runner import assert_failure, assert_success, rewrite_branch_layout_file
+from tests.git_repository import check_out, commit, create_repo_with_remote, new_branch, push
 from tests.mockers import mock_input_returning
 from tests.mockers_code_hosting import mock_from_url
-from tests.mockers_gitlab import (MockGitLabAPIState,
-                                  mock_gitlab_token_for_domain_fake,
-                                  mock_mr_json, mock_urlopen)
+from tests.mockers_gitlab import MockGitLabAPIState, mock_gitlab_token_for_domain_fake, mock_mr_json, mock_urlopen
 
 
 class TestTraverseGitLab(BaseTest):

--- a/tests/test_traverse_worktrees.py
+++ b/tests/test_traverse_worktrees.py
@@ -4,20 +4,14 @@ import subprocess
 import pytest
 from pytest_mock import MockerFixture
 
-from git_machete.git_version_thresholds import (REBASE_EMPTY_DROP,
-                                                WORKTREE_COMMAND)
+from git_machete.git_version_thresholds import REBASE_EMPTY_DROP, WORKTREE_COMMAND
 from git_machete.utils.exceptions import UnderlyingGitException
 from git_machete.utils.paths import AbsPath
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success, launch_command,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (add_file_and_commit, add_worktree, check_out,
-                                  commit, create_repo_with_remote,
-                                  get_current_branch, get_git_version,
-                                  get_worktree_dirs, new_branch, push,
-                                  set_git_config_key)
-from tests.mockers import (fixed_author_and_committer_date_in_past,
-                           mock_input_returning)
+from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import (add_file_and_commit, add_worktree, check_out, commit, create_repo_with_remote, get_current_branch,
+                                  get_git_version, get_worktree_dirs, new_branch, push, set_git_config_key)
+from tests.mockers import fixed_author_and_committer_date_in_past, mock_input_returning
 
 # pytestmark is a special variable that pytest recognizes automatically.
 # It applies the specified marks to all test functions in this module.

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -4,18 +4,11 @@ from git_machete.git_version_thresholds import REBASE_EMPTY_DROP
 from git_machete.utils.exceptions import UnderlyingGitException
 from git_machete.utils.terminal import FullTerminalAnsiOutputCodes
 from tests.base_test import BaseTest
-from tests.cli_runner import (assert_failure, assert_success, launch_command,
-                              rewrite_branch_layout_file)
-from tests.git_repository import (add_file_and_commit, check_out, commit,
-                                  create_repo, get_commit_hash,
-                                  get_current_commit_hash, get_git_version,
-                                  is_ancestor_or_equal, new_branch,
-                                  new_orphan_branch)
-from tests.mockers import (fixed_author_and_committer_date_in_past,
-                           mock_input_returning, mock_input_returning_y,
-                           overridden_environment)
-from tests.shell import (execute, execute_ignoring_exit_code, popen, read_file,
-                         set_file_executable, write_to_file)
+from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
+from tests.git_repository import (add_file_and_commit, check_out, commit, create_repo, get_commit_hash, get_current_commit_hash,
+                                  get_git_version, is_ancestor_or_equal, new_branch, new_orphan_branch)
+from tests.mockers import fixed_author_and_committer_date_in_past, mock_input_returning, mock_input_returning_y, overridden_environment
+from tests.shell import execute, execute_ignoring_exit_code, popen, read_file, set_file_executable, write_to_file
 
 
 class TestUpdate(BaseTest):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,8 +11,7 @@ from git_machete.utils.date import get_current_date
 from git_machete.utils.debug_log import debug, hex_repr
 from git_machete.utils.markup import _fmt
 from git_machete.utils.paths import AbsPath, strip_longest_common_path_prefix
-from git_machete.utils.terminal import (BasicTerminalAnsiOutputCodes,
-                                        FullTerminalAnsiOutputCodes)
+from git_machete.utils.terminal import BasicTerminalAnsiOutputCodes, FullTerminalAnsiOutputCodes
 from tests.base_test import BaseTest
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -136,6 +136,11 @@ extension =
   KW = keyword_argument_checker:KeywordArgumentChecker
 paths = flake8
 
+# Set isort configuration options which are used by the `isort` command in [testenv:isort] and [testenv:isort-check].
+# Keep `line_length` in sync with `max-line-length` in the [flake8] section above.
+[isort]
+line_length = 140
+
 [testenv:isort]
 description = "Tidy up imports in Python code"
 deps =


### PR DESCRIPTION
isort previously fell back to its default `line_length` of 79, so it wrapped multi-name imports far more aggressively than the 140-column limit enforced by flake8 (`max-line-length = 140`).
Add an `[isort]` section to `tox.ini` pinning `line_length = 140`, and run `tox -e isort` to repack the now-shorter imports across the codebase.