### PR TITLE
Document each `machete.{github,gitlab}.*` access config key individually and drop the `start-line` include machinery

### DIFF
--- a/ci/checks/prohibit-exempli-gratia-in-rst.sh
+++ b/ci/checks/prohibit-exempli-gratia-in-rst.sh
@@ -2,7 +2,7 @@
 
 set -e -o pipefail -u
 
-if git grep -En 'e\. ?g\.' -- '*.rst'; then
-  echo 'Do not use `e.g.` in docs; use a clearer alternative like `for example` instead'
+if git grep -Eni 'e\. ?g\.' -- '*.rst'; then
+  echo 'Do not use `e.g.`/`E.g.` in docs; use a clearer alternative like `for example` instead'
   exit 1
 fi

--- a/docs/generate_py_docs.py
+++ b/docs/generate_py_docs.py
@@ -1,41 +1,19 @@
 import os
 import re
-from itertools import takewhile
 from os.path import isfile, join
 from textwrap import dedent, indent
 from typing import List
 
 
 def resolve_includes(rst_content: str, docs_source_dir: str) -> str:
-    matches = re.findall(r'(.*)\.\. include:: (.*)\n(.* :(.*): ([0-9]*)\n)?(.* :(.*): ([0-9]*)\n)?', rst_content)
-    # example matches:
-    #     .. include:: status_extraSpaceBeforeBranchName_config_key.rst
-    #
-    #     .. include:: status_extraSpaceBeforeBranchName_config_key.rst
-    #         :start-line: 2
-    #
-    #     .. include:: status_extraSpaceBeforeBranchName_config_key.rst
-    #         :start-line: 2
-    #         :end-line: 6
-    for include_indent, included_file, opt1_line, opt1_key, opt1_value, opt2_line, opt2_key, opt2_value in matches:
+    matches = re.findall(r'(.*)\.\. include:: (.*)\n', rst_content)
+    # example match:
+    #     .. include:: status_extraSpaceBeforeBranchName.rst
+    for include_indent, included_file in matches:
         with open(f'{docs_source_dir}/{included_file}', 'r') as handle:
-            include_text = handle.readlines()
+            include_text = handle.read()
         replace_from = f'{include_indent}.. include:: {included_file}'
-
-        start_line, end_line = 0, len(include_text)
-        if opt1_key == 'start-line':
-            start_line = int(opt1_value)
-            replace_from += f'\n{opt1_line}'
-            if opt2_key == 'end-line':
-                end_line = int(opt2_value)
-                replace_from += opt2_line
-        elif opt1_key == 'end-line':
-            end_line = int(opt1_value)
-            replace_from += f'\n{opt1_line}'
-
-        include_text = include_text[start_line:end_line]
-        include_text = takewhile(lambda line: not line == "..\n", include_text)
-        replace_to = indent(dedent(''.join(include_text)), include_indent)
+        replace_to = indent(dedent(include_text), include_indent)
         rst_content = rst_content.replace(replace_from, replace_to, 1)
     return rst_content
 

