### PR TITLE
Push head/source branch only to the code-hosting-determined remote in github/gitlab commands

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 ## New in git-machete 3.43.1
 
+- changed: `git machete {github,gitlab} create-{pr,mr}` and `restack-{pr,mr}` now push the head/source branch to the remote
+  determined by the code-hosting logic (the `machete.{github,gitlab}.remote` git config key when set, otherwise the remote inferred from the matching remote URL), consistently with how the base/target branch is already handled;
+  in an ambiguous multi-remote setup with no remote configured, they now abort asking for the relevant git config keys rather than prompting to pick a remote interactively
+
 ## New in git-machete 3.43.0
 
 - changed: `git machete slide-out` no longer requires the given branches to form a chain; literally any set of managed branches can be slid out at once, with each slid-out branch's surviving children reattached to (and, unless `--no-rebase` is passed, rebased/merged onto) that branch's nearest surviving ancestor

--- a/docs/man/git-machete.1
+++ b/docs/man/git-machete.1
@@ -321,8 +321,12 @@ Note: \fBconfig\fP is not a command as such, just a help topic (there is no \fBg
 \fBGit config keys\fP
 .INDENT 0.0
 .TP
-.B \fBmachete.github.{remote,domain,organization,repository}\fP
+.B \fBmachete.github.{domain,remote,organization,repository}\fP
 .INDENT 7.0
+.TP
+.B \fBmachete.github.domain\fP
+The domain of the GitHub API server, for use with GitHub Enterprise; otherwise inferred from the remote URL.
+For example, \fBgit config machete.github.domain git.example.org\fP
 .TP
 .B \fBmachete.github.remote\fP
 The name of the git remote (as in \fBgit remote\fP) that git\-machete pushes the head branch to.
@@ -332,10 +336,6 @@ The pull request is operated on through the GitHub API, which addresses that org
 By default (when this key is unset), if exactly one remote\(aqs URL corresponds to GitHub, that remote is selected automatically;
 set this key to disambiguate when more than one remote points to GitHub.
 For example, \fBgit config machete.github.remote origin\fP
-.TP
-.B \fBmachete.github.domain\fP
-The domain of the GitHub API server, for use with GitHub Enterprise; otherwise inferred from the remote URL.
-For example, \fBgit config machete.github.domain git.example.org\fP
 .TP
 .B \fBmachete.github.organization\fP
 The GitHub organization (the part before \fB/\fP in \fBorganization/repository\fP); otherwise inferred from the remote URL.
@@ -379,8 +379,12 @@ from the message body of the first unique commit of the branch, even if \fB\&.gi
 .UNINDENT
 .UNINDENT
 .TP
-.B \fBmachete.gitlab.{remote,domain,namespace,project}\fP
+.B \fBmachete.gitlab.{domain,remote,namespace,project}\fP
 .INDENT 7.0
+.TP
+.B \fBmachete.gitlab.domain\fP
+The domain of the GitLab API server, for use with a GitLab self\-managed instance; otherwise inferred from the remote URL.
+For example, \fBgit config machete.gitlab.domain git.example.org\fP
 .TP
 .B \fBmachete.gitlab.remote\fP
 The name of the git remote (as in \fBgit remote\fP) that git\-machete pushes the source branch to.
@@ -390,10 +394,6 @@ The merge request is operated on through the GitLab API, which addresses that na
 By default (when this key is unset), if exactly one remote\(aqs URL corresponds to GitLab, that remote is selected automatically;
 set this key to disambiguate when more than one remote points to GitLab.
 For example, \fBgit config machete.gitlab.remote origin\fP
-.TP
-.B \fBmachete.gitlab.domain\fP
-The domain of the GitLab API server, for use with a GitLab self\-managed instance; otherwise inferred from the remote URL.
-For example, \fBgit config machete.gitlab.domain git.example.org\fP
 .TP
 .B \fBmachete.gitlab.namespace\fP
 The GitLab namespace (the part before the final \fB/\fP in \fBnamespace/project\fP); otherwise inferred from the remote URL.
@@ -1159,8 +1159,12 @@ Update PR descriptions for all PRs both upstream and downstream of the PR for th
 \fBGit config keys\fP
 .INDENT 0.0
 .TP
-.B \fBmachete.github.{remote,domain,organization,repository}\fP (all subcommands)
+.B \fBmachete.github.{domain,remote,organization,repository}\fP (all subcommands)
 .INDENT 7.0
+.TP
+.B \fBmachete.github.domain\fP
+The domain of the GitHub API server, for use with GitHub Enterprise; otherwise inferred from the remote URL.
+For example, \fBgit config machete.github.domain git.example.org\fP
 .TP
 .B \fBmachete.github.remote\fP
 The name of the git remote (as in \fBgit remote\fP) that git\-machete pushes the head branch to.
@@ -1170,10 +1174,6 @@ The pull request is operated on through the GitHub API, which addresses that org
 By default (when this key is unset), if exactly one remote\(aqs URL corresponds to GitHub, that remote is selected automatically;
 set this key to disambiguate when more than one remote points to GitHub.
 For example, \fBgit config machete.github.remote origin\fP
-.TP
-.B \fBmachete.github.domain\fP
-The domain of the GitHub API server, for use with GitHub Enterprise; otherwise inferred from the remote URL.
-For example, \fBgit config machete.github.domain git.example.org\fP
 .TP
 .B \fBmachete.github.organization\fP
 The GitHub organization (the part before \fB/\fP in \fBorganization/repository\fP); otherwise inferred from the remote URL.
@@ -1433,8 +1433,12 @@ Update MR descriptions for all MRs both upstream and downstream of the MR for th
 \fBGit config keys\fP
 .INDENT 0.0
 .TP
-.B \fBmachete.gitlab.{remote,domain,namespace,project}\fP (all subcommands)
+.B \fBmachete.gitlab.{domain,remote,namespace,project}\fP (all subcommands)
 .INDENT 7.0
+.TP
+.B \fBmachete.gitlab.domain\fP
+The domain of the GitLab API server, for use with a GitLab self\-managed instance; otherwise inferred from the remote URL.
+For example, \fBgit config machete.gitlab.domain git.example.org\fP
 .TP
 .B \fBmachete.gitlab.remote\fP
 The name of the git remote (as in \fBgit remote\fP) that git\-machete pushes the source branch to.
@@ -1444,10 +1448,6 @@ The merge request is operated on through the GitLab API, which addresses that na
 By default (when this key is unset), if exactly one remote\(aqs URL corresponds to GitLab, that remote is selected automatically;
 set this key to disambiguate when more than one remote points to GitLab.
 For example, \fBgit config machete.gitlab.remote origin\fP
-.TP
-.B \fBmachete.gitlab.domain\fP
-The domain of the GitLab API server, for use with a GitLab self\-managed instance; otherwise inferred from the remote URL.
-For example, \fBgit config machete.gitlab.domain git.example.org\fP
 .TP
 .B \fBmachete.gitlab.namespace\fP
 The GitLab namespace (the part before the final \fB/\fP in \fBnamespace/project\fP); otherwise inferred from the remote URL.

--- a/docs/source/cli/config.rst
+++ b/docs/source/cli/config.rst
@@ -8,7 +8,7 @@ Note: ``config`` is not a command as such, just a help topic (there is no ``git 
 
 **Git config keys**
 
-``machete.github.{remote,domain,organization,repository}``
+``machete.github.{domain,remote,organization,repository}``
   .. include:: git-config-keys/github_access.rst
 
 ``machete.github.annotateWithUrls``
@@ -20,7 +20,7 @@ Note: ``config`` is not a command as such, just a help topic (there is no ``git 
 ``machete.github.prDescriptionIntroStyle``
   .. include:: git-config-keys/github_prDescriptionIntroStyle.rst
 
-``machete.gitlab.{remote,domain,namespace,project}``
+``machete.gitlab.{domain,remote,namespace,project}``
   .. include:: git-config-keys/gitlab_access.rst
 
 ``machete.gitlab.annotateWithUrls``

--- a/docs/source/cli/github.rst
+++ b/docs/source/cli/github.rst
@@ -165,7 +165,7 @@ Create, check out and manage GitHub PRs while keeping them reflected in branch l
 
 **Git config keys**
 
-``machete.github.{remote,domain,organization,repository}`` (all subcommands)
+``machete.github.{domain,remote,organization,repository}`` (all subcommands)
   .. include:: git-config-keys/github_access.rst
 
 ``machete.github.annotateWithUrls`` (all subcommands)

--- a/docs/source/cli/gitlab.rst
+++ b/docs/source/cli/gitlab.rst
@@ -156,7 +156,7 @@ Create, check out and manage GitLab MRs while keeping them reflected in branch l
 
 **Git config keys**
 
-``machete.gitlab.{remote,domain,namespace,project}`` (all subcommands)
+``machete.gitlab.{domain,remote,namespace,project}`` (all subcommands)
   .. include:: git-config-keys/gitlab_access.rst
 
 ``machete.gitlab.annotateWithUrls`` (all subcommands)

--- a/docs/source/git-config-keys/github_access.rst
+++ b/docs/source/git-config-keys/github_access.rst
@@ -1,3 +1,7 @@
+``machete.github.domain``
+    The domain of the GitHub API server, for use with GitHub Enterprise; otherwise inferred from the remote URL.
+    For example, ``git config machete.github.domain git.example.org``
+
 ``machete.github.remote``
     The name of the git remote (as in ``git remote``) that git-machete pushes the head branch to.
     Unless both ``machete.github.organization`` and ``machete.github.repository`` are set, this remote's URL is also inspected
@@ -6,10 +10,6 @@
     By default (when this key is unset), if exactly one remote's URL corresponds to GitHub, that remote is selected automatically;
     set this key to disambiguate when more than one remote points to GitHub.
     For example, ``git config machete.github.remote origin``
-
-``machete.github.domain``
-    The domain of the GitHub API server, for use with GitHub Enterprise; otherwise inferred from the remote URL.
-    For example, ``git config machete.github.domain git.example.org``
 
 ``machete.github.organization``
     The GitHub organization (the part before ``/`` in ``organization/repository``); otherwise inferred from the remote URL.

--- a/docs/source/git-config-keys/gitlab_access.rst
+++ b/docs/source/git-config-keys/gitlab_access.rst
@@ -1,3 +1,7 @@
+``machete.gitlab.domain``
+    The domain of the GitLab API server, for use with a GitLab self-managed instance; otherwise inferred from the remote URL.
+    For example, ``git config machete.gitlab.domain git.example.org``
+
 ``machete.gitlab.remote``
     The name of the git remote (as in ``git remote``) that git-machete pushes the source branch to.
     Unless both ``machete.gitlab.namespace`` and ``machete.gitlab.project`` are set, this remote's URL is also inspected
@@ -6,10 +10,6 @@
     By default (when this key is unset), if exactly one remote's URL corresponds to GitLab, that remote is selected automatically;
     set this key to disambiguate when more than one remote points to GitLab.
     For example, ``git config machete.gitlab.remote origin``
-
-``machete.gitlab.domain``
-    The domain of the GitLab API server, for use with a GitLab self-managed instance; otherwise inferred from the remote URL.
-    For example, ``git config machete.gitlab.domain git.example.org``
 
 ``machete.gitlab.namespace``
     The GitLab namespace (the part before the final ``/`` in ``namespace/project``); otherwise inferred from the remote URL.

--- a/git_machete/client/with_code_hosting.py
+++ b/git_machete/client/with_code_hosting.py
@@ -1,6 +1,6 @@
 import itertools
 import os
-from typing import Callable, Dict, Iterator, List, Optional, Set, Tuple
+from typing import Dict, Iterator, List, Optional, Set, Tuple
 
 from git_machete.annotation import Annotation, Qualifiers
 from git_machete.client.state import ManagedBranchName
@@ -118,6 +118,15 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
                 return remote
         return None
 
+    def __get_sync_to_remote_status_against(self, *, branch: LocalBranchShortName, remote: str) -> SyncToRemoteStatus:
+        # Unlike `git.get_combined_remote_sync_status`, which compares the branch against its tracking/inferred
+        # counterpart (which may live on a different remote), this compares it specifically against `remote` -
+        # the remote determined by the code-hosting logic, i.e. the only remote that {github,gitlab} commands push to.
+        remote_branch = RemoteBranchShortName(f"{remote}/{branch}")
+        if not self._git.get_commit_hash_by_revision(remote_branch):
+            return SyncToRemoteStatus.UNTRACKED
+        return self._git.get_relation_to_remote_counterpart(branch, remote_branch)
+
     def sync_before_creating_pull_request(self, *, opt_yes: bool) -> None:
         spec = self.code_hosting_spec
         self.expect_at_least_one_managed_branch()
@@ -153,7 +162,13 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
                 f'All commits in <b>{current_branch}</b> branch are already included in <b>{up_branch}</b> branch.\n'
                 f'Cannot create {spec.pr_full_name}.')
 
-        s, remote = self._git.get_combined_remote_sync_status(current_branch)
+        if not self._git.get_remotes():
+            raise MacheteException(
+                f"Could not create {spec.pr_full_name} - there are no remote repositories!")
+
+        domain = self.__derive_code_hosting_domain()
+        remote = self.__derive_org_repo_and_remote(domain=domain, branch_used_for_tracking_data=current_branch).remote
+        s = self.__get_sync_to_remote_status_against(branch=current_branch, remote=remote)
         statuses_to_push = (
             SyncToRemoteStatus.UNTRACKED,
             SyncToRemoteStatus.AHEAD_OF_REMOTE,
@@ -162,7 +177,6 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             anno = self._state.get_annotation(current_branch)
             if anno is None or anno.qualifiers.push:
                 if s == SyncToRemoteStatus.AHEAD_OF_REMOTE:
-                    assert remote is not None
                     self.__handle_ahead_state(
                         current_branch=current_branch,
                         remote=remote,
@@ -171,11 +185,10 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
                 elif s == SyncToRemoteStatus.UNTRACKED:
                     self.__handle_untracked_state(
                         branch=current_branch,
-                        opt_push_tracked=True,
+                        new_remote=remote,
                         opt_push_untracked=True,
                         opt_yes=opt_yes)
                 elif s == SyncToRemoteStatus.DIVERGED_FROM_AND_NEWER_THAN_REMOTE:
-                    assert remote is not None
                     self.__handle_diverged_and_newer_state(
                         current_branch=current_branch,
                         remote=remote,
@@ -204,9 +217,6 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
                 self._ensure_blank_separator()
                 ans = self.ask_if(f"Proceed with creating {spec.pr_full_name}?" + pretty_choices('y', 'Q'),
                                   f"Proceeding with {spec.pr_full_name} creation...", opt_yes=opt_yes)
-            elif s == SyncToRemoteStatus.NO_REMOTES:
-                raise MacheteException(
-                    f"Could not create {spec.pr_full_name} - there are no remote repositories!")
             else:
                 ans = 'y'  # only IN SYNC status is left
 
@@ -318,7 +328,6 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             self.__handle_untracked_branch(
                 branch=base,
                 new_remote=base_org_repo_remote.remote,
-                opt_push_tracked=False,
                 opt_push_untracked=True,
                 opt_yes=opt_yes)
 
@@ -433,7 +442,8 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
 
         self._mark_trailing_blank_line()
         current_branch = self._git.get_current_branch()
-        s, remote = self._git.get_combined_remote_sync_status(current_branch)
+        remote = org_repo_remote.remote
+        s = self.__get_sync_to_remote_status_against(branch=current_branch, remote=remote)
         statuses_to_push = (
             SyncToRemoteStatus.UNTRACKED,
             SyncToRemoteStatus.AHEAD_OF_REMOTE,
@@ -455,7 +465,6 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
                                        opt_update_related_descriptions=opt_update_related_descriptions)
 
             if s == SyncToRemoteStatus.AHEAD_OF_REMOTE:
-                assert remote is not None
                 self.__handle_ahead_state(
                     current_branch=current_branch,
                     remote=remote,
@@ -464,11 +473,10 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             elif s == SyncToRemoteStatus.UNTRACKED:
                 self.__handle_untracked_state(
                     branch=current_branch,
-                    opt_push_tracked=True,
+                    new_remote=remote,
                     opt_push_untracked=True,
                     opt_yes=True)
             elif s == SyncToRemoteStatus.DIVERGED_FROM_AND_NEWER_THAN_REMOTE:
-                assert remote is not None
                 self.__handle_diverged_and_newer_state(
                     current_branch=current_branch,
                     remote=remote,
@@ -995,157 +1003,42 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             new_remote: str,
             branch: LocalBranchShortName,
             opt_push_untracked: bool,
-            opt_push_tracked: bool,
             opt_yes: bool
     ) -> None:
-        remote_branch = RemoteBranchShortName.of(f"{new_remote}/{branch}")
-        if not self._git.get_commit_hash_by_revision(remote_branch):
-            ask_message = f"Push untracked branch <b>{branch}</b> to <b>{new_remote}</b>?" + pretty_choices('y', 'Q')
-            ask_opt_yes_message = f"Pushing untracked branch <b>{branch}</b> to <b>{new_remote}</b>..."
-            ans = self.ask_if(
-                ask_message,
-                ask_opt_yes_message,
-                opt_yes=opt_yes,
-                override_answer=None if opt_push_untracked else "N")
-            if ans in ('y', 'yes'):
-                self._git.push(new_remote, branch)
-            else:
-                raise InteractionStopped
-            return
-
-        relation = self._git.get_relation_to_remote_counterpart(branch, remote_branch)
-
-        message: str = {
-            SyncToRemoteStatus.IN_SYNC_WITH_REMOTE:
-                f"Branch <b>{branch}</b> is untracked, but its remote counterpart candidate <b>{remote_branch}</b> "
-                f"already exists and both branches point to the same commit.",
-            SyncToRemoteStatus.BEHIND_REMOTE:
-                f"Branch <b>{branch}</b> is untracked, but its remote counterpart candidate <b>{remote_branch}</b> "
-                f"already exists and is ahead of <b>{branch}</b>.",
-            SyncToRemoteStatus.AHEAD_OF_REMOTE:
-                f"Branch <b>{branch}</b> is untracked, but its remote counterpart candidate <b>{remote_branch}</b> "
-                f"already exists and is behind <b>{branch}</b>.",
-            SyncToRemoteStatus.DIVERGED_FROM_AND_OLDER_THAN_REMOTE:
-                f"Branch <b>{branch}</b> is untracked, it diverged from its remote counterpart candidate <b>{remote_branch}</b>, "
-                f"and has <b>older</b> commits than <b>{remote_branch}</b>.",
-            SyncToRemoteStatus.DIVERGED_FROM_AND_NEWER_THAN_REMOTE:
-                f"Branch <b>{branch}</b> is untracked, it diverged from its remote counterpart candidate <b>{remote_branch}</b>, "
-                f"and has <b>newer</b> commits than <b>{remote_branch}</b>."
-        }[SyncToRemoteStatus(relation)]
-
-        ask_message, ask_opt_yes_message = {
-            SyncToRemoteStatus.IN_SYNC_WITH_REMOTE: (
-                f"Set the remote of <b>{branch}</b> to <b>{new_remote}</b> without pushing or pulling?" +
-                pretty_choices('y', 'N', 'q', 'yq'),
-                f"Setting the remote of <b>{branch}</b> to <b>{new_remote}</b>..."
-            ),
-            SyncToRemoteStatus.BEHIND_REMOTE: (
-                f"Pull <b>{branch}</b> (fast-forward only) from <b>{new_remote}</b>?" +
-                pretty_choices('y', 'N', 'q', 'yq'),
-                f"Pulling <b>{branch}</b> (fast-forward only) from <b>{new_remote}</b>..."
-            ),
-            SyncToRemoteStatus.AHEAD_OF_REMOTE: (
-                f"Push branch <b>{branch}</b> to <b>{new_remote}</b>?" + pretty_choices('y', 'N', 'q', 'yq'),
-                f"Pushing branch <b>{branch}</b> to <b>{new_remote}</b>..."
-            ),
-            SyncToRemoteStatus.DIVERGED_FROM_AND_OLDER_THAN_REMOTE: (
-                f"Reset branch <b>{branch}</b> to the commit pointed by <b>{remote_branch}</b>?" +
-                pretty_choices('y', 'N', 'q', 'yq'),
-                f"Resetting branch <b>{branch}</b> to the commit pointed by <b>{remote_branch}</b>..."
-            ),
-            SyncToRemoteStatus.DIVERGED_FROM_AND_NEWER_THAN_REMOTE: (
-                f"Push branch <b>{branch}</b> with force-with-lease to <b>{new_remote}</b>?" +
-                pretty_choices('y', 'N', 'q', 'yq'),
-                f"Pushing branch <b>{branch}</b> with force-with-lease to <b>{new_remote}</b>..."
-            )
-        }[SyncToRemoteStatus(relation)]
-
-        override_answer: Optional[str] = {
-            SyncToRemoteStatus.IN_SYNC_WITH_REMOTE: None,
-            SyncToRemoteStatus.BEHIND_REMOTE: None,
-            SyncToRemoteStatus.AHEAD_OF_REMOTE: None if opt_push_tracked else "N",
-            SyncToRemoteStatus.DIVERGED_FROM_AND_OLDER_THAN_REMOTE: None,
-            SyncToRemoteStatus.DIVERGED_FROM_AND_NEWER_THAN_REMOTE: None if opt_push_tracked else "N",
-        }[SyncToRemoteStatus(relation)]
-
-        yes_action: Callable[[], None] = {
-            SyncToRemoteStatus.IN_SYNC_WITH_REMOTE: lambda: self._git.set_upstream_to(remote_branch),
-            SyncToRemoteStatus.BEHIND_REMOTE: lambda: self._git.pull_ff_only(new_remote, remote_branch),
-            SyncToRemoteStatus.AHEAD_OF_REMOTE: lambda: self._git.push(new_remote, branch),
-            SyncToRemoteStatus.DIVERGED_FROM_AND_OLDER_THAN_REMOTE: lambda: self._git.reset_keep(remote_branch),
-            SyncToRemoteStatus.DIVERGED_FROM_AND_NEWER_THAN_REMOTE: lambda: self._git.push(
-                new_remote, branch, force_with_lease=True)
-        }[SyncToRemoteStatus(relation)]
-
-        print_fmt(message)
-        ans = self.ask_if(ask_message, ask_opt_yes_message, override_answer=override_answer, opt_yes=opt_yes)
-        if ans in ('y', 'yes', 'yq'):
-            yes_action()
-            if ans == 'yq':
-                raise InteractionStopped
-        elif ans in ('q', 'quit'):
+        # In the {github,gitlab} flows this is only ever reached for a branch whose `<new_remote>/<branch>` counterpart
+        # does not exist yet: the sync-to-remote status is computed against that exact remote (see
+        # `__get_sync_to_remote_status_against`), so an already-existing counterpart yields a non-UNTRACKED status
+        # handled by the ahead/diverged/etc. branches instead. Hence - unlike the traverse variant - there is no
+        # remote-counterpart-already-exists case (set upstream / pull / reset / force-push) to handle here.
+        ask_message = f"Push untracked branch <b>{branch}</b> to <b>{new_remote}</b>?" + pretty_choices('y', 'Q')
+        ask_opt_yes_message = f"Pushing untracked branch <b>{branch}</b> to <b>{new_remote}</b>..."
+        ans = self.ask_if(
+            ask_message,
+            ask_opt_yes_message,
+            opt_yes=opt_yes,
+            override_answer=None if opt_push_untracked else "N")
+        if ans in ('y', 'yes'):
+            self._git.push(new_remote, branch)
+        else:
             raise InteractionStopped
 
     def __handle_untracked_state(
             self,
             *,
             branch: LocalBranchShortName,
-            opt_push_tracked: bool,
+            new_remote: str,
             opt_push_untracked: bool,
             opt_yes: bool
     ) -> None:
-        remotes: List[str] = self._git.get_remotes()
+        # In {github,gitlab} commands the destination remote is determined by the code-hosting logic
+        # (the `machete.{github,gitlab}.remote` git config key when set, otherwise the remote inferred from the
+        # matching remote URL), so - unlike `traverse` - there's no generic origin/single-remote/interactive selection here.
         self._ensure_blank_separator()
-        if len(remotes) == 1:
-            self.__handle_untracked_branch(
-                new_remote=remotes[0],
-                branch=branch,
-                opt_push_untracked=opt_push_untracked,
-                opt_push_tracked=opt_push_tracked,
-                opt_yes=opt_yes)
-        elif "origin" in remotes:
-            self.__handle_untracked_branch(
-                new_remote="origin",
-                branch=branch,
-                opt_push_untracked=opt_push_untracked,
-                opt_push_tracked=opt_push_tracked,
-                opt_yes=opt_yes)
-        else:
-            # We know that there is at least 1 remote, otherwise sync-to-remote state would be NO_REMOTES and not UNTRACKED
-            print_fmt(f"Branch <b>{branch}</b> is untracked and there's no <b>origin</b> remote.")
-            self.__pick_remote(
-                branch=branch,
-                opt_push_untracked=opt_push_untracked,
-                opt_push_tracked=opt_push_tracked,
-                opt_yes=opt_yes)
-
-    def __pick_remote(
-            self,
-            *,
-            branch: LocalBranchShortName,
-            opt_push_untracked: bool,
-            opt_push_tracked: bool,
-            opt_yes: bool
-    ) -> None:
-        rems = self._git.get_remotes()
-        print("\n".join(f"[{index + 1}] {rem}" for index, rem in enumerate(rems)))
-        msg = f"Select number 1..{len(rems)} to specify the destination remote " \
-            "repository, or 'q' to quit the operation: "
-        ans = input(msg).lower()
-        if ans in ('q', 'quit'):
-            raise InteractionStopped
-        try:
-            index = int(ans) - 1
-            if index not in range(len(rems)):
-                raise MacheteException(f"Invalid index: {index + 1}")
-            self.__handle_untracked_branch(
-                new_remote=rems[index],
-                branch=branch,
-                opt_push_untracked=opt_push_untracked,
-                opt_push_tracked=opt_push_tracked,
-                opt_yes=opt_yes)
-        except ValueError:
-            raise MacheteException('Could not establish remote repository, operation interrupted.')
+        self.__handle_untracked_branch(
+            new_remote=new_remote,
+            branch=branch,
+            opt_push_untracked=opt_push_untracked,
+            opt_yes=opt_yes)
 
     def __handle_ahead_state(
             self,

--- a/git_machete/generated_docs.py
+++ b/git_machete/generated_docs.py
@@ -244,7 +244,11 @@ long_docs: Dict[str, str] = {
 
         <b>Git config keys</b>
 
-           `machete.github.{remote,domain,organization,repository}`
+           `machete.github.{domain,remote,organization,repository}`
+             `machete.github.domain`
+                The domain of the GitHub API server, for use with GitHub Enterprise; otherwise inferred from the remote URL.
+                For example, `git config machete.github.domain git.example.org`
+
              `machete.github.remote`
                 The name of the git remote (as in `git remote`) that git-machete pushes the head branch to.
                 Unless both `machete.github.organization` and `machete.github.repository` are set, this remote's URL is also inspected
@@ -253,10 +257,6 @@ long_docs: Dict[str, str] = {
                 By default (when this key is unset), if exactly one remote's URL corresponds to GitHub, that remote is selected automatically;
                 set this key to disambiguate when more than one remote points to GitHub.
                 For example, `git config machete.github.remote origin`
-
-             `machete.github.domain`
-                The domain of the GitHub API server, for use with GitHub Enterprise; otherwise inferred from the remote URL.
-                For example, `git config machete.github.domain git.example.org`
 
              `machete.github.organization`
                 The GitHub organization (the part before `/` in `organization/repository`); otherwise inferred from the remote URL.
@@ -289,7 +289,11 @@ long_docs: Dict[str, str] = {
               * `up-only-no-branches` — same as `up-only`, but no branch names are included (only PR numbers & titles)
               * `none`                — prepend no intro to the PR description at all
 
-           `machete.gitlab.{remote,domain,namespace,project}`
+           `machete.gitlab.{domain,remote,namespace,project}`
+             `machete.gitlab.domain`
+                The domain of the GitLab API server, for use with a GitLab self-managed instance; otherwise inferred from the remote URL.
+                For example, `git config machete.gitlab.domain git.example.org`
+
              `machete.gitlab.remote`
                 The name of the git remote (as in `git remote`) that git-machete pushes the source branch to.
                 Unless both `machete.gitlab.namespace` and `machete.gitlab.project` are set, this remote's URL is also inspected
@@ -298,10 +302,6 @@ long_docs: Dict[str, str] = {
                 By default (when this key is unset), if exactly one remote's URL corresponds to GitLab, that remote is selected automatically;
                 set this key to disambiguate when more than one remote points to GitLab.
                 For example, `git config machete.gitlab.remote origin`
-
-             `machete.gitlab.domain`
-                The domain of the GitLab API server, for use with a GitLab self-managed instance; otherwise inferred from the remote URL.
-                For example, `git config machete.gitlab.domain git.example.org`
 
              `machete.gitlab.namespace`
                 The GitLab namespace (the part before the final `/` in `namespace/project`); otherwise inferred from the remote URL.
@@ -789,7 +789,11 @@ long_docs: Dict[str, str] = {
 
         <b>Git config keys</b>
 
-           `machete.github.{remote,domain,organization,repository}` (all subcommands)
+           `machete.github.{domain,remote,organization,repository}` (all subcommands)
+             `machete.github.domain`
+                The domain of the GitHub API server, for use with GitHub Enterprise; otherwise inferred from the remote URL.
+                For example, `git config machete.github.domain git.example.org`
+
              `machete.github.remote`
                 The name of the git remote (as in `git remote`) that git-machete pushes the head branch to.
                 Unless both `machete.github.organization` and `machete.github.repository` are set, this remote's URL is also inspected
@@ -798,10 +802,6 @@ long_docs: Dict[str, str] = {
                 By default (when this key is unset), if exactly one remote's URL corresponds to GitHub, that remote is selected automatically;
                 set this key to disambiguate when more than one remote points to GitHub.
                 For example, `git config machete.github.remote origin`
-
-             `machete.github.domain`
-                The domain of the GitHub API server, for use with GitHub Enterprise; otherwise inferred from the remote URL.
-                For example, `git config machete.github.domain git.example.org`
 
              `machete.github.organization`
                 The GitHub organization (the part before `/` in `organization/repository`); otherwise inferred from the remote URL.
@@ -988,7 +988,11 @@ long_docs: Dict[str, str] = {
 
         <b>Git config keys</b>
 
-           `machete.gitlab.{remote,domain,namespace,project}` (all subcommands)
+           `machete.gitlab.{domain,remote,namespace,project}` (all subcommands)
+             `machete.gitlab.domain`
+                The domain of the GitLab API server, for use with a GitLab self-managed instance; otherwise inferred from the remote URL.
+                For example, `git config machete.gitlab.domain git.example.org`
+
              `machete.gitlab.remote`
                 The name of the git remote (as in `git remote`) that git-machete pushes the source branch to.
                 Unless both `machete.gitlab.namespace` and `machete.gitlab.project` are set, this remote's URL is also inspected
@@ -997,10 +1001,6 @@ long_docs: Dict[str, str] = {
                 By default (when this key is unset), if exactly one remote's URL corresponds to GitLab, that remote is selected automatically;
                 set this key to disambiguate when more than one remote points to GitLab.
                 For example, `git config machete.gitlab.remote origin`
-
-             `machete.gitlab.domain`
-                The domain of the GitLab API server, for use with a GitLab self-managed instance; otherwise inferred from the remote URL.
-                For example, `git config machete.gitlab.domain git.example.org`
 
              `machete.gitlab.namespace`
                 The GitLab namespace (the part before the final `/` in `namespace/project`); otherwise inferred from the remote URL.

--- a/tests/test_github_create_pr.py
+++ b/tests/test_github_create_pr.py
@@ -6,7 +6,7 @@ from pytest_mock import MockerFixture
 from tests.base_test import BaseTest
 from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
 from tests.git_repository import (add_remote, amend_commit, check_out, commit, create_repo, create_repo_with_remote, delete_branch,
-                                  delete_remote_branch, new_branch, push, remove_remote, reset_to, set_git_config_key,
+                                  delete_remote_branch, new_branch, push, remove_remote, reset_to, set_git_config_key, unset_git_config_key,
                                   wait_to_bump_commit_timestamp)
 from tests.mockers import fixed_author_and_committer_date_in_past, mock_input_returning, mock_input_returning_y
 from tests.mockers_code_hosting import mock_from_url
@@ -547,31 +547,8 @@ class TestGitHubCreatePR(BaseTest):
             """
         rewrite_branch_layout_file(body)
 
-        self.patch_symbol(mocker, 'builtins.input', mock_input_returning('q'))
-        expected_result = """
-        Branch feature is untracked and there's no origin remote.
-        [1] origin_1
-        [2] origin_2
-        Select number 1..2 to specify the destination remote repository, or 'q' to quit the operation:
-        """
-        assert_success(
-            ['github', 'create-pr'],
-            expected_result
-        )
-
-        self.patch_symbol(mocker, 'builtins.input', mock_input_returning('3'))
-        assert_failure(
-            ['github', 'create-pr'],
-            "Invalid index: 3"
-        )
-
-        self.patch_symbol(mocker, 'builtins.input', mock_input_returning('xd'))
-        assert_failure(
-            ['github', 'create-pr'],
-            "Could not establish remote repository, operation interrupted."
-        )
-
-        self.patch_symbol(mocker, 'builtins.input', mock_input_returning('1', 'n'))
+        # feature exists on both non-origin remotes, but has no tracking data and there's no `origin` remote,
+        # so the code-hosting logic cannot determine a unique remote -> create-pr aborts (no interactive remote picker).
         assert_failure(
             ['github', 'create-pr'],
             "Multiple non-origin remotes correspond to GitHub in this repository: origin_1, origin_2 -> aborting.\n"
@@ -579,44 +556,9 @@ class TestGitHubCreatePR(BaseTest):
             "machete.github.domain, machete.github.organization, machete.github.repository, machete.github.remote\n"
         )
 
+        # Once the head remote is unambiguous (here pinned via tracking data), create-pr pushes to / checks against it.
+        execute("git branch --set-upstream-to=origin_1/feature feature")
         expected_result = """
-        Branch feature is untracked and there's no origin remote.
-        [1] origin_1
-        [2] origin_2
-        Select number 1..2 to specify the destination remote repository, or 'q' to quit the operation:
-        Branch feature is untracked, but its remote counterpart candidate origin_1/feature already exists and both branches point to the same commit.
-        Set the remote of feature to origin_1 without pushing or pulling? (y, N, q, yq)
-        """  # noqa: E501
-
-        self.patch_symbol(mocker, 'builtins.input', mock_input_returning('1', 'q'))
-        assert_success(
-            ['github', 'create-pr'],
-            expected_result
-        )
-
-        self.patch_symbol(mocker, 'builtins.input', mock_input_returning('1', 'yq'))
-        assert_success(
-            ['github', 'create-pr'],
-            expected_result
-        )
-
-        execute("git branch --unset-upstream feature")
-
-        self.patch_symbol(mocker, 'builtins.input', mock_input_returning('1', 'y'))
-        expected_result = """
-        Branch feature is untracked and there's no origin remote.
-        [1] origin_1
-        [2] origin_2
-        Select number 1..2 to specify the destination remote repository, or 'q' to quit the operation:
-        Branch feature is untracked, but its remote counterpart candidate origin_1/feature already exists and both branches point to the same commit.
-        Set the remote of feature to origin_1 without pushing or pulling? (y, N, q, yq)
-
-          root
-          |
-          o-branch-1
-            |
-            o-feature *
-
         Warn: base branch branch-1 lives in example-org/example-repo-2 repository,
         while head branch feature lives in example-org/example-repo-1 repository.
         git-machete will now attempt to create a PR in example-org/example-repo-2.
@@ -699,20 +641,17 @@ class TestGitHubCreatePR(BaseTest):
             expected_result
         )
 
-        # branch feature_2 not present in any of the remotes, remote origin_1 picked manually via mock_input()
+        # branch feature_2 not present in any of the remotes; the head remote is pinned via the `remote` config key.
         check_out('feature')
         new_branch('feature_2')
         commit('introduce feature 2')
 
-        self.patch_symbol(mocker, 'builtins.input', mock_input_returning('y', '1', 'y'))
+        set_git_config_key('machete.github.remote', 'origin_1')
+        self.patch_symbol(mocker, 'builtins.input', mock_input_returning('y', 'y'))
 
         expected_result = """
         Add feature_2 onto the inferred upstream (parent) branch feature? (y, N)
         Added branch feature_2 onto feature
-        Branch feature_2 is untracked and there's no origin remote.
-        [1] origin_1
-        [2] origin_2
-        Select number 1..2 to specify the destination remote repository, or 'q' to quit the operation:
         Push untracked branch feature_2 to origin_1? (y, Q)
 
           root
@@ -735,6 +674,7 @@ class TestGitHubCreatePR(BaseTest):
             ['github', 'create-pr'],
             expected_result
         )
+        unset_git_config_key('machete.github.remote')
 
         # branch feature_2 present in only one remote: origin_1, no tracking data
         check_out('feature_2')
@@ -897,6 +837,8 @@ class TestGitHubCreatePR(BaseTest):
         )
 
     def test_github_create_pr_for_untracked_branch(self, mocker: MockerFixture) -> None:
+        self.patch_symbol(mocker, 'git_machete.code_hosting.OrganizationAndRepository.from_url', mock_from_url)
+
         create_repo_with_remote()
         new_branch("master")
         commit()
@@ -913,6 +855,8 @@ class TestGitHubCreatePR(BaseTest):
         )
 
     def test_github_create_pr_for_branch_diverged_from_and_newer_than_remote(self, mocker: MockerFixture) -> None:
+        self.patch_symbol(mocker, 'git_machete.code_hosting.OrganizationAndRepository.from_url', mock_from_url)
+
         create_repo_with_remote()
 
         new_branch("master")
@@ -937,6 +881,8 @@ class TestGitHubCreatePR(BaseTest):
         )
 
     def test_github_create_pr_quit_on_branch_diverged_from_and_newer_than_remote(self, mocker: MockerFixture) -> None:
+        self.patch_symbol(mocker, 'git_machete.code_hosting.OrganizationAndRepository.from_url', mock_from_url)
+
         create_repo_with_remote()
 
         new_branch("master")
@@ -961,6 +907,8 @@ class TestGitHubCreatePR(BaseTest):
         )
 
     def test_github_create_pr_quit_on_ahead_branch(self, mocker: MockerFixture) -> None:
+        self.patch_symbol(mocker, 'git_machete.code_hosting.OrganizationAndRepository.from_url', mock_from_url)
+
         create_repo_with_remote()
 
         new_branch("master")

--- a/tests/test_gitlab_create_mr.py
+++ b/tests/test_gitlab_create_mr.py
@@ -6,7 +6,7 @@ from pytest_mock import MockerFixture
 from tests.base_test import BaseTest
 from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
 from tests.git_repository import (add_remote, amend_commit, check_out, commit, create_repo, create_repo_with_remote, delete_branch,
-                                  delete_remote_branch, new_branch, push, remove_remote, reset_to, set_git_config_key,
+                                  delete_remote_branch, new_branch, push, remove_remote, reset_to, set_git_config_key, unset_git_config_key,
                                   wait_to_bump_commit_timestamp)
 from tests.mockers import fixed_author_and_committer_date_in_past, mock_input_returning, mock_input_returning_y
 from tests.mockers_code_hosting import mock_from_url
@@ -527,31 +527,8 @@ class TestGitLabCreateMR(BaseTest):
             """
         rewrite_branch_layout_file(body)
 
-        self.patch_symbol(mocker, 'builtins.input', mock_input_returning('q'))
-        expected_result = """
-        Branch feature is untracked and there's no origin remote.
-        [1] origin_1
-        [2] origin_2
-        Select number 1..2 to specify the destination remote repository, or 'q' to quit the operation:
-        """
-        assert_success(
-            ['gitlab', 'create-mr'],
-            expected_result
-        )
-
-        self.patch_symbol(mocker, 'builtins.input', mock_input_returning('3'))
-        assert_failure(
-            ['gitlab', 'create-mr'],
-            "Invalid index: 3"
-        )
-
-        self.patch_symbol(mocker, 'builtins.input', mock_input_returning('xd'))
-        assert_failure(
-            ['gitlab', 'create-mr'],
-            "Could not establish remote repository, operation interrupted."
-        )
-
-        self.patch_symbol(mocker, 'builtins.input', mock_input_returning('1', 'n'))
+        # feature exists on both non-origin remotes, but has no tracking data and there's no `origin` remote,
+        # so the code-hosting logic cannot determine a unique remote -> create-mr aborts (no interactive remote picker).
         assert_failure(
             ['gitlab', 'create-mr'],
             "Multiple non-origin remotes correspond to GitLab in this repository: origin_1, origin_2 -> aborting.\n"
@@ -559,44 +536,9 @@ class TestGitLabCreateMR(BaseTest):
             "machete.gitlab.domain, machete.gitlab.namespace, machete.gitlab.project, machete.gitlab.remote\n"
         )
 
+        # Once the source remote is unambiguous (here pinned via tracking data), create-mr pushes to / checks against it.
+        execute("git branch --set-upstream-to=origin_1/feature feature")
         expected_result = """
-        Branch feature is untracked and there's no origin remote.
-        [1] origin_1
-        [2] origin_2
-        Select number 1..2 to specify the destination remote repository, or 'q' to quit the operation:
-        Branch feature is untracked, but its remote counterpart candidate origin_1/feature already exists and both branches point to the same commit.
-        Set the remote of feature to origin_1 without pushing or pulling? (y, N, q, yq)
-        """  # noqa: E501
-
-        self.patch_symbol(mocker, 'builtins.input', mock_input_returning('1', 'q'))
-        assert_success(
-            ['gitlab', 'create-mr'],
-            expected_result
-        )
-
-        self.patch_symbol(mocker, 'builtins.input', mock_input_returning('1', 'yq'))
-        assert_success(
-            ['gitlab', 'create-mr'],
-            expected_result
-        )
-
-        execute("git branch --unset-upstream feature")
-
-        self.patch_symbol(mocker, 'builtins.input', mock_input_returning('1', 'y'))
-        expected_result = """
-        Branch feature is untracked and there's no origin remote.
-        [1] origin_1
-        [2] origin_2
-        Select number 1..2 to specify the destination remote repository, or 'q' to quit the operation:
-        Branch feature is untracked, but its remote counterpart candidate origin_1/feature already exists and both branches point to the same commit.
-        Set the remote of feature to origin_1 without pushing or pulling? (y, N, q, yq)
-
-          root
-          |
-          o-branch-1
-            |
-            o-feature *
-
         Warn: target branch branch-1 lives in example-org/example-repo-2 project,
         while source branch feature lives in example-org/example-repo-1 project.
         git-machete will now attempt to create an MR in example-org/example-repo-2.
@@ -679,20 +621,17 @@ class TestGitLabCreateMR(BaseTest):
             expected_result
         )
 
-        # branch feature_2 not present in any of the remotes, remote origin_1 picked manually via mock_input()
+        # branch feature_2 not present in any of the remotes; the source remote is pinned via the `remote` config key.
         check_out('feature')
         new_branch('feature_2')
         commit('introduce feature 2')
 
-        self.patch_symbol(mocker, 'builtins.input', mock_input_returning('y', '1', 'y'))
+        set_git_config_key('machete.gitlab.remote', 'origin_1')
+        self.patch_symbol(mocker, 'builtins.input', mock_input_returning('y', 'y'))
 
         expected_result = """
         Add feature_2 onto the inferred upstream (parent) branch feature? (y, N)
         Added branch feature_2 onto feature
-        Branch feature_2 is untracked and there's no origin remote.
-        [1] origin_1
-        [2] origin_2
-        Select number 1..2 to specify the destination remote repository, or 'q' to quit the operation:
         Push untracked branch feature_2 to origin_1? (y, Q)
 
           root
@@ -715,6 +654,7 @@ class TestGitLabCreateMR(BaseTest):
             ['gitlab', 'create-mr'],
             expected_result
         )
+        unset_git_config_key('machete.gitlab.remote')
 
         # branch feature_2 present in only one remote: origin_1, no tracking data
         check_out('feature_2')
@@ -880,6 +820,8 @@ class TestGitLabCreateMR(BaseTest):
         )
 
     def test_gitlab_create_mr_for_untracked_branch(self, mocker: MockerFixture) -> None:
+        self.patch_symbol(mocker, 'git_machete.code_hosting.OrganizationAndRepository.from_url', mock_from_url)
+
         create_repo_with_remote()
 
         new_branch("master")
@@ -898,6 +840,8 @@ class TestGitLabCreateMR(BaseTest):
         )
 
     def test_gitlab_create_mr_for_branch_diverged_from_and_newer_than_remote(self, mocker: MockerFixture) -> None:
+        self.patch_symbol(mocker, 'git_machete.code_hosting.OrganizationAndRepository.from_url', mock_from_url)
+
         create_repo_with_remote()
 
         new_branch("master")


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1734

## Chain of upstream PRs & tree of downstream PRs as of 2026-06-23

* PR #1734:
  `develop` ← `docs/githublab-access-keys`

  * **PR #1733 (THIS ONE)**:
    `docs/githublab-access-keys` ← `fix/hublab-remote-logic`

      * PR #1728:
        `fix/hublab-remote-logic` ← `feature/base-githublab-config-keys`

<!-- end git-machete generated -->

`git machete {github,gitlab} create-{pr,mr}` and `restack-{pr,mr}` now push the head/source branch to the remote determined by the code-hosting logic (the `machete.{github,gitlab}.remote` git config key when set, otherwise the remote inferred from the matching remote URL), consistently with how the base/target branch is already handled.
Previously the head/source branch push relied on git's tracking/inferred counterpart plus the generic origin/single-remote/interactive-picker selection, so it could land on a remote unrelated to the code-hosting logic.

In an ambiguous multi-remote setup with no remote configured, these commands now abort asking for the relevant git config keys rather than prompting to pick a remote interactively. `advance` and `traverse` keep their previous push-remote selection.

Also de-glob the `machete.{github,gitlab}.*` access keys in the docs: document `domain`, `remote`, `organization`/`namespace` and `repository`/`project` as separate entries, each explaining what the key does.