--- a/docs/man/git-machete.1
+++ b/docs/man/git-machete.1
@@ -321,21 +321,29 @@ Note: \fBconfig\fP is not a command as such, just a help topic (there is no \fBg
 \fBGit config keys:\fP
 .INDENT 0.0
 .TP
-.B \fBmachete.github.{domain,remote,organization,repository}\fP:
+.B \fBmachete.github.{remote,domain,organization,repository}\fP:
 .INDENT 7.0
-.INDENT 3.5
-.INDENT 0.0
 .TP
-.B GitHub Enterprise domain
-E.g. \fBgit config machete.github.domain git.example.org\fP
+.B \fBmachete.github.remote\fP
+The name of the git remote (as in \fBgit remote\fP) that git\-machete pushes the head branch to.
+Unless both \fBmachete.github.organization\fP and \fBmachete.github.repository\fP are set, this remote\(aqs URL is also inspected
+to derive the GitHub organization and repository that the pull request resides in.
+The pull request is operated on through the GitHub API, which addresses that organization/repository rather than a git remote.
+By default (when this key is unset), if exactly one remote\(aqs URL corresponds to GitHub, that remote is selected automatically;
+set this key to disambiguate when more than one remote points to GitHub.
+For example, \fBgit config machete.github.remote origin\fP
 .TP
-.B Remote name (as in \fBgit remote\fP)
-E.g. \fBgit config machete.github.remote origin\fP
+.B \fBmachete.github.domain\fP
+The domain of the GitHub API server, for use with GitHub Enterprise; otherwise inferred from the remote URL.
+For example, \fBgit config machete.github.domain git.example.org\fP
 .TP
-.B Organization and repository name
-E.g. \fBgit config machete.github.organization VirtusLab; git config machete.github.repository git\-machete\fP
-.UNINDENT
-.UNINDENT
+.B \fBmachete.github.organization\fP
+The GitHub organization (the part before \fB/\fP in \fBorganization/repository\fP); otherwise inferred from the remote URL.
+For example, \fBgit config machete.github.organization VirtusLab\fP
+.TP
+.B \fBmachete.github.repository\fP
+The GitHub repository (the part after \fB/\fP in \fBorganization/repository\fP); otherwise inferred from the remote URL.
+For example, \fBgit config machete.github.repository git\-machete\fP
 .UNINDENT
 .sp
 Note that you do \fBnot\fP need to set all four keys at once.
@@ -371,21 +379,29 @@ from the message body of the first unique commit of the branch, even if \fB\&.gi
 .UNINDENT
 .UNINDENT
 .TP
-.B \fBmachete.gitlab.{domain,remote,namespace,project}\fP:
+.B \fBmachete.gitlab.{remote,domain,namespace,project}\fP:
 .INDENT 7.0
-.INDENT 3.5
-.INDENT 0.0
 .TP
-.B GitLab self\-managed domain
-E.g. \fBgit config machete.gitlab.domain git.example.org\fP
+.B \fBmachete.gitlab.remote\fP
+The name of the git remote (as in \fBgit remote\fP) that git\-machete pushes the source branch to.
+Unless both \fBmachete.gitlab.namespace\fP and \fBmachete.gitlab.project\fP are set, this remote\(aqs URL is also inspected
+to derive the GitLab namespace and project that the merge request resides in.
+The merge request is operated on through the GitLab API, which addresses that namespace/project rather than a git remote.
+By default (when this key is unset), if exactly one remote\(aqs URL corresponds to GitLab, that remote is selected automatically;
+set this key to disambiguate when more than one remote points to GitLab.
+For example, \fBgit config machete.gitlab.remote origin\fP
 .TP
-.B Remote name (as in \fBgit remote\fP)
-E.g. \fBgit config machete.gitlab.remote origin\fP
+.B \fBmachete.gitlab.domain\fP
+The domain of the GitLab API server, for use with a GitLab self\-managed instance; otherwise inferred from the remote URL.
+For example, \fBgit config machete.gitlab.domain git.example.org\fP
 .TP
-.B Namespace and project name
-E.g. \fBgit config machete.gitlab.namespace foo/bar; git config machete.gitlab.project hello\-world\fP
-.UNINDENT
-.UNINDENT
+.B \fBmachete.gitlab.namespace\fP
+The GitLab namespace (the part before the final \fB/\fP in \fBnamespace/project\fP); otherwise inferred from the remote URL.
+For example, \fBgit config machete.gitlab.namespace foo/bar\fP
+.TP
+.B \fBmachete.gitlab.project\fP
+The GitLab project (the part after the final \fB/\fP in \fBnamespace/project\fP); otherwise inferred from the remote URL.
+For example, \fBgit config machete.gitlab.project hello\-world\fP
 .UNINDENT
 .sp
 Note that you do \fBnot\fP need to set all four keys at once.
@@ -1143,23 +1159,29 @@ Update PR descriptions for all PRs both upstream and downstream of the PR for th
 \fBGit config keys:\fP
 .INDENT 0.0
 .TP
-.B \fBmachete.github.{domain,remote,organization,repository}\fP (all subcommands):
-GitHub API server URL will be inferred from \fBgit remote\fP\&.
-You can alter the default behavior by setting the following git config keys:
+.B \fBmachete.github.{remote,domain,organization,repository}\fP (all subcommands):
 .INDENT 7.0
-.INDENT 3.5
-.INDENT 0.0
 .TP
-.B GitHub Enterprise domain
-E.g. \fBgit config machete.github.domain git.example.org\fP
+.B \fBmachete.github.remote\fP
+The name of the git remote (as in \fBgit remote\fP) that git\-machete pushes the head branch to.
+Unless both \fBmachete.github.organization\fP and \fBmachete.github.repository\fP are set, this remote\(aqs URL is also inspected
+to derive the GitHub organization and repository that the pull request resides in.
+The pull request is operated on through the GitHub API, which addresses that organization/repository rather than a git remote.
+By default (when this key is unset), if exactly one remote\(aqs URL corresponds to GitHub, that remote is selected automatically;
+set this key to disambiguate when more than one remote points to GitHub.
+For example, \fBgit config machete.github.remote origin\fP
 .TP
-.B Remote name (as in \fBgit remote\fP)
-E.g. \fBgit config machete.github.remote origin\fP
+.B \fBmachete.github.domain\fP
+The domain of the GitHub API server, for use with GitHub Enterprise; otherwise inferred from the remote URL.
+For example, \fBgit config machete.github.domain git.example.org\fP
 .TP
-.B Organization and repository name
-E.g. \fBgit config machete.github.organization VirtusLab; git config machete.github.repository git\-machete\fP
-.UNINDENT
-.UNINDENT
+.B \fBmachete.github.organization\fP
+The GitHub organization (the part before \fB/\fP in \fBorganization/repository\fP); otherwise inferred from the remote URL.
+For example, \fBgit config machete.github.organization VirtusLab\fP
+.TP
+.B \fBmachete.github.repository\fP
+The GitHub repository (the part after \fB/\fP in \fBorganization/repository\fP); otherwise inferred from the remote URL.
+For example, \fBgit config machete.github.repository git\-machete\fP
 .UNINDENT
 .sp
 Note that you do \fBnot\fP need to set all four keys at once.
@@ -1411,23 +1433,29 @@ Update MR descriptions for all MRs both upstream and downstream of the MR for th
 \fBGit config keys:\fP
 .INDENT 0.0
 .TP
-.B \fBmachete.gitlab.{domain,remote,namespace,project}\fP (all subcommands):
-GitLab API server URL will be inferred from \fBgit remote\fP\&.
-You can alter the default behavior by setting the following git config keys:
+.B \fBmachete.gitlab.{remote,domain,namespace,project}\fP (all subcommands):
 .INDENT 7.0
-.INDENT 3.5
-.INDENT 0.0
 .TP
-.B GitLab self\-managed domain
-E.g. \fBgit config machete.gitlab.domain git.example.org\fP
+.B \fBmachete.gitlab.remote\fP
+The name of the git remote (as in \fBgit remote\fP) that git\-machete pushes the source branch to.
+Unless both \fBmachete.gitlab.namespace\fP and \fBmachete.gitlab.project\fP are set, this remote\(aqs URL is also inspected
+to derive the GitLab namespace and project that the merge request resides in.
+The merge request is operated on through the GitLab API, which addresses that namespace/project rather than a git remote.
+By default (when this key is unset), if exactly one remote\(aqs URL corresponds to GitLab, that remote is selected automatically;
+set this key to disambiguate when more than one remote points to GitLab.
+For example, \fBgit config machete.gitlab.remote origin\fP
 .TP
-.B Remote name (as in \fBgit remote\fP)
-E.g. \fBgit config machete.gitlab.remote origin\fP
+.B \fBmachete.gitlab.domain\fP
+The domain of the GitLab API server, for use with a GitLab self\-managed instance; otherwise inferred from the remote URL.
+For example, \fBgit config machete.gitlab.domain git.example.org\fP
 .TP
-.B Namespace and project name
-E.g. \fBgit config machete.gitlab.namespace foo/bar; git config machete.gitlab.project hello\-world\fP
-.UNINDENT
-.UNINDENT
+.B \fBmachete.gitlab.namespace\fP
+The GitLab namespace (the part before the final \fB/\fP in \fBnamespace/project\fP); otherwise inferred from the remote URL.
+For example, \fBgit config machete.gitlab.namespace foo/bar\fP
+.TP
+.B \fBmachete.gitlab.project\fP
+The GitLab project (the part after the final \fB/\fP in \fBnamespace/project\fP); otherwise inferred from the remote URL.
+For example, \fBgit config machete.gitlab.project hello\-world\fP
 .UNINDENT
 .sp
 Note that you do \fBnot\fP need to set all four keys at once.

--- a/docs/source/cli/config.rst
+++ b/docs/source/cli/config.rst
@@ -8,9 +8,8 @@ Note: ``config`` is not a command as such, just a help topic (there is no ``git 
 
 **Git config keys:**
 
-``machete.github.{domain,remote,organization,repository}``:
+``machete.github.{remote,domain,organization,repository}``:
   .. include:: git-config-keys/github_access.rst
-      :start-line: 3
 
 ``machete.github.annotateWithUrls``:
   .. include:: git-config-keys/github_annotateWithUrls.rst
@@ -21,9 +20,8 @@ Note: ``config`` is not a command as such, just a help topic (there is no ``git 
 ``machete.github.prDescriptionIntroStyle``:
   .. include:: git-config-keys/github_prDescriptionIntroStyle.rst
 
-``machete.gitlab.{domain,remote,namespace,project}``:
+``machete.gitlab.{remote,domain,namespace,project}``:
   .. include:: git-config-keys/gitlab_access.rst
-      :start-line: 3
 
 ``machete.gitlab.annotateWithUrls``:
   .. include:: git-config-keys/gitlab_annotateWithUrls.rst
@@ -47,6 +45,8 @@ Note: ``config`` is not a command as such, just a help topic (there is no ``git 
 
 ``machete.status.extraSpaceBeforeBranchName``:
     .. include:: git-config-keys/status_extraSpaceBeforeBranchName.rst
+
+    .. include:: git-config-keys/status_extraSpaceBeforeBranchName_example.rst
 
 ``machete.traverse.fetch.<remote>``:
     .. include:: git-config-keys/traverse_fetch_remote.rst

--- a/docs/source/cli/github.rst
+++ b/docs/source/cli/github.rst
@@ -165,7 +165,7 @@ Create, check out and manage GitHub PRs while keeping them reflected in branch l
 
 **Git config keys:**
 
-``machete.github.{domain,remote,organization,repository}`` (all subcommands):
+``machete.github.{remote,domain,organization,repository}`` (all subcommands):
   .. include:: git-config-keys/github_access.rst
 
 ``machete.github.annotateWithUrls`` (all subcommands):

--- a/docs/source/cli/gitlab.rst
+++ b/docs/source/cli/gitlab.rst
@@ -156,7 +156,7 @@ Create, check out and manage GitLab MRs while keeping them reflected in branch l
 
 **Git config keys:**
 
-``machete.gitlab.{domain,remote,namespace,project}`` (all subcommands):
+``machete.gitlab.{remote,domain,namespace,project}`` (all subcommands):
   .. include:: git-config-keys/gitlab_access.rst
 
 ``machete.gitlab.annotateWithUrls`` (all subcommands):

--- a/docs/source/cli/status.rst
+++ b/docs/source/cli/status.rst
@@ -72,6 +72,8 @@ When colors are disabled, relation between branches is represented in the follow
 
 .. include:: git-config-keys/status_extraSpaceBeforeBranchName.rst
 
+.. include:: git-config-keys/status_extraSpaceBeforeBranchName_example.rst
+
 **Options:**
 
 --color=WHEN                      Colorize the output; WHEN can be ``always``, ``auto`` (default: colorize only if stdout is a terminal), or ``never``.
@@ -95,4 +97,3 @@ When colors are disabled, relation between branches is represented in the follow
 
 ``machete.status.extraSpaceBeforeBranchName``:
     .. include:: git-config-keys/status_extraSpaceBeforeBranchName.rst
-      :end-line: 3

--- a/docs/source/git-config-keys/github_access.rst
+++ b/docs/source/git-config-keys/github_access.rst
@@ -1,19 +1,24 @@
-GitHub API server URL will be inferred from ``git remote``.
-You can alter the default behavior by setting the following git config keys:
+``machete.github.remote``
+    The name of the git remote (as in ``git remote``) that git-machete pushes the head branch to.
+    Unless both ``machete.github.organization`` and ``machete.github.repository`` are set, this remote's URL is also inspected
+    to derive the GitHub organization and repository that the pull request resides in.
+    The pull request is operated on through the GitHub API, which addresses that organization/repository rather than a git remote.
+    By default (when this key is unset), if exactly one remote's URL corresponds to GitHub, that remote is selected automatically;
+    set this key to disambiguate when more than one remote points to GitHub.
+    For example, ``git config machete.github.remote origin``
 
-    GitHub Enterprise domain
-        E.g. ``git config machete.github.domain git.example.org``
+``machete.github.domain``
+    The domain of the GitHub API server, for use with GitHub Enterprise; otherwise inferred from the remote URL.
+    For example, ``git config machete.github.domain git.example.org``
 
-    Remote name (as in ``git remote``)
-        E.g. ``git config machete.github.remote origin``
+``machete.github.organization``
+    The GitHub organization (the part before ``/`` in ``organization/repository``); otherwise inferred from the remote URL.
+    For example, ``git config machete.github.organization VirtusLab``
 
-    Organization and repository name
-        E.g. ``git config machete.github.organization VirtusLab; git config machete.github.repository git-machete``
+``machete.github.repository``
+    The GitHub repository (the part after ``/`` in ``organization/repository``); otherwise inferred from the remote URL.
+    For example, ``git config machete.github.repository git-machete``
 
 Note that you do **not** need to set all four keys at once.
 For example, in a typical usage of GitHub Enterprise, it should be enough to just set ``machete.github.domain``.
 Only ``machete.github.organization`` and ``machete.github.repository`` must be specified together.
-
-..
-    Text order in this file is relevant, if you want to change something, find each occurrence of ``.. include:: git-config-keys/github_access.rst``
-    and if this occurrence has ``start-line`` or ``end-line`` options provided, make sure that after changes the output text stays the same.

--- a/docs/source/git-config-keys/gitlab_access.rst
+++ b/docs/source/git-config-keys/gitlab_access.rst
@@ -1,19 +1,24 @@
-GitLab API server URL will be inferred from ``git remote``.
-You can alter the default behavior by setting the following git config keys:
+``machete.gitlab.remote``
+    The name of the git remote (as in ``git remote``) that git-machete pushes the source branch to.
+    Unless both ``machete.gitlab.namespace`` and ``machete.gitlab.project`` are set, this remote's URL is also inspected
+    to derive the GitLab namespace and project that the merge request resides in.
+    The merge request is operated on through the GitLab API, which addresses that namespace/project rather than a git remote.
+    By default (when this key is unset), if exactly one remote's URL corresponds to GitLab, that remote is selected automatically;
+    set this key to disambiguate when more than one remote points to GitLab.
+    For example, ``git config machete.gitlab.remote origin``
 
-    GitLab self-managed domain
-        E.g. ``git config machete.gitlab.domain git.example.org``
+``machete.gitlab.domain``
+    The domain of the GitLab API server, for use with a GitLab self-managed instance; otherwise inferred from the remote URL.
+    For example, ``git config machete.gitlab.domain git.example.org``
 
-    Remote name (as in ``git remote``)
-        E.g. ``git config machete.gitlab.remote origin``
+``machete.gitlab.namespace``
+    The GitLab namespace (the part before the final ``/`` in ``namespace/project``); otherwise inferred from the remote URL.
+    For example, ``git config machete.gitlab.namespace foo/bar``
 
-    Namespace and project name
-        E.g. ``git config machete.gitlab.namespace foo/bar; git config machete.gitlab.project hello-world``
+``machete.gitlab.project``
+    The GitLab project (the part after the final ``/`` in ``namespace/project``); otherwise inferred from the remote URL.
+    For example, ``git config machete.gitlab.project hello-world``
 
 Note that you do **not** need to set all four keys at once.
 For example, in a typical usage for GitLab self-managed instance, it should be enough to just set ``machete.gitlab.domain``.
 Only ``machete.gitlab.namespace`` and ``machete.gitlab.project`` must be specified together.
-
-..
-    Text order in this file is relevant, if you want to change something, find each occurrence of ``.. include:: git-config-keys/gitlab_access.rst``
-    and if this occurrence has ``start-line`` or ``end-line`` options provided, make sure that after changes the output text stays the same.

--- a/docs/source/git-config-keys/status_extraSpaceBeforeBranchName.rst
+++ b/docs/source/git-config-keys/status_extraSpaceBeforeBranchName.rst
@@ -1,26 +1,2 @@
 To make it easier to select branch name from the ``status`` output on certain terminals (like `Alacritty <https://github.com/alacritty/alacritty>`_),
 you can add an extra space between └─ and branch name by setting ``git config machete.status.extraSpaceBeforeBranchName true``.
-
-For example, by default the status is displayed as:
-
-.. code-block::
-
-    develop
-    │
-    ├─feature_branch1
-    │
-    └─feature_branch2
-
-With ``machete.status.extraSpaceBeforeBranchName`` config set to ``true``:
-
-.. code-block::
-
-     develop
-     │
-     ├─ feature_branch1
-     │
-     └─ feature_branch2
-
-..
-    Text order in this file is relevant, if you want to change something, find each occurrence of ``.. include:: git-config-keys/status_extraSpaceBeforeBranchName.rst``
-    and if this occurrence has ``start-line`` or ``end-line`` options provided, make sure that after changes the output text stays the same.

--- a/docs/source/git-config-keys/status_extraSpaceBeforeBranchName_example.rst
+++ b/docs/source/git-config-keys/status_extraSpaceBeforeBranchName_example.rst
@@ -1,0 +1,19 @@
+For example, by default the status is displayed as:
+
+.. code-block::
+
+    develop
+    │
+    ├─feature_branch1
+    │
+    └─feature_branch2
+
+With ``machete.status.extraSpaceBeforeBranchName`` config set to ``true``:
+
+.. code-block::
+
+     develop
+     │
+     ├─ feature_branch1
+     │
+     └─ feature_branch2

--- a/git_machete/generated_docs.py
+++ b/git_machete/generated_docs.py
@@ -244,15 +244,27 @@ long_docs: Dict[str, str] = {
 
         <b>Git config keys:</b>
 
-           `machete.github.{domain,remote,organization,repository}`:
-                GitHub Enterprise domain
-                    E.g. `git config machete.github.domain git.example.org`
+           `machete.github.{remote,domain,organization,repository}`:
+             `machete.github.remote`
+                The name of the git remote (as in `git remote`) that git-machete pushes the head branch to.
+                Unless both `machete.github.organization` and `machete.github.repository` are set, this remote's URL is also inspected
+                to derive the GitHub organization and repository that the pull request resides in.
+                The pull request is operated on through the GitHub API, which addresses that organization/repository rather than a git remote.
+                By default (when this key is unset), if exactly one remote's URL corresponds to GitHub, that remote is selected automatically;
+                set this key to disambiguate when more than one remote points to GitHub.
+                For example, `git config machete.github.remote origin`
 
-                Remote name (as in `git remote`)
-                    E.g. `git config machete.github.remote origin`
+             `machete.github.domain`
+                The domain of the GitHub API server, for use with GitHub Enterprise; otherwise inferred from the remote URL.
+                For example, `git config machete.github.domain git.example.org`
 
-                Organization and repository name
-                    E.g. `git config machete.github.organization VirtusLab; git config machete.github.repository git-machete`
+             `machete.github.organization`
+                The GitHub organization (the part before `/` in `organization/repository`); otherwise inferred from the remote URL.
+                For example, `git config machete.github.organization VirtusLab`
+
+             `machete.github.repository`
+                The GitHub repository (the part after `/` in `organization/repository`); otherwise inferred from the remote URL.
+                For example, `git config machete.github.repository git-machete`
 
              Note that you do <b>not</b> need to set all four keys at once.
              For example, in a typical usage of GitHub Enterprise, it should be enough to just set `machete.github.domain`.
@@ -277,15 +289,27 @@ long_docs: Dict[str, str] = {
               * `up-only-no-branches` — same as `up-only`, but no branch names are included (only PR numbers & titles)
               * `none`                — prepend no intro to the PR description at all
 
-           `machete.gitlab.{domain,remote,namespace,project}`:
-                GitLab self-managed domain
-                    E.g. `git config machete.gitlab.domain git.example.org`
+           `machete.gitlab.{remote,domain,namespace,project}`:
+             `machete.gitlab.remote`
+                The name of the git remote (as in `git remote`) that git-machete pushes the source branch to.
+                Unless both `machete.gitlab.namespace` and `machete.gitlab.project` are set, this remote's URL is also inspected
+                to derive the GitLab namespace and project that the merge request resides in.
+                The merge request is operated on through the GitLab API, which addresses that namespace/project rather than a git remote.
+                By default (when this key is unset), if exactly one remote's URL corresponds to GitLab, that remote is selected automatically;
+                set this key to disambiguate when more than one remote points to GitLab.
+                For example, `git config machete.gitlab.remote origin`
 
-                Remote name (as in `git remote`)
-                    E.g. `git config machete.gitlab.remote origin`
+             `machete.gitlab.domain`
+                The domain of the GitLab API server, for use with a GitLab self-managed instance; otherwise inferred from the remote URL.
+                For example, `git config machete.gitlab.domain git.example.org`
 
-                Namespace and project name
-                    E.g. `git config machete.gitlab.namespace foo/bar; git config machete.gitlab.project hello-world`
+             `machete.gitlab.namespace`
+                The GitLab namespace (the part before the final `/` in `namespace/project`); otherwise inferred from the remote URL.
+                For example, `git config machete.gitlab.namespace foo/bar`
+
+             `machete.gitlab.project`
+                The GitLab project (the part after the final `/` in `namespace/project`); otherwise inferred from the remote URL.
+                For example, `git config machete.gitlab.project hello-world`
 
              Note that you do <b>not</b> need to set all four keys at once.
              For example, in a typical usage for GitLab self-managed instance, it should be enough to just set `machete.gitlab.domain`.
@@ -765,18 +789,27 @@ long_docs: Dict[str, str] = {
 
         <b>Git config keys:</b>
 
-           `machete.github.{domain,remote,organization,repository}` (all subcommands):
-             GitHub API server URL will be inferred from `git remote`.
-             You can alter the default behavior by setting the following git config keys:
+           `machete.github.{remote,domain,organization,repository}` (all subcommands):
+             `machete.github.remote`
+                The name of the git remote (as in `git remote`) that git-machete pushes the head branch to.
+                Unless both `machete.github.organization` and `machete.github.repository` are set, this remote's URL is also inspected
+                to derive the GitHub organization and repository that the pull request resides in.
+                The pull request is operated on through the GitHub API, which addresses that organization/repository rather than a git remote.
+                By default (when this key is unset), if exactly one remote's URL corresponds to GitHub, that remote is selected automatically;
+                set this key to disambiguate when more than one remote points to GitHub.
+                For example, `git config machete.github.remote origin`
 
-                GitHub Enterprise domain
-                    E.g. `git config machete.github.domain git.example.org`
+             `machete.github.domain`
+                The domain of the GitHub API server, for use with GitHub Enterprise; otherwise inferred from the remote URL.
+                For example, `git config machete.github.domain git.example.org`
 
-                Remote name (as in `git remote`)
-                    E.g. `git config machete.github.remote origin`
+             `machete.github.organization`
+                The GitHub organization (the part before `/` in `organization/repository`); otherwise inferred from the remote URL.
+                For example, `git config machete.github.organization VirtusLab`
 
-                Organization and repository name
-                    E.g. `git config machete.github.organization VirtusLab; git config machete.github.repository git-machete`
+             `machete.github.repository`
+                The GitHub repository (the part after `/` in `organization/repository`); otherwise inferred from the remote URL.
+                For example, `git config machete.github.repository git-machete`
 
              Note that you do <b>not</b> need to set all four keys at once.
              For example, in a typical usage of GitHub Enterprise, it should be enough to just set `machete.github.domain`.
@@ -955,18 +988,27 @@ long_docs: Dict[str, str] = {
 
         <b>Git config keys:</b>
 
-           `machete.gitlab.{domain,remote,namespace,project}` (all subcommands):
-             GitLab API server URL will be inferred from `git remote`.
-             You can alter the default behavior by setting the following git config keys:
+           `machete.gitlab.{remote,domain,namespace,project}` (all subcommands):
+             `machete.gitlab.remote`
+                The name of the git remote (as in `git remote`) that git-machete pushes the source branch to.
+                Unless both `machete.gitlab.namespace` and `machete.gitlab.project` are set, this remote's URL is also inspected
+                to derive the GitLab namespace and project that the merge request resides in.
+                The merge request is operated on through the GitLab API, which addresses that namespace/project rather than a git remote.
+                By default (when this key is unset), if exactly one remote's URL corresponds to GitLab, that remote is selected automatically;
+                set this key to disambiguate when more than one remote points to GitLab.
+                For example, `git config machete.gitlab.remote origin`
 
-                GitLab self-managed domain
-                    E.g. `git config machete.gitlab.domain git.example.org`
+             `machete.gitlab.domain`
+                The domain of the GitLab API server, for use with a GitLab self-managed instance; otherwise inferred from the remote URL.
+                For example, `git config machete.gitlab.domain git.example.org`
 
-                Remote name (as in `git remote`)
-                    E.g. `git config machete.gitlab.remote origin`
+             `machete.gitlab.namespace`
+                The GitLab namespace (the part before the final `/` in `namespace/project`); otherwise inferred from the remote URL.
+                For example, `git config machete.gitlab.namespace foo/bar`
 
-                Namespace and project name
-                    E.g. `git config machete.gitlab.namespace foo/bar; git config machete.gitlab.project hello-world`
+             `machete.gitlab.project`
+                The GitLab project (the part after the final `/` in `namespace/project`); otherwise inferred from the remote URL.
+                For example, `git config machete.gitlab.project hello-world`
 
              Note that you do <b>not</b> need to set all four keys at once.
              For example, in a typical usage for GitLab self-managed instance, it should be enough to just set `machete.gitlab.domain`.


### PR DESCRIPTION
<!-- start git-machete generated -->

## Tree of downstream PRs as of 2026-06-23

* **PR #1734 (THIS ONE)**:
  `develop` ← `docs/githublab-access-keys`

    * PR #1733:
      `docs/githublab-access-keys` ← `fix/hublab-remote-logic`

      * PR #1728:
        `fix/hublab-remote-logic` ← `feature/base-githublab-config-keys`

<!-- end git-machete generated -->

Split the previously lumped-together `machete.{github,gitlab}.{remote,domain,organization/namespace,repository/project}` documentation into a per-key description, ordered `remote`, `domain`, then the org/repo (namespace/project) pair since the latter are derived from the former.

Clarify that `machete.{github,gitlab}.remote` names the git remote the head/source branch is pushed to,
while the PR/MR is operated on through the hosting API against the org/repo (namespace/project) the remote URL resolves to, and note that a single GitHub/GitLab remote is auto-selected when the key is unset.

Drop the now-redundant intro paragraph from the `*_access.rst` fragments (the surrounding headers already introduce them), which also lets the `:start-line:` include option - and all of its handling in `generate_py_docs.py` - go away; only `:end-line:` (still used by `status.rst`) remains.