### PR TITLE
Drop the trailing colon from headers in the reStructuredText docs and enforce it

### DIFF
--- a/ci/checks/prohibit-colon-after-header-in-rst.sh
+++ b/ci/checks/prohibit-colon-after-header-in-rst.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail -u
+
+# Headers in the docs should NOT be terminated with a colon. This covers:
+#  * definition-term headers consisting of an inline literal (optionally followed by a parenthetical),
+#    such as config keys (``machete.github.annotateWithUrls``:), subcommand signatures (``create-pr [...]``:)
+#    and environment variable names (``GIT_MACHETE_EDITOR``:),
+#  * bold section titles such as **Usage:**, **Options:** or **Git config keys:**.
+if git grep -nE -e '^``[^`]+``( \(.*\))?:$' -e '^\*\*.*:\*\*$' -- '*.rst'; then
+  echo
+  echo 'Do not put a trailing colon after a header in the docs (config key, subcommand signature, environment variable name or bold section title).'
+  echo 'Drop the colon: a header reads as a label on its own, and the colon is just visual noise.'
+  exit 1
+fi

--- a/ci/checks/run-all-checks.sh
+++ b/ci/checks/run-all-checks.sh
@@ -34,6 +34,7 @@ _ enforce-yq-check-for-each-y-yes-yq-check
 _ prohibit-a-mr
 _ prohibit-all-caps-not-in-rst
 _ prohibit-bash-usages-from-python
+_ prohibit-colon-after-header-in-rst
 _ prohibit-current-date-in-tests
 _ prohibit-deploy-step-in-circleci
 _ prohibit-double-backticks-in-python

--- a/docs/generate_py_docs.py
+++ b/docs/generate_py_docs.py
@@ -49,7 +49,7 @@ def rst2txt(rst: str) -> str:
         return lne
 
     def is_section_header(lne: str) -> bool:
-        return "Environment variables:" in lne or "Git config keys:" in lne or "Hooks:" in lne or "Subcommands:" in lne
+        return bool(re.fullmatch(r'\*\*(Environment variables|Git config keys|Hooks|Subcommands).*\*\*', lne.strip()))
 
     def process_new_option(lne: str) -> List[str]:
         lne = process_rst_formatting(lne)
@@ -61,13 +61,13 @@ def rst2txt(rst: str) -> str:
 
     for line in rst.splitlines():
         if line.startswith('=='):
-            if "**Usage:**" in rst:
+            if "**Usage**" in rst:
                 state = USAGE
             else:
                 state = NORMAL
         elif state == USAGE:
-            if "**Usage:**" in line:
-                result += ["<b>Usage:</b><b>"]
+            if "**Usage**" in line:
+                result += ["<b>Usage</b><b>"]
             elif line.startswith('    '):
                 result += [line[1:]]
             elif line and (line[0].isalpha() or line.startswith('**')):

--- a/docs/man/git-machete.1
+++ b/docs/man/git-machete.1
@@ -132,7 +132,7 @@ Print version and exit.
 .UNINDENT
 .SH ADD
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -159,7 +159,7 @@ If the upstream branch can be inferred, the user will be presented with inferred
 .sp
 Note: all the effects of \fBadd\fP (except git branch creation) can as well be achieved by manually editing the branch layout file.
 .sp
-\fBOptions:\fP
+\fBOptions\fP
 .INDENT 0.0
 .TP
 .B  \-f\fP,\fB  \-\-as\-first\-child
@@ -178,7 +178,7 @@ Don\(aqt ask for confirmation whether to create the branch or whether to add ont
 .UNINDENT
 .SH ADVANCE
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -246,7 +246,7 @@ If the current branch \fBC\fP is annotated with \fBpush=no\fP qualifier, the pus
 If the downstream branch \fBD\fP is annotated with \fBslide\-out=no\fP qualifier, the slide\-out is not performed.
 See help for traverse for more details on the qualifiers.
 .sp
-\fBOptions:\fP
+\fBOptions\fP
 .INDENT 0.0
 .TP
 .B  \-y\fP,\fB  \-\-yes
@@ -255,7 +255,7 @@ Fails if the current branch has more than one green\-edge downstream branch.
 .UNINDENT
 .SH ANNO
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -300,7 +300,7 @@ Note: \fBanno\fP command is able to overwrite the existing branch qualifiers, fo
 .sp
 Note: all the effects of \fBanno\fP can be always achieved by manually editing the branch layout file.
 .sp
-\fBOptions:\fP
+\fBOptions\fP
 .INDENT 0.0
 .TP
 .BI \-b\fP,\fB  \-\-branch\fB= <branch>
@@ -318,10 +318,10 @@ Documentation about available \fBgit machete\fP git config keys and environment 
 .sp
 Note: \fBconfig\fP is not a command as such, just a help topic (there is no \fBgit machete config\fP command).
 .sp
-\fBGit config keys:\fP
+\fBGit config keys\fP
 .INDENT 0.0
 .TP
-.B \fBmachete.github.{remote,domain,organization,repository}\fP:
+.B \fBmachete.github.{remote,domain,organization,repository}\fP
 .INDENT 7.0
 .TP
 .B \fBmachete.github.remote\fP
@@ -350,18 +350,18 @@ Note that you do \fBnot\fP need to set all four keys at once.
 For example, in a typical usage of GitHub Enterprise, it should be enough to just set \fBmachete.github.domain\fP\&.
 Only \fBmachete.github.organization\fP and \fBmachete.github.repository\fP must be specified together.
 .TP
-.B \fBmachete.github.annotateWithUrls\fP:
+.B \fBmachete.github.annotateWithUrls\fP
 Setting this config key to \fBtrue\fP will cause all commands that write GitHub PR numbers into annotations
 to not only include PR number and author (if different from the current user), but also the full URL of the PR.
 .sp
 The affected (sub)commands clearly include \fBanno \-\-sync\-github\-prs\fP and \fBgithub anno\-prs\fP,
 but also \fBgithub checkout\-prs\fP, \fBgithub create\-pr\fP, \fBgithub retarget\-pr\fP and \fBgithub restack\-pr\fP\&.
 .TP
-.B \fBmachete.github.forceDescriptionFromCommitMessage\fP:
+.B \fBmachete.github.forceDescriptionFromCommitMessage\fP
 Setting this config key to \fBtrue\fP will force \fBgit machete github create\-pr\fP to take PR description
 from the message body of the first unique commit of the branch, even if \fB\&.git/info/description\fP and/or \fB\&.github/pull_request_template.md\fP is present.
 .TP
-.B \fBmachete.github.prDescriptionIntroStyle\fP:
+.B \fBmachete.github.prDescriptionIntroStyle\fP
 .INDENT 7.0
 .TP
 .B Select the style of the generated section (\(dqintro\(dq) added to the PR description:
@@ -379,7 +379,7 @@ from the message body of the first unique commit of the branch, even if \fB\&.gi
 .UNINDENT
 .UNINDENT
 .TP
-.B \fBmachete.gitlab.{remote,domain,namespace,project}\fP:
+.B \fBmachete.gitlab.{remote,domain,namespace,project}\fP
 .INDENT 7.0
 .TP
 .B \fBmachete.gitlab.remote\fP
@@ -408,18 +408,18 @@ Note that you do \fBnot\fP need to set all four keys at once.
 For example, in a typical usage for GitLab self\-managed instance, it should be enough to just set \fBmachete.gitlab.domain\fP\&.
 Only \fBmachete.gitlab.namespace\fP and \fBmachete.gitlab.project\fP must be specified together.
 .TP
-.B \fBmachete.gitlab.annotateWithUrls\fP:
+.B \fBmachete.gitlab.annotateWithUrls\fP
 Setting this config key to \fBtrue\fP will cause all commands that write GitLab MR numbers into annotations
 to not only include MR number and author (if different from the current user), but also the full URL of the MR.
 .sp
 The affected (sub)commands clearly include \fBanno \-\-sync\-gitlab\-mrs\fP and \fBgitlab anno\-mrs\fP,
 but also \fBgitlab checkout\-mrs\fP, \fBgitlab create\-mr\fP, \fBgitlab retarget\-mr\fP and \fBgitlab restack\-mr\fP\&.
 .TP
-.B \fBmachete.gitlab.forceDescriptionFromCommitMessage\fP:
+.B \fBmachete.gitlab.forceDescriptionFromCommitMessage\fP
 Setting this config key to \fBtrue\fP will force \fBgit machete gitlab create\-mr\fP to take MR description
 from the message body of the first unique commit of the branch, even if \fB\&.git/info/description\fP and/or \fB\&.gitlab/merge_request_templates/Default.md\fP is present.
 .TP
-.B \fBmachete.gitlab.mrDescriptionIntroStyle\fP:
+.B \fBmachete.gitlab.mrDescriptionIntroStyle\fP
 .INDENT 7.0
 .TP
 .B Select the style of the generated section (\(dqintro\(dq) added to the MR description:
@@ -437,7 +437,7 @@ from the message body of the first unique commit of the branch, even if \fB\&.gi
 .UNINDENT
 .UNINDENT
 .TP
-.B \fBmachete.overrideForkPoint.<branch>.to\fP:
+.B \fBmachete.overrideForkPoint.<branch>.to\fP
 Executing \fBgit machete fork\-point \-\-override\-to[\-parent|\-inferred|=<revision>] [<branch>]\fP sets up a fork point override for \fB<branch>\fP\&.
 .sp
 The override data is stored under \fBmachete.overrideForkPoint.<branch>.to\fP git config key.
@@ -445,7 +445,7 @@ The override data is stored under \fBmachete.overrideForkPoint.<branch>.to\fP gi
 There should be \fBno\fP need for the user to interact with this key directly,
 \fBgit machete fork\-point\fP with flags should be used instead.
 .TP
-.B \fBmachete.squashMergeDetection\fP:
+.B \fBmachete.squashMergeDetection\fP
 Select the algorithm used to detect squash merges. Possible values are:
 .INDENT 7.0
 .IP \(bu 2
@@ -467,7 +467,7 @@ whether a gray edge is displayed in \fBstatus\fP,
 whether \fBtraverse\fP suggests to slide out the branch.
 .UNINDENT
 .TP
-.B \fBmachete.status.extraSpaceBeforeBranchName\fP:
+.B \fBmachete.status.extraSpaceBeforeBranchName\fP
 To make it easier to select branch name from the \fBstatus\fP output on certain terminals (like Alacritty \%<https://\:github\:.com/\:alacritty/\:alacritty>),
 you can add an extra space between └─ and branch name by setting \fBgit config machete.status.extraSpaceBeforeBranchName true\fP\&.
 .sp
@@ -499,18 +499,18 @@ develop
 .UNINDENT
 .UNINDENT
 .TP
-.B \fBmachete.traverse.fetch.<remote>\fP:
+.B \fBmachete.traverse.fetch.<remote>\fP
 Configure the behavior of \fBgit machete traverse\fP command for the given remote when \fB\-\-fetch\fP flag is used.
 If set to \fBfalse\fP, this remote will not be fetched before the traversal.
 The default value of this key is \fBtrue\fP\&.
 This is useful for excluding remotes that are temporarily offline, or take a long time to respond.
 .TP
-.B \fBmachete.traverse.push\fP:
+.B \fBmachete.traverse.push\fP
 Set to \fBfalse\fP to change the behavior of \fBgit machete traverse\fP so that it doesn\(aqt push branches by default.
 The default value of this key is \fBtrue\fP\&.
 Configuration key value can be overridden by the presence of the \fB\-\-push\fP or \fB\-\-push\-untracked\fP flags.
 .TP
-.B \fBmachete.traverse.whenBranchNotCheckedOutInAnyWorktree\fP:
+.B \fBmachete.traverse.whenBranchNotCheckedOutInAnyWorktree\fP
 Controls the behavior of \fBgit machete traverse\fP when it needs to act on a branch that is not currently checked out in any worktree.
 .sp
 Allowed values:
@@ -526,7 +526,7 @@ and remove this temporary worktree once \fBtraverse\fP moves on to the next bran
 This ensures that no existing (non\-temporary) worktree has its checked\-out branch changed by \fBtraverse\fP\&.
 .UNINDENT
 .TP
-.B \fBmachete.worktree.useTopLevelMacheteFile\fP:
+.B \fBmachete.worktree.useTopLevelMacheteFile\fP
 The default value of this key is \fBtrue\fP, which means that the path to branch layout file will be \fB\&.git/machete\fP
 for both regular directory and worktree.
 .sp
@@ -534,7 +534,7 @@ If you want the worktree to have its own branch layout file (located under \fB\&
 set \fBgit config machete.worktree.useTopLevelMacheteFile false\fP\&.
 .UNINDENT
 .sp
-\fBEnvironment variables:\fP
+\fBEnvironment variables\fP
 .INDENT 0.0
 .TP
 .B \fBGIT_MACHETE_EDITOR\fP
@@ -554,7 +554,7 @@ Used to store GitLab API token. Used by commands such as \fBanno \-\-sync\-gitla
 .UNINDENT
 .SH CLEAN
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -589,7 +589,7 @@ For enterprise domains, non\-standard URLs etc., check git config keys in \fBgit
 .UNINDENT
 .UNINDENT
 .sp
-\fBOptions:\fP
+\fBOptions\fP
 .INDENT 0.0
 .TP
 .B  \-H\fP,\fB  \-\-checkout\-my\-github\-prs
@@ -599,7 +599,7 @@ Checkout your open PRs into local branches.
 Don\(aqt ask for confirmation when deleting branches from git.
 .UNINDENT
 .sp
-\fBEnvironment variables:\fP
+\fBEnvironment variables\fP
 .INDENT 0.0
 .TP
 .B \fBGITHUB_TOKEN\fP
@@ -607,7 +607,7 @@ GitHub API token.
 .UNINDENT
 .SH COMPLETION
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -621,7 +621,7 @@ where \fB<shell>\fP is one of: \fBbash\fP, \fBfish\fP, \fBzsh\fP\&.
 .sp
 Prints out completion scripts.
 .sp
-\fBSupported shells:\fP
+\fBSupported shells\fP
 .sp
 \fBbash\fP
 .sp
@@ -662,7 +662,7 @@ source <(git machete completion zsh)
 .UNINDENT
 .SH DELETE-UNMANAGED
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -680,7 +680,7 @@ Note: this should be used with care since deleting local branches can sometimes 
 for \fBgit machete\fP to properly figure out fork points.
 See help for fork\-point for more details.
 .sp
-\fBOptions:\fP
+\fBOptions\fP
 .INDENT 0.0
 .TP
 .B  \-y\fP,\fB  \-\-yes
@@ -688,7 +688,7 @@ Don\(aqt ask for confirmation.
 .UNINDENT
 .SH DIFF
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -704,7 +704,7 @@ See help for fork\-point for more details.
 .sp
 Note: the branch in question does not need to occur in the branch layout file.
 .sp
-\fBOptions:\fP
+\fBOptions\fP
 .sp
 \-\- <pass\-through\-arguments>    Arguments to pass directly to the underlying \fBgit diff\fP, for example \fBgit machete diff \-\- \-\-name\-only\fP\&.
 .INDENT 0.0
@@ -714,7 +714,7 @@ Make \fBgit machete diff\fP pass \fB\-\-stat\fP option to \fBgit diff\fP, so tha
 .UNINDENT
 .SH DISCOVER
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -731,7 +731,7 @@ and saves the new tree under the usual \fB$GIT_DIR/machete\fP path.
 If the reply was \fBe[dit]\fP, additionally an editor is opened (as in: \fBgit machete\fP edit) after saving the new branch layout file.
 \fBdiscover\fP retains the existing branch qualifiers used by \fBgit machete traverse\fP (see help for traverse).
 .sp
-\fBOptions:\fP
+\fBOptions\fP
 .INDENT 0.0
 .TP
 .BI \-C\fP,\fB  \-\-checked\-out\-since\fB= <date>
@@ -754,7 +754,7 @@ Mostly useful in scripts; not recommended for manual use.
 .UNINDENT
 .SH EDIT
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -794,7 +794,7 @@ but not for any other actions that may be indirectly triggered by git machete, i
 The branch layout file can be always accessed and edited directly under the path returned by \fBgit machete file\fP
 (usually \fB\&.git/machete\fP, unless worktrees or submodules are involved).
 .sp
-\fBEnvironment variables:\fP
+\fBEnvironment variables\fP
 .INDENT 0.0
 .TP
 .B \fBGIT_MACHETE_EDITOR\fP
@@ -802,7 +802,7 @@ Name of the editor executable.
 .UNINDENT
 .SH FILE
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -834,7 +834,7 @@ if \fBgit machete\fP is executed from a \fBsubmodule\fP, this file is located in
 .UNINDENT
 .SH FORK-POINT
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -938,7 +938,7 @@ Tabs or any number of spaces can be used as indentation.
 It\(aqs only important to use indentation characters consistently between all lines.
 .SH GITHUB
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -996,10 +996,10 @@ ghp_yetanothertoken_for_git_example_com git.example.com
 .UNINDENT
 .UNINDENT
 .sp
-\fBSubcommands:\fP
+\fBSubcommands\fP
 .INDENT 0.0
 .TP
-.B \fBanno\-prs [\-\-with\-urls]\fP:
+.B \fBanno\-prs [\-\-with\-urls]\fP
 Annotate the branches based on their corresponding GitHub PR numbers and authors.
 Any existing annotations are overwritten for the branches that have an opened PR; annotations for the other branches remain untouched.
 Equivalent to \fBgit machete anno \-\-sync\-github\-prs\fP\&.
@@ -1014,7 +1014,7 @@ so that you don\(aqt rebase or push someone else\(aqs PR by accident (see help f
 Also include full PR URLs in the annotations (rather than just PR number).
 .UNINDENT
 .TP
-.B \fBcheckout\-prs [\-\-all | \-\-by=<github\-login> | \-\-mine | <PR\-number\-1> ... <PR\-number\-N>]\fP:
+.B \fBcheckout\-prs [\-\-all | \-\-by=<github\-login> | \-\-mine | <PR\-number\-1> ... <PR\-number\-N>]\fP
 Check out the head branch of the given pull requests (specified by numbers or by a flag),
 also traverse chain of pull requests upwards, adding branches one by one to git\-machete and check them out locally.
 Once the specified pull requests are checked out locally, annotate local branches with corresponding pull request numbers.
@@ -1040,7 +1040,7 @@ Checkout open PRs for the current user associated with the GitHub token.
 .sp
 \fB<PR\-number\-1> ... <PR\-number\-N>\fP    Pull request numbers to checkout.
 .TP
-.B \fBcreate\-pr [\-\-draft] [\-\-title=<title>] [\-U|\-\-update\-related\-descriptions] [\-y|\-\-yes]\fP:
+.B \fBcreate\-pr [\-\-draft] [\-\-title=<title>] [\-U|\-\-update\-related\-descriptions] [\-y|\-\-yes]\fP
 Create a PR for the current branch, using the upstream (parent) branch as the PR base.
 Once the PR is successfully created, annotate the current branch with the new PR\(aqs number.
 .sp
@@ -1073,7 +1073,7 @@ See help for \fBgit machete github update\-pr\-descriptions \-\-related\fP for d
 Do not ask for confirmation whether to push the branch.
 .UNINDENT
 .TP
-.B \fBrestack\-pr [\-U|\-\-update\-related\-descriptions]\fP:
+.B \fBrestack\-pr [\-U|\-\-update\-related\-descriptions]\fP
 Perform the following sequence of actions:
 .INDENT 7.0
 .IP 1. 3
@@ -1097,7 +1097,7 @@ Update the generated sections (\(dqintros\(dq) of PR descriptions that list the 
 See help for \fBgit machete github update\-pr\-descriptions \-\-related\fP for details.
 .UNINDENT
 .TP
-.B \fBretarget\-pr [\-b|\-\-branch=<branch>] [\-\-ignore\-if\-missing] [\-U|\-\-update\-related\-descriptions]\fP:
+.B \fBretarget\-pr [\-b|\-\-branch=<branch>] [\-\-ignore\-if\-missing] [\-U|\-\-update\-related\-descriptions]\fP
 Set the base of the current (or specified) branch\(aqs PR to upstream (parent) branch, as seen by git machete (see \fBgit machete show up\fP).
 .sp
 If after changing the base the PR ends up stacked atop another PR, the PR description posted to GitHub will include
@@ -1119,7 +1119,7 @@ Update the generated sections (\(dqintros\(dq) of PR descriptions that list the 
 See help for \fBgit machete github update\-pr\-descriptions \-\-related\fP for details.
 .UNINDENT
 .TP
-.B \fBsync\fP:
+.B \fBsync\fP
 \fBDeprecated.\fP Use \fBgithub checkout\-prs \-\-mine\fP, \fBdelete\-unmanaged\fP and \fBslide\-out \-\-removed\-from\-remote\fP\&.
 .sp
 Synchronize with the remote repository:
@@ -1133,7 +1133,7 @@ delete unmanaged branches,
 delete untracked managed branches that have no downstream branch.
 .UNINDENT
 .TP
-.B \fBupdate\-pr\-descriptions [\-\-all | \-\-by=<github\-login> | \-\-mine | \-\-related]\fP:
+.B \fBupdate\-pr\-descriptions [\-\-all | \-\-by=<github\-login> | \-\-mine | \-\-related]\fP
 Update the generated sections (\(dqintros\(dq) of PR descriptions that list the upstream and/or downstream PRs
 (depending on \fBmachete.github.prDescriptionIntroStyle\fP git config key).
 .sp
@@ -1156,10 +1156,10 @@ Update PR descriptions for all PRs both upstream and downstream of the PR for th
 .UNINDENT
 .UNINDENT
 .sp
-\fBGit config keys:\fP
+\fBGit config keys\fP
 .INDENT 0.0
 .TP
-.B \fBmachete.github.{remote,domain,organization,repository}\fP (all subcommands):
+.B \fBmachete.github.{remote,domain,organization,repository}\fP (all subcommands)
 .INDENT 7.0
 .TP
 .B \fBmachete.github.remote\fP
@@ -1188,18 +1188,18 @@ Note that you do \fBnot\fP need to set all four keys at once.
 For example, in a typical usage of GitHub Enterprise, it should be enough to just set \fBmachete.github.domain\fP\&.
 Only \fBmachete.github.organization\fP and \fBmachete.github.repository\fP must be specified together.
 .TP
-.B \fBmachete.github.annotateWithUrls\fP (all subcommands):
+.B \fBmachete.github.annotateWithUrls\fP (all subcommands)
 Setting this config key to \fBtrue\fP will cause all commands that write GitHub PR numbers into annotations
 to not only include PR number and author (if different from the current user), but also the full URL of the PR.
 .sp
 The affected (sub)commands clearly include \fBanno \-\-sync\-github\-prs\fP and \fBgithub anno\-prs\fP,
 but also \fBgithub checkout\-prs\fP, \fBgithub create\-pr\fP, \fBgithub retarget\-pr\fP and \fBgithub restack\-pr\fP\&.
 .TP
-.B \fBmachete.github.forceDescriptionFromCommitMessage\fP (\fBcreate\-pr\fP only):
+.B \fBmachete.github.forceDescriptionFromCommitMessage\fP (\fBcreate\-pr\fP only)
 Setting this config key to \fBtrue\fP will force \fBgit machete github create\-pr\fP to take PR description
 from the message body of the first unique commit of the branch, even if \fB\&.git/info/description\fP and/or \fB\&.github/pull_request_template.md\fP is present.
 .TP
-.B \fBmachete.github.prDescriptionIntroStyle\fP (\fBcreate\-pr\fP, \fBrestack\-pr\fP and \fBretarget\-pr\fP):
+.B \fBmachete.github.prDescriptionIntroStyle\fP (\fBcreate\-pr\fP, \fBrestack\-pr\fP and \fBretarget\-pr\fP)
 .INDENT 7.0
 .TP
 .B Select the style of the generated section (\(dqintro\(dq) added to the PR description:
@@ -1218,7 +1218,7 @@ from the message body of the first unique commit of the branch, even if \fB\&.gi
 .UNINDENT
 .UNINDENT
 .sp
-\fBEnvironment variables (all subcommands):\fP
+\fBEnvironment variables (all subcommands)\fP
 .INDENT 0.0
 .TP
 .B \fBGITHUB_TOKEN\fP
@@ -1226,7 +1226,7 @@ GitHub API token.
 .UNINDENT
 .SH GITLAB
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -1282,10 +1282,10 @@ glpat\-yetanothertoken_for_git_example_com git.example.com
 .UNINDENT
 .UNINDENT
 .sp
-\fBSubcommands:\fP
+\fBSubcommands\fP
 .INDENT 0.0
 .TP
-.B \fBanno\-mrs [\-\-with\-urls]\fP:
+.B \fBanno\-mrs [\-\-with\-urls]\fP
 Annotate the branches based on their corresponding GitLab MR numbers and authors.
 Any existing annotations are overwritten for the branches that have an opened MR; annotations for the other branches remain untouched.
 Equivalent to \fBgit machete anno \-\-sync\-gitlab\-mrs\fP\&.
@@ -1300,7 +1300,7 @@ so that you don\(aqt rebase or push someone else\(aqs MR by accident (see help f
 Also include full MR URLs in the annotations (rather than just MR number).
 .UNINDENT
 .TP
-.B \fBcheckout\-mrs [\-\-all | \-\-by=<gitlab\-login> | \-\-mine | <MR\-number\-1> ... <MR\-number\-N>]\fP:
+.B \fBcheckout\-mrs [\-\-all | \-\-by=<gitlab\-login> | \-\-mine | <MR\-number\-1> ... <MR\-number\-N>]\fP
 Check out the source branch of the given merge requests (specified by numbers or by a flag),
 also traverse chain of merge requests upwards, adding branches one by one to git\-machete and check them out locally.
 Once the specified merge requests are checked out locally, annotate local branches with corresponding merge request numbers.
@@ -1326,7 +1326,7 @@ Checkout open MRs for the current user associated with the GitLab token.
 .sp
 \fB<MR\-number\-1> ... <MR\-number\-N>\fP    Merge request numbers to checkout.
 .TP
-.B \fBcreate\-mr [\-\-draft] [\-\-title=<title>] [\-U|\-\-update\-related\-descriptions] [\-y|\-\-yes]\fP:
+.B \fBcreate\-mr [\-\-draft] [\-\-title=<title>] [\-U|\-\-update\-related\-descriptions] [\-y|\-\-yes]\fP
 Create an MR for the current branch, using the upstream (parent) branch as the MR source branch.
 Once the MR is successfully created, annotate the current branch with the new MR\(aqs number.
 .sp
@@ -1361,7 +1361,7 @@ See help for \fBgit machete gitlab update\-mr\-descriptions \-\-related\fP for d
 Do not ask for confirmation whether to push the branch.
 .UNINDENT
 .TP
-.B \fBrestack\-mr [\-U|\-\-update\-related\-descriptions]\fP:
+.B \fBrestack\-mr [\-U|\-\-update\-related\-descriptions]\fP
 Perform the following sequence of actions:
 .INDENT 7.0
 .IP 1. 3
@@ -1385,7 +1385,7 @@ Update the generated sections (\(dqintros\(dq) of MR descriptions that list the 
 See help for \fBgit machete gitlab update\-mr\-descriptions \-\-related\fP for details.
 .UNINDENT
 .TP
-.B \fBretarget\-mr [\-b|\-\-branch=<branch>] [\-\-ignore\-if\-missing] [\-U|\-\-update\-related\-descriptions]\fP:
+.B \fBretarget\-mr [\-b|\-\-branch=<branch>] [\-\-ignore\-if\-missing] [\-U|\-\-update\-related\-descriptions]\fP
 Set the target of the current (or specified) branch\(aqs MR to upstream (parent) branch, as seen by git machete (see \fBgit machete show up\fP).
 .sp
 If after changing the base the MR ends up stacked atop another MR, the MR description posted to GitLab will include
@@ -1407,7 +1407,7 @@ Update the generated sections (\(dqintros\(dq) of MR descriptions that list the 
 See help for \fBgit machete gitlab update\-mr\-descriptions \-\-related\fP for details.
 .UNINDENT
 .TP
-.B \fBupdate\-mr\-descriptions [\-\-all | \-\-by=<gitlab\-login> | \-\-mine | \-\-related]\fP:
+.B \fBupdate\-mr\-descriptions [\-\-all | \-\-by=<gitlab\-login> | \-\-mine | \-\-related]\fP
 Update the generated sections (\(dqintros\(dq) of MR descriptions that list the upstream and/or downstream MRs
 (depending on \fBmachete.gitlab.mrDescriptionIntroStyle\fP git config key).
 .sp
@@ -1430,10 +1430,10 @@ Update MR descriptions for all MRs both upstream and downstream of the MR for th
 .UNINDENT
 .UNINDENT
 .sp
-\fBGit config keys:\fP
+\fBGit config keys\fP
 .INDENT 0.0
 .TP
-.B \fBmachete.gitlab.{remote,domain,namespace,project}\fP (all subcommands):
+.B \fBmachete.gitlab.{remote,domain,namespace,project}\fP (all subcommands)
 .INDENT 7.0
 .TP
 .B \fBmachete.gitlab.remote\fP
@@ -1462,18 +1462,18 @@ Note that you do \fBnot\fP need to set all four keys at once.
 For example, in a typical usage for GitLab self\-managed instance, it should be enough to just set \fBmachete.gitlab.domain\fP\&.
 Only \fBmachete.gitlab.namespace\fP and \fBmachete.gitlab.project\fP must be specified together.
 .TP
-.B \fBmachete.gitlab.annotateWithUrls\fP (all subcommands):
+.B \fBmachete.gitlab.annotateWithUrls\fP (all subcommands)
 Setting this config key to \fBtrue\fP will cause all commands that write GitLab MR numbers into annotations
 to not only include MR number and author (if different from the current user), but also the full URL of the MR.
 .sp
 The affected (sub)commands clearly include \fBanno \-\-sync\-gitlab\-mrs\fP and \fBgitlab anno\-mrs\fP,
 but also \fBgitlab checkout\-mrs\fP, \fBgitlab create\-mr\fP, \fBgitlab retarget\-mr\fP and \fBgitlab restack\-mr\fP\&.
 .TP
-.B \fBmachete.gitlab.forceDescriptionFromCommitMessage\fP (\fBcreate\-mr\fP only):
+.B \fBmachete.gitlab.forceDescriptionFromCommitMessage\fP (\fBcreate\-mr\fP only)
 Setting this config key to \fBtrue\fP will force \fBgit machete gitlab create\-mr\fP to take MR description
 from the message body of the first unique commit of the branch, even if \fB\&.git/info/description\fP and/or \fB\&.gitlab/merge_request_templates/Default.md\fP is present.
 .TP
-.B \fBmachete.gitlab.mrDescriptionIntroStyle\fP (\fBcreate\-mr\fP, \fBrestack\-mr\fP and \fBretarget\-mr\fP):
+.B \fBmachete.gitlab.mrDescriptionIntroStyle\fP (\fBcreate\-mr\fP, \fBrestack\-mr\fP and \fBretarget\-mr\fP)
 .INDENT 7.0
 .TP
 .B Select the style of the generated section (\(dqintro\(dq) added to the MR description:
@@ -1492,7 +1492,7 @@ from the message body of the first unique commit of the branch, even if \fB\&.gi
 .UNINDENT
 .UNINDENT
 .sp
-\fBEnvironment variables (all subcommands):\fP
+\fBEnvironment variables (all subcommands)\fP
 .INDENT 0.0
 .TP
 .B \fBGITLAB_TOKEN\fP
@@ -1500,7 +1500,7 @@ GitLab API token.
 .UNINDENT
 .SH GO
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -1514,7 +1514,7 @@ where <direction> is one of: \fBd[own]\fP, \fBf[irst]\fP, \fBl[ast]\fP, \fBn[ext
 .sp
 If \fB<direction>\fP is not provided, an interactive mode is launched where you can navigate the branch tree using arrow keys and select a branch to check out.
 .sp
-\fBInteractive mode controls:\fP
+\fBInteractive mode controls\fP
 .INDENT 0.0
 .IP \(bu 2
 \fB↑/↓\fP: Navigate up/down through branches
@@ -1559,7 +1559,7 @@ since all branches are usually meant to be ultimately merged to one of those.
 This is roughly equivalent to \fBgit checkout $(git machete show <direction>)\fP\&.
 .SH HELP
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -1577,7 +1577,7 @@ All hooks are executed from the top\-level folder of the repository (or top\-lev
 .sp
 Note: \fBhooks\fP is not a command as such, just a help topic (there is no \fBgit machete hooks\fP command).
 .sp
-\fBHooks:\fP
+\fBHooks\fP
 .INDENT 0.0
 .TP
 .B \fBmachete\-post\-slide\-out <new\-upstream> <lowest\-slid\-out\-branch> [<new\-downstreams>...]\fP
@@ -1653,7 +1653,7 @@ Please see hook_samples \%<https://\:github\:.com/\:VirtusLab/\:git-machete/\:tr
 An example of using the standard git \fBpost\-commit hook\fP to \fBgit machete add\fP branches automatically is also included.
 .SH IS-MANAGED
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -1676,7 +1676,7 @@ the <branch> isn\(aqt provided and there\(aqs no current branch (detached HEAD).
 .UNINDENT
 .SH LIST
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -1713,7 +1713,7 @@ it was only ever used to drive \fBslide\-out\fP completion of the second and fur
 This command is generally not meant for a day\-to\-day use, it\(aqs mostly needed for branch name completion in shell.
 .SH LOG
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -1728,12 +1728,12 @@ See help for fork\-point for more details on meaning of the \fIfork point\fP\&.
 .sp
 Note: the branch in question does not need to occur in the branch layout file.
 .sp
-\fBOptions:\fP
+\fBOptions\fP
 .sp
 \-\- <pass\-through\-arguments>    Arguments to pass directly to the underlying \fBgit log\fP, for example \fBgit machete log \-\- \-\-patch\fP\&.
 .SH REAPPLY
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -1753,14 +1753,14 @@ Note: the current reapplied branch does not need to occur in the branch layout f
 Tip: \fBreapply\fP can be used for squashing the commits on the current branch to make history more condensed before push to the remote,
 but there is also dedicated \fBsquash\fP command that achieves the same goal without running \fBgit rebase\fP\&.
 .sp
-\fBOptions:\fP
+\fBOptions\fP
 .INDENT 0.0
 .TP
 .BI \-f\fP,\fB  \-\-fork\-point\fB= <fork\-point\-commit>
 Specifies the alternative fork point commit after which the rebased part of history is meant to start.
 .UNINDENT
 .sp
-\fBEnvironment variables:\fP
+\fBEnvironment variables\fP
 .INDENT 0.0
 .TP
 .B \fBGIT_MACHETE_REBASE_OPTS\fP
@@ -1769,7 +1769,7 @@ Example: \fBGIT_MACHETE_REBASE_OPTS=\(dq\-\-keep\-empty \-\-rebase\-merges\(dq g
 .UNINDENT
 .SH RENAME
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -1790,7 +1790,7 @@ As a result, after the rename the local branch still tracks the same remote bran
 Note: \fBrename\fP does \fBnot\fP rename the branch on the remote — it only renames the local branch.
 The remote branch is left intact and can still be pushed to under its original name.
 .sp
-\fBOptions:\fP
+\fBOptions\fP
 .INDENT 0.0
 .TP
 .BI \-b\fP,\fB  \-\-branch\fB= <branch>
@@ -1804,7 +1804,7 @@ branch it pointed to before (for example \fBorigin/old\-name\fP).
 .UNINDENT
 .SH SHOW
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -1842,7 +1842,7 @@ since all branches are usually meant to be ultimately merged to one of those.
 .UNINDENT
 .SH SLIDE-OUT
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -1910,7 +1910,7 @@ Note: Unless \fB\-\-delete\fP is passed, \fBslide\-out\fP doesn\(aqt delete any 
 Note: if a child branch is annotated with \fBrebase=no\fP qualifier, the rebase is not performed.
 See help for traverse for more details on the qualifiers.
 .sp
-\fBOptions:\fP
+\fBOptions\fP
 .INDENT 0.0
 .TP
 .BI \-d\fP,\fB  \-\-down\-fork\-point\fB= <down\-fork\-point\-commit>
@@ -1957,7 +1957,7 @@ those that have at least one downstream (child) branch.
 .UNINDENT
 .UNINDENT
 .sp
-\fBEnvironment variables:\fP
+\fBEnvironment variables\fP
 .INDENT 0.0
 .TP
 .B \fBGIT_MACHETE_REBASE_OPTS\fP
@@ -1966,7 +1966,7 @@ Example: \fBGIT_MACHETE_REBASE_OPTS=\(dq\-\-keep\-empty \-\-rebase\-merges\(dq g
 .UNINDENT
 .SH SQUASH
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -1988,7 +1988,7 @@ for example \fBgit machete squash \-\-fork\-point=HEAD~3\fP\&.
 Note: \fBsquash\fP does \fBnot\fP run \fBgit rebase\fP under the hood.
 For more complex scenarios that require rewriting the history of current branch, see \fBreapply\fP and \fBupdate\fP\&.
 .sp
-\fBOptions:\fP
+\fBOptions\fP
 .INDENT 0.0
 .TP
 .BI \-f\fP,\fB  \-\-fork\-point\fB= <fork\-point\-commit>
@@ -1996,7 +1996,7 @@ Specify the alternative fork point commit after which the squashed part of histo
 .UNINDENT
 .SH STATUS
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -2112,7 +2112,7 @@ develop
 .UNINDENT
 .UNINDENT
 .sp
-\fBOptions:\fP
+\fBOptions\fP
 .INDENT 0.0
 .TP
 .BI \-\-color\fB= WHEN
@@ -2135,10 +2135,10 @@ Specify the mode for detection of rebase/squash merges (gray edges).
 See the below paragraph on \fBmachete.squashMergeDetection\fP git config key for more details.
 .UNINDENT
 .sp
-\fBGit config keys:\fP
+\fBGit config keys\fP
 .INDENT 0.0
 .TP
-.B \fBmachete.squashMergeDetection\fP:
+.B \fBmachete.squashMergeDetection\fP
 Select the algorithm used to detect squash merges. Possible values are:
 .INDENT 7.0
 .IP \(bu 2
@@ -2160,13 +2160,13 @@ whether a gray edge is displayed in \fBstatus\fP,
 whether \fBtraverse\fP suggests to slide out the branch.
 .UNINDENT
 .TP
-.B \fBmachete.status.extraSpaceBeforeBranchName\fP:
+.B \fBmachete.status.extraSpaceBeforeBranchName\fP
 To make it easier to select branch name from the \fBstatus\fP output on certain terminals (like Alacritty \%<https://\:github\:.com/\:alacritty/\:alacritty>),
 you can add an extra space between └─ and branch name by setting \fBgit config machete.status.extraSpaceBeforeBranchName true\fP\&.
 .UNINDENT
 .SH TRAVERSE
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -2283,7 +2283,7 @@ when the current user is \fBnot\fP the author of the PR/MR associated with that 
 If a branch is not checked out in any worktree, by default \fBtraverse\fP will change directory to the main worktree before checking out the branch.
 This behavior can be customized using \fBmachete.traverse.whenBranchNotCheckedOutInAnyWorktree\fP git config key (see below).
 .sp
-\fBOptions:\fP
+\fBOptions\fP
 .INDENT 0.0
 .TP
 .B  \-F\fP,\fB  \-\-fetch
@@ -2369,10 +2369,10 @@ Equivalent to \fB\-\-fetch \-\-whole\fP; useful for even more automated traversa
 Don\(aqt ask for any interactive input, including confirmation of rebase/push/pull. Implies \fB\-n\fP\&.
 .UNINDENT
 .sp
-\fBGit config keys:\fP
+\fBGit config keys\fP
 .INDENT 0.0
 .TP
-.B \fBmachete.squashMergeDetection\fP:
+.B \fBmachete.squashMergeDetection\fP
 Select the algorithm used to detect squash merges. Possible values are:
 .INDENT 7.0
 .IP \(bu 2
@@ -2394,18 +2394,18 @@ whether a gray edge is displayed in \fBstatus\fP,
 whether \fBtraverse\fP suggests to slide out the branch.
 .UNINDENT
 .TP
-.B \fBmachete.traverse.fetch.<remote>\fP:
+.B \fBmachete.traverse.fetch.<remote>\fP
 Configure the behavior of \fBgit machete traverse\fP command for the given remote when \fB\-\-fetch\fP flag is used.
 If set to \fBfalse\fP, this remote will not be fetched before the traversal.
 The default value of this key is \fBtrue\fP\&.
 This is useful for excluding remotes that are temporarily offline, or take a long time to respond.
 .TP
-.B \fBmachete.traverse.push\fP:
+.B \fBmachete.traverse.push\fP
 Set to \fBfalse\fP to change the behavior of \fBgit machete traverse\fP so that it doesn\(aqt push branches by default.
 The default value of this key is \fBtrue\fP\&.
 Configuration key value can be overridden by the presence of the \fB\-\-push\fP or \fB\-\-push\-untracked\fP flags.
 .TP
-.B \fBmachete.traverse.whenBranchNotCheckedOutInAnyWorktree\fP:
+.B \fBmachete.traverse.whenBranchNotCheckedOutInAnyWorktree\fP
 Controls the behavior of \fBgit machete traverse\fP when it needs to act on a branch that is not currently checked out in any worktree.
 .sp
 Allowed values:
@@ -2422,7 +2422,7 @@ This ensures that no existing (non\-temporary) worktree has its checked\-out bra
 .UNINDENT
 .UNINDENT
 .sp
-\fBEnvironment variables:\fP
+\fBEnvironment variables\fP
 .INDENT 0.0
 .TP
 .B \fBGIT_MACHETE_REBASE_OPTS\fP
@@ -2431,7 +2431,7 @@ Example: \fBGIT_MACHETE_REBASE_OPTS=\(dq\-\-keep\-empty \-\-rebase\-merges\(dq g
 .UNINDENT
 .SH UPDATE
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -2450,7 +2450,7 @@ See help for fork\-point for more details.
 .sp
 If updating by merge, merges the upstream (parent) branch into the current branch.
 .sp
-\fBOptions:\fP
+\fBOptions\fP
 .INDENT 0.0
 .TP
 .BI \-f\fP,\fB  \-\-fork\-point\fB= <fork\-point\-commit>
@@ -2473,7 +2473,7 @@ If updating by rebase, run \fBgit rebase\fP in non\-interactive mode (without \f
 Not allowed if updating by merge.
 .UNINDENT
 .sp
-\fBEnvironment variables:\fP
+\fBEnvironment variables\fP
 .INDENT 0.0
 .TP
 .B \fBGIT_MACHETE_REBASE_OPTS\fP
@@ -2482,7 +2482,7 @@ Example: \fBGIT_MACHETE_REBASE_OPTS=\(dq\-\-keep\-empty \-\-rebase\-merges\(dq g
 .UNINDENT
 .SH VERSION
 .sp
-\fBUsage:\fP
+\fBUsage\fP
 .INDENT 0.0
 .INDENT 3.5
 .sp

--- a/docs/source/cli/add.rst
+++ b/docs/source/cli/add.rst
@@ -2,7 +2,7 @@
 
 add
 ===
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 
@@ -22,7 +22,7 @@ If the upstream branch can be inferred, the user will be presented with inferred
 
 Note: all the effects of ``add`` (except git branch creation) can as well be achieved by manually editing the branch layout file.
 
-**Options:**
+**Options**
 
 -f, --as-first-child                   Add the given branch as the first (instead of last) child of its parent.
                                        Cannot be specified together with ``-R/--as-root``.

--- a/docs/source/cli/advance.rst
+++ b/docs/source/cli/advance.rst
@@ -2,7 +2,7 @@
 
 advance
 =======
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 
@@ -54,7 +54,7 @@ If the current branch ``C`` is annotated with ``push=no`` qualifier, the push is
 If the downstream branch ``D`` is annotated with ``slide-out=no`` qualifier, the slide-out is not performed.
 See help for :ref:`traverse` for more details on the qualifiers.
 
-**Options:**
+**Options**
 
 -y, --yes         Don't ask for confirmation whether to fast-forward the current branch or whether to slide-out the downstream.
                   Fails if the current branch has more than one :green:`green-edge` downstream branch.

--- a/docs/source/cli/anno.rst
+++ b/docs/source/cli/anno.rst
@@ -2,7 +2,7 @@
 
 anno
 ====
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 
@@ -40,7 +40,7 @@ Note: ``anno`` command is able to overwrite the existing branch qualifiers, for 
 
 Note: all the effects of ``anno`` can be always achieved by manually editing the branch layout file.
 
-**Options:**
+**Options**
 
 -b, --branch=<branch>     Branch to set the annotation for.
 

--- a/docs/source/cli/clean.rst
+++ b/docs/source/cli/clean.rst
@@ -2,7 +2,7 @@
 
 clean
 =====
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 
@@ -26,13 +26,13 @@ Equivalent of ``git machete github sync`` if invoked with ``-H`` or ``--checkout
   TL;DR: ``GITHUB_TOKEN`` env var or ``~/.github-token`` file or ``gh``/``hub`` CLI configs if exist.
   For enterprise domains, non-standard URLs etc., check git config keys in ``github`` help.
 
-**Options:**
+**Options**
 
 -H, --checkout-my-github-prs    Checkout your open PRs into local branches.
 
 -y, --yes                       Don't ask for confirmation when deleting branches from git.
 
-**Environment variables:**
+**Environment variables**
 
 ``GITHUB_TOKEN``
     GitHub API token.

--- a/docs/source/cli/completion.rst
+++ b/docs/source/cli/completion.rst
@@ -2,7 +2,7 @@
 
 completion
 ==========
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 
@@ -12,7 +12,7 @@ where ``<shell>`` is one of: ``bash``, ``fish``, ``zsh``.
 
 Prints out completion scripts.
 
-**Supported shells:**
+**Supported shells**
 
 **bash**
 

--- a/docs/source/cli/config.rst
+++ b/docs/source/cli/config.rst
@@ -6,33 +6,33 @@ Documentation about available ``git machete`` git config keys and environment va
 
 Note: ``config`` is not a command as such, just a help topic (there is no ``git machete config`` command).
 
-**Git config keys:**
+**Git config keys**
 
-``machete.github.{remote,domain,organization,repository}``:
+``machete.github.{remote,domain,organization,repository}``
   .. include:: git-config-keys/github_access.rst
 
-``machete.github.annotateWithUrls``:
+``machete.github.annotateWithUrls``
   .. include:: git-config-keys/github_annotateWithUrls.rst
 
-``machete.github.forceDescriptionFromCommitMessage``:
+``machete.github.forceDescriptionFromCommitMessage``
   .. include:: git-config-keys/github_forceDescriptionFromCommitMessage.rst
 
-``machete.github.prDescriptionIntroStyle``:
+``machete.github.prDescriptionIntroStyle``
   .. include:: git-config-keys/github_prDescriptionIntroStyle.rst
 
-``machete.gitlab.{remote,domain,namespace,project}``:
+``machete.gitlab.{remote,domain,namespace,project}``
   .. include:: git-config-keys/gitlab_access.rst
 
-``machete.gitlab.annotateWithUrls``:
+``machete.gitlab.annotateWithUrls``
   .. include:: git-config-keys/gitlab_annotateWithUrls.rst
 
-``machete.gitlab.forceDescriptionFromCommitMessage``:
+``machete.gitlab.forceDescriptionFromCommitMessage``
   .. include:: git-config-keys/gitlab_forceDescriptionFromCommitMessage.rst
 
-``machete.gitlab.mrDescriptionIntroStyle``:
+``machete.gitlab.mrDescriptionIntroStyle``
   .. include:: git-config-keys/gitlab_mrDescriptionIntroStyle.rst
 
-``machete.overrideForkPoint.<branch>.to``:
+``machete.overrideForkPoint.<branch>.to``
     Executing ``git machete fork-point --override-to[-parent|-inferred|=<revision>] [<branch>]`` sets up a fork point override for ``<branch>``.
 
     The override data is stored under ``machete.overrideForkPoint.<branch>.to`` git config key.
@@ -40,31 +40,31 @@ Note: ``config`` is not a command as such, just a help topic (there is no ``git 
     There should be **no** need for the user to interact with this key directly,
     ``git machete fork-point`` with flags should be used instead.
 
-``machete.squashMergeDetection``:
+``machete.squashMergeDetection``
     .. include:: git-config-keys/squashMergeDetection.rst
 
-``machete.status.extraSpaceBeforeBranchName``:
+``machete.status.extraSpaceBeforeBranchName``
     .. include:: git-config-keys/status_extraSpaceBeforeBranchName.rst
 
     .. include:: git-config-keys/status_extraSpaceBeforeBranchName_example.rst
 
-``machete.traverse.fetch.<remote>``:
+``machete.traverse.fetch.<remote>``
     .. include:: git-config-keys/traverse_fetch_remote.rst
 
-``machete.traverse.push``:
+``machete.traverse.push``
     .. include:: git-config-keys/traverse_push.rst
 
-``machete.traverse.whenBranchNotCheckedOutInAnyWorktree``:
+``machete.traverse.whenBranchNotCheckedOutInAnyWorktree``
     .. include:: git-config-keys/traverse_whenBranchNotCheckedOutInAnyWorktree.rst
 
-``machete.worktree.useTopLevelMacheteFile``:
+``machete.worktree.useTopLevelMacheteFile``
     The default value of this key is ``true``, which means that the path to branch layout file will be ``.git/machete``
     for both regular directory and worktree.
 
     If you want the worktree to have its own branch layout file (located under ``.git/worktrees/.../machete``),
     set ``git config machete.worktree.useTopLevelMacheteFile false``.
 
-**Environment variables:**
+**Environment variables**
 
 ``GIT_MACHETE_EDITOR``
     Name of the editor used by ``git machete e[dit]``, example: ``vim`` or ``nano``.

--- a/docs/source/cli/delete-unmanaged.rst
+++ b/docs/source/cli/delete-unmanaged.rst
@@ -2,7 +2,7 @@
 
 delete-unmanaged
 ================
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 
@@ -16,6 +16,6 @@ Note: this should be used with care since deleting local branches can sometimes 
 for ``git machete`` to properly figure out fork points.
 See help for :ref:`fork-point` for more details.
 
-**Options:**
+**Options**
 
 -y, --yes          Don't ask for confirmation.

--- a/docs/source/cli/diff.rst
+++ b/docs/source/cli/diff.rst
@@ -2,7 +2,7 @@
 
 diff
 ====
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 
@@ -14,7 +14,7 @@ See help for :ref:`fork-point` for more details.
 
 Note: the branch in question does not need to occur in the branch layout file.
 
-**Options:**
+**Options**
 
 -- <pass-through-arguments>    Arguments to pass directly to the underlying ``git diff``, for example ``git machete diff -- --name-only``.
 

--- a/docs/source/cli/discover.rst
+++ b/docs/source/cli/discover.rst
@@ -2,7 +2,7 @@
 
 discover
 ========
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 
@@ -15,7 +15,7 @@ and saves the new tree under the usual ``$GIT_DIR/machete`` path.
 If the reply was ``e[dit]``, additionally an editor is opened (as in: ``git machete`` :ref:`edit`) after saving the new branch layout file.
 ``discover`` retains the existing branch qualifiers used by ``git machete traverse`` (see help for :ref:`traverse`).
 
-**Options:**
+**Options**
 
 -C, --checked-out-since=<date>   Only consider branches checked out at least once since the given date.
                                  ``<date>`` can be, for example, ``2 weeks ago`` or ``2020-06-01``, as in ``git log --since=<date>``.

--- a/docs/source/cli/edit.rst
+++ b/docs/source/cli/edit.rst
@@ -2,7 +2,7 @@
 
 edit
 ====
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 
@@ -29,7 +29,7 @@ but not for any other actions that may be indirectly triggered by git machete, i
 The branch layout file can be always accessed and edited directly under the path returned by ``git machete file``
 (usually ``.git/machete``, unless worktrees or submodules are involved).
 
-**Environment variables:**
+**Environment variables**
 
 ``GIT_MACHETE_EDITOR``
     Name of the editor executable.

--- a/docs/source/cli/file.rst
+++ b/docs/source/cli/file.rst
@@ -2,7 +2,7 @@
 
 file
 ====
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 

--- a/docs/source/cli/fork-point.rst
+++ b/docs/source/cli/fork-point.rst
@@ -2,7 +2,7 @@
 
 fork-point
 ==========
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 

--- a/docs/source/cli/github.rst
+++ b/docs/source/cli/github.rst
@@ -2,7 +2,7 @@
 
 github
 ======
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 
@@ -41,9 +41,9 @@ Create, check out and manage GitHub PRs while keeping them reflected in branch l
           ghp_myothertoken_for_git_example_org git.example.org
           ghp_yetanothertoken_for_git_example_com git.example.com
 
-**Subcommands:**
+**Subcommands**
 
-``anno-prs [--with-urls]``:
+``anno-prs [--with-urls]``
     Annotate the branches based on their corresponding GitHub PR numbers and authors.
     Any existing annotations are overwritten for the branches that have an opened PR; annotations for the other branches remain untouched.
     Equivalent to ``git machete anno --sync-github-prs``.
@@ -56,7 +56,7 @@ Create, check out and manage GitHub PRs while keeping them reflected in branch l
     --with-urls                   Also include full PR URLs in the annotations (rather than just PR number).
 
 
-``checkout-prs [--all | --by=<github-login> | --mine | <PR-number-1> ... <PR-number-N>]``:
+``checkout-prs [--all | --by=<github-login> | --mine | <PR-number-1> ... <PR-number-N>]``
     Check out the head branch of the given pull requests (specified by numbers or by a flag),
     also traverse chain of pull requests upwards, adding branches one by one to git-machete and check them out locally.
     Once the specified pull requests are checked out locally, annotate local branches with corresponding pull request numbers.
@@ -77,7 +77,7 @@ Create, check out and manage GitHub PRs while keeping them reflected in branch l
 
     ``<PR-number-1> ... <PR-number-N>``    Pull request numbers to checkout.
 
-``create-pr [--draft] [--title=<title>] [-U|--update-related-descriptions] [-y|--yes]``:
+``create-pr [--draft] [--title=<title>] [-U|--update-related-descriptions] [-y|--yes]``
     Create a PR for the current branch, using the upstream (parent) branch as the PR base.
     Once the PR is successfully created, annotate the current branch with the new PR's number.
 
@@ -104,7 +104,7 @@ Create, check out and manage GitHub PRs while keeping them reflected in branch l
 
     -y, --yes                          Do not ask for confirmation whether to push the branch.
 
-``restack-pr [-U|--update-related-descriptions]``:
+``restack-pr [-U|--update-related-descriptions]``
     Perform the following sequence of actions:
 
     #. If the PR for the current branch is ready for review, it gets converted into a draft.
@@ -120,7 +120,7 @@ Create, check out and manage GitHub PRs while keeping them reflected in branch l
     -U, --update-related-descriptions  Update the generated sections ("intros") of PR descriptions that list the upstream and/or downstream PRs.
                                        See help for ``git machete github update-pr-descriptions --related`` for details.
 
-``retarget-pr [-b|--branch=<branch>] [--ignore-if-missing] [-U|--update-related-descriptions]``:
+``retarget-pr [-b|--branch=<branch>] [--ignore-if-missing] [-U|--update-related-descriptions]``
     Set the base of the current (or specified) branch's PR to upstream (parent) branch, as seen by git machete (see ``git machete show up``).
 
     If after changing the base the PR ends up stacked atop another PR, the PR description posted to GitHub will include
@@ -137,7 +137,7 @@ Create, check out and manage GitHub PRs while keeping them reflected in branch l
     -U, --update-related-descriptions  Update the generated sections ("intros") of PR descriptions that list the upstream and/or downstream PRs.
                                        See help for ``git machete github update-pr-descriptions --related`` for details.
 
-``sync``:
+``sync``
     **Deprecated.** Use ``github checkout-prs --mine``, ``delete-unmanaged`` and ``slide-out --removed-from-remote``.
 
     Synchronize with the remote repository:
@@ -147,7 +147,7 @@ Create, check out and manage GitHub PRs while keeping them reflected in branch l
     #. delete unmanaged branches,
     #. delete untracked managed branches that have no downstream branch.
 
-``update-pr-descriptions [--all | --by=<github-login> | --mine | --related]``:
+``update-pr-descriptions [--all | --by=<github-login> | --mine | --related]``
     Update the generated sections ("intros") of PR descriptions that list the upstream and/or downstream PRs
     (depending on ``machete.github.prDescriptionIntroStyle`` git config key).
 
@@ -163,21 +163,21 @@ Create, check out and manage GitHub PRs while keeping them reflected in branch l
 
     --related            Update PR descriptions for all PRs both upstream and downstream of the PR for the current branch (the entire stack). This is the default if no flag is given.
 
-**Git config keys:**
+**Git config keys**
 
-``machete.github.{remote,domain,organization,repository}`` (all subcommands):
+``machete.github.{remote,domain,organization,repository}`` (all subcommands)
   .. include:: git-config-keys/github_access.rst
 
-``machete.github.annotateWithUrls`` (all subcommands):
+``machete.github.annotateWithUrls`` (all subcommands)
   .. include:: git-config-keys/github_annotateWithUrls.rst
 
-``machete.github.forceDescriptionFromCommitMessage`` (``create-pr`` only):
+``machete.github.forceDescriptionFromCommitMessage`` (``create-pr`` only)
   .. include:: git-config-keys/github_forceDescriptionFromCommitMessage.rst
 
-``machete.github.prDescriptionIntroStyle`` (``create-pr``, ``restack-pr`` and ``retarget-pr``):
+``machete.github.prDescriptionIntroStyle`` (``create-pr``, ``restack-pr`` and ``retarget-pr``)
   .. include:: git-config-keys/github_prDescriptionIntroStyle.rst
 
-**Environment variables (all subcommands):**
+**Environment variables (all subcommands)**
 
 ``GITHUB_TOKEN``
     GitHub API token.

--- a/docs/source/cli/gitlab.rst
+++ b/docs/source/cli/gitlab.rst
@@ -2,7 +2,7 @@
 
 gitlab
 ======
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 
@@ -40,9 +40,9 @@ Create, check out and manage GitLab MRs while keeping them reflected in branch l
           glpat-myothertoken_for_git_example_org git.example.org
           glpat-yetanothertoken_for_git_example_com git.example.com
 
-**Subcommands:**
+**Subcommands**
 
-``anno-mrs [--with-urls]``:
+``anno-mrs [--with-urls]``
     Annotate the branches based on their corresponding GitLab MR numbers and authors.
     Any existing annotations are overwritten for the branches that have an opened MR; annotations for the other branches remain untouched.
     Equivalent to ``git machete anno --sync-gitlab-mrs``.
@@ -55,7 +55,7 @@ Create, check out and manage GitLab MRs while keeping them reflected in branch l
     --with-urls                   Also include full MR URLs in the annotations (rather than just MR number).
 
 
-``checkout-mrs [--all | --by=<gitlab-login> | --mine | <MR-number-1> ... <MR-number-N>]``:
+``checkout-mrs [--all | --by=<gitlab-login> | --mine | <MR-number-1> ... <MR-number-N>]``
     Check out the source branch of the given merge requests (specified by numbers or by a flag),
     also traverse chain of merge requests upwards, adding branches one by one to git-machete and check them out locally.
     Once the specified merge requests are checked out locally, annotate local branches with corresponding merge request numbers.
@@ -76,7 +76,7 @@ Create, check out and manage GitLab MRs while keeping them reflected in branch l
 
     ``<MR-number-1> ... <MR-number-N>``    Merge request numbers to checkout.
 
-``create-mr [--draft] [--title=<title>] [-U|--update-related-descriptions] [-y|--yes]``:
+``create-mr [--draft] [--title=<title>] [-U|--update-related-descriptions] [-y|--yes]``
     Create an MR for the current branch, using the upstream (parent) branch as the MR source branch.
     Once the MR is successfully created, annotate the current branch with the new MR's number.
 
@@ -105,7 +105,7 @@ Create, check out and manage GitLab MRs while keeping them reflected in branch l
 
     -y, --yes                          Do not ask for confirmation whether to push the branch.
 
-``restack-mr [-U|--update-related-descriptions]``:
+``restack-mr [-U|--update-related-descriptions]``
     Perform the following sequence of actions:
 
     #. If the MR for the current branch is ready for review, it gets converted into a draft.
@@ -121,7 +121,7 @@ Create, check out and manage GitLab MRs while keeping them reflected in branch l
     -U, --update-related-descriptions  Update the generated sections ("intros") of MR descriptions that list the upstream and/or downstream MRs.
                                        See help for ``git machete gitlab update-mr-descriptions --related`` for details.
 
-``retarget-mr [-b|--branch=<branch>] [--ignore-if-missing] [-U|--update-related-descriptions]``:
+``retarget-mr [-b|--branch=<branch>] [--ignore-if-missing] [-U|--update-related-descriptions]``
     Set the target of the current (or specified) branch's MR to upstream (parent) branch, as seen by git machete (see ``git machete show up``).
 
     If after changing the base the MR ends up stacked atop another MR, the MR description posted to GitLab will include
@@ -138,7 +138,7 @@ Create, check out and manage GitLab MRs while keeping them reflected in branch l
     -U, --update-related-descriptions  Update the generated sections ("intros") of MR descriptions that list the upstream and/or downstream MRs.
                                        See help for ``git machete gitlab update-mr-descriptions --related`` for details.
 
-``update-mr-descriptions [--all | --by=<gitlab-login> | --mine | --related]``:
+``update-mr-descriptions [--all | --by=<gitlab-login> | --mine | --related]``
     Update the generated sections ("intros") of MR descriptions that list the upstream and/or downstream MRs
     (depending on ``machete.gitlab.mrDescriptionIntroStyle`` git config key).
 
@@ -154,21 +154,21 @@ Create, check out and manage GitLab MRs while keeping them reflected in branch l
 
     --related            Update MR descriptions for all MRs both upstream and downstream of the MR for the current branch (the entire stack). This is the default if no flag is given.
 
-**Git config keys:**
+**Git config keys**
 
-``machete.gitlab.{remote,domain,namespace,project}`` (all subcommands):
+``machete.gitlab.{remote,domain,namespace,project}`` (all subcommands)
   .. include:: git-config-keys/gitlab_access.rst
 
-``machete.gitlab.annotateWithUrls`` (all subcommands):
+``machete.gitlab.annotateWithUrls`` (all subcommands)
   .. include:: git-config-keys/gitlab_annotateWithUrls.rst
 
-``machete.gitlab.forceDescriptionFromCommitMessage`` (``create-mr`` only):
+``machete.gitlab.forceDescriptionFromCommitMessage`` (``create-mr`` only)
   .. include:: git-config-keys/gitlab_forceDescriptionFromCommitMessage.rst
 
-``machete.gitlab.mrDescriptionIntroStyle`` (``create-mr``, ``restack-mr`` and ``retarget-mr``):
+``machete.gitlab.mrDescriptionIntroStyle`` (``create-mr``, ``restack-mr`` and ``retarget-mr``)
   .. include:: git-config-keys/gitlab_mrDescriptionIntroStyle.rst
 
-**Environment variables (all subcommands):**
+**Environment variables (all subcommands)**
 
 ``GITLAB_TOKEN``
     GitLab API token.

--- a/docs/source/cli/go.rst
+++ b/docs/source/cli/go.rst
@@ -2,7 +2,7 @@
 
 go
 ==
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 
@@ -12,7 +12,7 @@ where <direction> is one of: ``d[own]``, ``f[irst]``, ``l[ast]``, ``n[ext]``, ``
 
 If ``<direction>`` is not provided, an interactive mode is launched where you can navigate the branch tree using arrow keys and select a branch to check out.
 
-**Interactive mode controls:**
+**Interactive mode controls**
 
 * **↑/↓**: Navigate up/down through branches
 * **Shift+↑**: Jump to the first branch

--- a/docs/source/cli/help.rst
+++ b/docs/source/cli/help.rst
@@ -2,7 +2,7 @@
 
 help
 ====
-**Usage:**
+**Usage**
 
 .. code-block:: awk
 

--- a/docs/source/cli/hooks.rst
+++ b/docs/source/cli/hooks.rst
@@ -7,7 +7,7 @@ All hooks are executed from the top-level folder of the repository (or top-level
 
 Note: ``hooks`` is not a command as such, just a help topic (there is no ``git machete hooks`` command).
 
-**Hooks:**
+**Hooks**
 
 ``machete-post-slide-out <new-upstream> <lowest-slid-out-branch> [<new-downstreams>...]``
     The hook that is executed after a branch (or possibly multiple branches, in case of ``slide-out``)

--- a/docs/source/cli/is-managed.rst
+++ b/docs/source/cli/is-managed.rst
@@ -2,7 +2,7 @@
 
 is-managed
 ==========
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 

--- a/docs/source/cli/list.rst
+++ b/docs/source/cli/list.rst
@@ -2,7 +2,7 @@
 
 list
 ====
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 

--- a/docs/source/cli/log.rst
+++ b/docs/source/cli/log.rst
@@ -2,7 +2,7 @@
 
 log
 ===
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 
@@ -13,6 +13,6 @@ See help for :ref:`fork-point` for more details on meaning of the *fork point*.
 
 Note: the branch in question does not need to occur in the branch layout file.
 
-**Options:**
+**Options**
 
 -- <pass-through-arguments>    Arguments to pass directly to the underlying ``git log``, for example ``git machete log -- --patch``.

--- a/docs/source/cli/reapply.rst
+++ b/docs/source/cli/reapply.rst
@@ -2,7 +2,7 @@
 
 reapply
 =======
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 
@@ -18,11 +18,11 @@ Note: the current reapplied branch does not need to occur in the branch layout f
 Tip: ``reapply`` can be used for squashing the commits on the current branch to make history more condensed before push to the remote,
 but there is also dedicated ``squash`` command that achieves the same goal without running ``git rebase``.
 
-**Options:**
+**Options**
 
 -f, --fork-point=<fork-point-commit>    Specifies the alternative fork point commit after which the rebased part of history is meant to start.
 
-**Environment variables:**
+**Environment variables**
 
 ``GIT_MACHETE_REBASE_OPTS``
     .. include:: env-vars/git_machete_rebase_opts.rst

--- a/docs/source/cli/rename.rst
+++ b/docs/source/cli/rename.rst
@@ -2,7 +2,7 @@
 
 rename
 ======
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 
@@ -19,7 +19,7 @@ As a result, after the rename the local branch still tracks the same remote bran
 Note: ``rename`` does **not** rename the branch on the remote — it only renames the local branch.
 The remote branch is left intact and can still be pushed to under its original name.
 
-**Options:**
+**Options**
 
 -b, --branch=<branch>   Branch to rename; if not given, the current branch is renamed.
 

--- a/docs/source/cli/show.rst
+++ b/docs/source/cli/show.rst
@@ -2,7 +2,7 @@
 
 show
 ====
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 

--- a/docs/source/cli/slide-out.rst
+++ b/docs/source/cli/slide-out.rst
@@ -2,7 +2,7 @@
 
 slide-out
 =========
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 
@@ -58,7 +58,7 @@ Note: Unless ``--delete`` is passed, ``slide-out`` doesn't delete any branches f
 Note: if a child branch is annotated with ``rebase=no`` qualifier, the rebase is not performed.
 See help for :ref:`traverse` for more details on the qualifiers.
 
-**Options:**
+**Options**
 
 -d, --down-fork-point=<down-fork-point-commit>    If updating by rebase, specify the alternative fork point for downstream branches for the operation.
                                                   ``git machete fork-point`` overrides for downstream branches are recommended over use of this option.
@@ -90,7 +90,7 @@ See help for :ref:`traverse` for more details on the qualifiers.
                                                   * those whose remote tracking branches still exist (not deleted remotely),
                                                   * those that have at least one downstream (child) branch.
 
-**Environment variables:**
+**Environment variables**
 
 ``GIT_MACHETE_REBASE_OPTS``
     .. include:: env-vars/git_machete_rebase_opts.rst

--- a/docs/source/cli/squash.rst
+++ b/docs/source/cli/squash.rst
@@ -2,7 +2,7 @@
 
 squash
 ======
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 
@@ -20,6 +20,6 @@ for example ``git machete squash --fork-point=HEAD~3``.
 Note: ``squash`` does **not** run ``git rebase`` under the hood.
 For more complex scenarios that require rewriting the history of current branch, see ``reapply`` and ``update``.
 
-**Options:**
+**Options**
 
 -f, --fork-point=<fork-point-commit>   Specify the alternative fork point commit after which the squashed part of history is meant to start.

--- a/docs/source/cli/status.rst
+++ b/docs/source/cli/status.rst
@@ -2,7 +2,7 @@
 
 status
 ======
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 
@@ -74,7 +74,7 @@ When colors are disabled, relation between branches is represented in the follow
 
 .. include:: git-config-keys/status_extraSpaceBeforeBranchName_example.rst
 
-**Options:**
+**Options**
 
 --color=WHEN                      Colorize the output; WHEN can be ``always``, ``auto`` (default: colorize only if stdout is a terminal), or ``never``.
 
@@ -90,10 +90,10 @@ When colors are disabled, relation between branches is represented in the follow
                                   ``MODE`` can be ``none`` (fastest, no squash merges are detected), ``simple`` (default) or ``exact`` (slowest).
                                   See the below paragraph on ``machete.squashMergeDetection`` git config key for more details.
 
-**Git config keys:**
+**Git config keys**
 
-``machete.squashMergeDetection``:
+``machete.squashMergeDetection``
     .. include:: git-config-keys/squashMergeDetection.rst
 
-``machete.status.extraSpaceBeforeBranchName``:
+``machete.status.extraSpaceBeforeBranchName``
     .. include:: git-config-keys/status_extraSpaceBeforeBranchName.rst

--- a/docs/source/cli/traverse.rst
+++ b/docs/source/cli/traverse.rst
@@ -2,7 +2,7 @@
 
 traverse
 ========
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 
@@ -89,7 +89,7 @@ when the current user is **not** the author of the PR/MR associated with that br
 If a branch is not checked out in any worktree, by default ``traverse`` will change directory to the main worktree before checking out the branch.
 This behavior can be customized using ``machete.traverse.whenBranchNotCheckedOutInAnyWorktree`` git config key (see below).
 
-**Options:**
+**Options**
 
 -F, --fetch                    Fetch the remotes of all managed branches at the beginning of traversal (no ``git pull`` involved, only ``git fetch``).
 
@@ -153,21 +153,21 @@ This behavior can be customized using ``machete.traverse.whenBranchNotCheckedOut
 
 -y, --yes                      Don't ask for any interactive input, including confirmation of rebase/push/pull. Implies ``-n``.
 
-**Git config keys:**
+**Git config keys**
 
-``machete.squashMergeDetection``:
+``machete.squashMergeDetection``
     .. include:: git-config-keys/squashMergeDetection.rst
 
-``machete.traverse.fetch.<remote>``:
+``machete.traverse.fetch.<remote>``
     .. include:: git-config-keys/traverse_fetch_remote.rst
 
-``machete.traverse.push``:
+``machete.traverse.push``
     .. include:: git-config-keys/traverse_push.rst
 
-``machete.traverse.whenBranchNotCheckedOutInAnyWorktree``:
+``machete.traverse.whenBranchNotCheckedOutInAnyWorktree``
     .. include:: git-config-keys/traverse_whenBranchNotCheckedOutInAnyWorktree.rst
 
-**Environment variables:**
+**Environment variables**
 
 ``GIT_MACHETE_REBASE_OPTS``
     .. include:: env-vars/git_machete_rebase_opts.rst

--- a/docs/source/cli/update.rst
+++ b/docs/source/cli/update.rst
@@ -2,7 +2,7 @@
 
 update
 ======
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 
@@ -17,7 +17,7 @@ See help for :ref:`fork-point` for more details.
 
 If updating by merge, merges the upstream (parent) branch into the current branch.
 
-**Options:**
+**Options**
 
 -f, --fork-point=<fork-point-commit>    If updating by rebase, specifies the alternative fork point commit after which the rebased
                                         part of history is meant to start. Not allowed if updating by merge.
@@ -33,7 +33,7 @@ If updating by merge, merges the upstream (parent) branch into the current branc
 --no-interactive-rebase                 If updating by rebase, run ``git rebase`` in non-interactive mode (without ``-i/--interactive`` flag).
                                         Not allowed if updating by merge.
 
-**Environment variables:**
+**Environment variables**
 
 ``GIT_MACHETE_REBASE_OPTS``
     .. include:: env-vars/git_machete_rebase_opts.rst

--- a/docs/source/cli/version.rst
+++ b/docs/source/cli/version.rst
@@ -2,7 +2,7 @@
 
 version
 =======
-**Usage:**
+**Usage**
 
 .. code-block:: shell
 

--- a/git_machete/generated_docs.py
+++ b/git_machete/generated_docs.py
@@ -39,7 +39,7 @@ short_docs: Dict[str, str] = {
 
 long_docs: Dict[str, str] = {
     "add": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete add [-o|--onto=<target-upstream-branch>] [-R|--as-root] [-y|--yes] [<branch>]</b>
 
         Adds the provided <branch> (or the current branch, if none specified) to the branch layout file.
@@ -56,7 +56,7 @@ long_docs: Dict[str, str] = {
 
         Note: all the effects of `add` (except git branch creation) can as well be achieved by manually editing the branch layout file.
 
-        <b>Options:</b>
+        <b>Options</b>
 
            <b>-f</b>, <b>--as-first-child</b>
               Add the given branch as the first (instead of last) child of its parent.
@@ -73,7 +73,7 @@ long_docs: Dict[str, str] = {
               Don't ask for confirmation whether to create the branch or whether to add onto the inferred upstream.
    """,
     "advance": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete advance [-y|--yes]</b>
 
         Fast forwards (as in `git merge --ff-only`) the current branch `C` to match its downstream `D`, pushes `C`
@@ -118,14 +118,14 @@ long_docs: Dict[str, str] = {
         If the downstream branch `D` is annotated with `slide-out=no` qualifier, the slide-out is not performed.
         See help for `traverse` for more details on the qualifiers.
 
-        <b>Options:</b>
+        <b>Options</b>
 
            <b>-y</b>, <b>--yes</b>
               Don't ask for confirmation whether to fast-forward the current branch or whether to slide-out the downstream.
               Fails if the current branch has more than one <green>green-edge</green> downstream branch.
    """,
     "anno": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete anno [-b|--branch=<branch>] [<annotation text>]
            git machete anno -H|--sync-github-prs
            git machete anno -L|--sync-gitlab-mrs</b>
@@ -160,7 +160,7 @@ long_docs: Dict[str, str] = {
 
         Note: all the effects of `anno` can be always achieved by manually editing the branch layout file.
 
-        <b>Options:</b>
+        <b>Options</b>
 
            <b>-b</b>, <b>--branch=<branch></b>
               Branch to set the annotation for.
@@ -172,7 +172,7 @@ long_docs: Dict[str, str] = {
               Annotate with GitLab MR numbers and author logins where applicable.
    """,
     "clean": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete clean [-H|--checkout-my-github-prs] [-y|--yes]</b>
 
         <b>Deprecated.</b> Use `github checkout-prs --mine`, `delete-unmanaged` and `slide-out --removed-from-remote`.
@@ -193,7 +193,7 @@ long_docs: Dict[str, str] = {
              TL;DR: `GITHUB_TOKEN` env var or `~/.github-token` file or `gh`/`hub` CLI configs if exist.
              For enterprise domains, non-standard URLs etc., check git config keys in `github` help.
 
-        <b>Options:</b>
+        <b>Options</b>
 
            <b>-H</b>, <b>--checkout-my-github-prs</b>
               Checkout your open PRs into local branches.
@@ -201,20 +201,20 @@ long_docs: Dict[str, str] = {
            <b>-y</b>, <b>--yes</b>
               Don't ask for confirmation when deleting branches from git.
 
-        <b>Environment variables:</b>
+        <b>Environment variables</b>
 
            `GITHUB_TOKEN`
               GitHub API token.
    """,
     "completion": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete completion <shell></b>
 
         where `<shell>` is one of: `bash`, `fish`, `zsh`.
 
         Prints out completion scripts.
 
-        <b>Supported shells:</b>
+        <b>Supported shells</b>
 
         <b>bash</b>
 
@@ -242,9 +242,9 @@ long_docs: Dict[str, str] = {
 
         Note: `config` is not a command as such, just a help topic (there is no `git machete config` command).
 
-        <b>Git config keys:</b>
+        <b>Git config keys</b>
 
-           `machete.github.{remote,domain,organization,repository}`:
+           `machete.github.{remote,domain,organization,repository}`
              `machete.github.remote`
                 The name of the git remote (as in `git remote`) that git-machete pushes the head branch to.
                 Unless both `machete.github.organization` and `machete.github.repository` are set, this remote's URL is also inspected
@@ -270,18 +270,18 @@ long_docs: Dict[str, str] = {
              For example, in a typical usage of GitHub Enterprise, it should be enough to just set `machete.github.domain`.
              Only `machete.github.organization` and `machete.github.repository` must be specified together.
 
-           `machete.github.annotateWithUrls`:
+           `machete.github.annotateWithUrls`
              Setting this config key to `true` will cause all commands that write GitHub PR numbers into annotations
              to not only include PR number and author (if different from the current user), but also the full URL of the PR.
 
              The affected (sub)commands clearly include `anno --sync-github-prs` and `github anno-prs`,
              but also `github checkout-prs`, `github create-pr`, `github retarget-pr` and `github restack-pr`.
 
-           `machete.github.forceDescriptionFromCommitMessage`:
+           `machete.github.forceDescriptionFromCommitMessage`
              Setting this config key to `true` will force `git machete github create-pr` to take PR description
              from the message body of the first unique commit of the branch, even if `.git/info/description` and/or `.github/pull_request_template.md` is present.
 
-           `machete.github.prDescriptionIntroStyle`:
+           `machete.github.prDescriptionIntroStyle`
              Select the style of the generated section ("intro") added to the PR description:
               * `full`                — include both a chain of upstream PRs (typically leading to `main`, `master`, `develop` etc.) and a tree of downstream PRs
               * `full-no-branches`    — same as `full`, but no branch names are included (only PR numbers & titles)
@@ -289,7 +289,7 @@ long_docs: Dict[str, str] = {
               * `up-only-no-branches` — same as `up-only`, but no branch names are included (only PR numbers & titles)
               * `none`                — prepend no intro to the PR description at all
 
-           `machete.gitlab.{remote,domain,namespace,project}`:
+           `machete.gitlab.{remote,domain,namespace,project}`
              `machete.gitlab.remote`
                 The name of the git remote (as in `git remote`) that git-machete pushes the source branch to.
                 Unless both `machete.gitlab.namespace` and `machete.gitlab.project` are set, this remote's URL is also inspected
@@ -315,18 +315,18 @@ long_docs: Dict[str, str] = {
              For example, in a typical usage for GitLab self-managed instance, it should be enough to just set `machete.gitlab.domain`.
              Only `machete.gitlab.namespace` and `machete.gitlab.project` must be specified together.
 
-           `machete.gitlab.annotateWithUrls`:
+           `machete.gitlab.annotateWithUrls`
              Setting this config key to `true` will cause all commands that write GitLab MR numbers into annotations
              to not only include MR number and author (if different from the current user), but also the full URL of the MR.
 
              The affected (sub)commands clearly include `anno --sync-gitlab-mrs` and `gitlab anno-mrs`,
              but also `gitlab checkout-mrs`, `gitlab create-mr`, `gitlab retarget-mr` and `gitlab restack-mr`.
 
-           `machete.gitlab.forceDescriptionFromCommitMessage`:
+           `machete.gitlab.forceDescriptionFromCommitMessage`
              Setting this config key to `true` will force `git machete gitlab create-mr` to take MR description
              from the message body of the first unique commit of the branch, even if `.git/info/description` and/or `.gitlab/merge_request_templates/Default.md` is present.
 
-           `machete.gitlab.mrDescriptionIntroStyle`:
+           `machete.gitlab.mrDescriptionIntroStyle`
              Select the style of the generated section ("intro") added to the MR description:
               * `full`                — include both a chain of upstream MRs (typically leading to `main`, `master`, `develop` etc.) and a tree of downstream MRs
               * `full-no-branches`    — same as `full`, but no branch names are included (only MR numbers & titles)
@@ -334,7 +334,7 @@ long_docs: Dict[str, str] = {
               * `up-only-no-branches` — same as `up-only`, but no branch names are included (only MR numbers & titles)
               * `none`                — prepend no intro to the MR description at all
 
-           `machete.overrideForkPoint.<branch>.to`:
+           `machete.overrideForkPoint.<branch>.to`
               Executing `git machete fork-point --override-to[-parent|-inferred|=<revision>] [<branch>]` sets up a fork point override for `<branch>`.
 
               The override data is stored under `machete.overrideForkPoint.<branch>.to` git config key.
@@ -342,7 +342,7 @@ long_docs: Dict[str, str] = {
               There should be <b>no</b> need for the user to interact with this key directly,
               `git machete fork-point` with flags should be used instead.
 
-           `machete.squashMergeDetection`:
+           `machete.squashMergeDetection`
               Select the algorithm used to detect squash merges. Possible values are:
 
               * `none`: Fastest mode, with no squash merge/rebase detection. Only strict (fast-forward or 2-parent) merges are detected.
@@ -359,7 +359,7 @@ long_docs: Dict[str, str] = {
               * whether a gray edge is displayed in `status`,
               * whether `traverse` suggests to slide out the branch.
 
-           `machete.status.extraSpaceBeforeBranchName`:
+           `machete.status.extraSpaceBeforeBranchName`
               To make it easier to select branch name from the `status` output on certain terminals (like `Alacritty),
               you can add an extra space between └─ and branch name by setting `git config machete.status.extraSpaceBeforeBranchName true`.
 
@@ -379,18 +379,18 @@ long_docs: Dict[str, str] = {
                    │
                    └─ feature_branch2
 
-           `machete.traverse.fetch.<remote>`:
+           `machete.traverse.fetch.<remote>`
               Configure the behavior of `git machete traverse` command for the given remote when `--fetch` flag is used.
               If set to `false`, this remote will not be fetched before the traversal.
               The default value of this key is `true`.
               This is useful for excluding remotes that are temporarily offline, or take a long time to respond.
 
-           `machete.traverse.push`:
+           `machete.traverse.push`
               Set to `false` to change the behavior of `git machete traverse` so that it doesn't push branches by default.
               The default value of this key is `true`.
               Configuration key value can be overridden by the presence of the `--push` or `--push-untracked` flags.
 
-           `machete.traverse.whenBranchNotCheckedOutInAnyWorktree`:
+           `machete.traverse.whenBranchNotCheckedOutInAnyWorktree`
               Controls the behavior of `git machete traverse` when it needs to act on a branch that is not currently checked out in any worktree.
 
               Allowed values:
@@ -404,14 +404,14 @@ long_docs: Dict[str, str] = {
                 and remove this temporary worktree once `traverse` moves on to the next branch (or finishes).
                 This ensures that no existing (non-temporary) worktree has its checked-out branch changed by `traverse`.
 
-           `machete.worktree.useTopLevelMacheteFile`:
+           `machete.worktree.useTopLevelMacheteFile`
               The default value of this key is `true`, which means that the path to branch layout file will be `.git/machete`
               for both regular directory and worktree.
 
               If you want the worktree to have its own branch layout file (located under `.git/worktrees/.../machete`),
               set `git config machete.worktree.useTopLevelMacheteFile false`.
 
-        <b>Environment variables:</b>
+        <b>Environment variables</b>
 
            `GIT_MACHETE_EDITOR`
               Name of the editor used by `git machete e[dit]`, example: `vim` or `nano`.
@@ -429,7 +429,7 @@ long_docs: Dict[str, str] = {
               Used to store GitLab API token. Used by commands such as `anno --sync-gitlab-mrs` and `gitlab`.
    """,
     "delete-unmanaged": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete delete-unmanaged [-y|--yes]</b>
 
         Goes one-by-one through all the local git branches that don't exist in the branch layout file,
@@ -440,13 +440,13 @@ long_docs: Dict[str, str] = {
         for `git machete` to properly figure out fork points.
         See help for `fork-point` for more details.
 
-        <b>Options:</b>
+        <b>Options</b>
 
            <b>-y</b>, <b>--yes</b>
               Don't ask for confirmation.
    """,
     "diff": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete d[iff] [-s|--stat] [<branch>] [-- <pass-through-arguments>]</b>
 
         Runs `git diff` of the given branch tip against its fork point or, if none specified,
@@ -455,7 +455,7 @@ long_docs: Dict[str, str] = {
 
         Note: the branch in question does not need to occur in the branch layout file.
 
-        <b>Options:</b>
+        <b>Options</b>
 
            <b>-- <pass-through-arguments></b>
               Arguments to pass directly to the underlying `git diff`, for example `git machete diff -- --name-only`.
@@ -464,7 +464,7 @@ long_docs: Dict[str, str] = {
               Make `git machete diff` pass `--stat` option to `git diff`, so that only summary (diffstat) is printed.
    """,
     "discover": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete discover [-C|--checked-out-since=<date>] [-l|--list-commits] [-r|--roots=<branch1>,<branch2>,...] [-y|--yes]</b>
 
         Discovers and displays tree of branch dependencies using a heuristic based on reflogs
@@ -474,7 +474,7 @@ long_docs: Dict[str, str] = {
         If the reply was `e[dit]`, additionally an editor is opened (as in: `git machete` `edit`) after saving the new branch layout file.
         `discover` retains the existing branch qualifiers used by `git machete traverse` (see help for `traverse`).
 
-        <b>Options:</b>
+        <b>Options</b>
 
            <b>-C</b>, <b>--checked-out-since=<date></b>
               Only consider branches checked out at least once since the given date.
@@ -495,7 +495,7 @@ long_docs: Dict[str, str] = {
               Mostly useful in scripts; not recommended for manual use.
    """,
     "edit": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete e[dit]</b>
 
         Opens an editor and lets you edit the branch layout file manually.
@@ -519,13 +519,13 @@ long_docs: Dict[str, str] = {
         The branch layout file can be always accessed and edited directly under the path returned by `git machete file`
         (usually `.git/machete`, unless worktrees or submodules are involved).
 
-        <b>Environment variables:</b>
+        <b>Environment variables</b>
 
            `GIT_MACHETE_EDITOR`
               Name of the editor executable.
    """,
     "file": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete file</b>
 
         Outputs the absolute path of branch layout file.
@@ -545,7 +545,7 @@ long_docs: Dict[str, str] = {
            * if `git machete` is executed from a <b>submodule</b>, this file is located in the git folder of the submodule itself under `.git/modules/.../machete`.
    """,
     "fork-point": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete fork-point [--inferred] [--explain] [<branch>]
            git machete fork-point --override-to=<revision>|--override-to-inferred|--override-to-parent [<branch>]
            git machete fork-point --unset-override [<branch>]</b>
@@ -632,7 +632,7 @@ long_docs: Dict[str, str] = {
         It's only important to use indentation characters consistently between all lines.
    """,
     "github": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete github <subcommand></b>
 
         where `<subcommand>` is one of: `anno-prs`, `checkout-prs`, `create-pr`, `restack-pr`, `retarget-pr` or `update-pr-descriptions`.
@@ -666,9 +666,9 @@ long_docs: Dict[str, str] = {
                 ghp_myothertoken_for_git_example_org git.example.org
                 ghp_yetanothertoken_for_git_example_com git.example.com
         </dim>
-        <b>Subcommands:</b>
+        <b>Subcommands</b>
 
-           `anno-prs [--with-urls]`:
+           `anno-prs [--with-urls]`
               Annotate the branches based on their corresponding GitHub PR numbers and authors.
               Any existing annotations are overwritten for the branches that have an opened PR; annotations for the other branches remain untouched.
               Equivalent to `git machete anno --sync-github-prs`.
@@ -680,7 +680,7 @@ long_docs: Dict[str, str] = {
 
               --with-urls                   Also include full PR URLs in the annotations (rather than just PR number).
 
-           `checkout-prs [--all | --by=<github-login> | --mine | <PR-number-1> ... <PR-number-N>]`:
+           `checkout-prs [--all | --by=<github-login> | --mine | <PR-number-1> ... <PR-number-N>]`
               Check out the head branch of the given pull requests (specified by numbers or by a flag),
               also traverse chain of pull requests upwards, adding branches one by one to git-machete and check them out locally.
               Once the specified pull requests are checked out locally, annotate local branches with corresponding pull request numbers.
@@ -701,7 +701,7 @@ long_docs: Dict[str, str] = {
 
               `<PR-number-1> ... <PR-number-N>`    Pull request numbers to checkout.
 
-           `create-pr [--draft] [--title=<title>] [-U|--update-related-descriptions] [-y|--yes]`:
+           `create-pr [--draft] [--title=<title>] [-U|--update-related-descriptions] [-y|--yes]`
               Create a PR for the current branch, using the upstream (parent) branch as the PR base.
               Once the PR is successfully created, annotate the current branch with the new PR's number.
 
@@ -728,7 +728,7 @@ long_docs: Dict[str, str] = {
 
               -y, --yes                          Do not ask for confirmation whether to push the branch.
 
-           `restack-pr [-U|--update-related-descriptions]`:
+           `restack-pr [-U|--update-related-descriptions]`
               Perform the following sequence of actions:
 
                * If the PR for the current branch is ready for review, it gets converted into a draft.
@@ -744,7 +744,7 @@ long_docs: Dict[str, str] = {
               -U, --update-related-descriptions  Update the generated sections ("intros") of PR descriptions that list the upstream and/or downstream PRs.
                                                  See help for `git machete github update-pr-descriptions --related` for details.
 
-           `retarget-pr [-b|--branch=<branch>] [--ignore-if-missing] [-U|--update-related-descriptions]`:
+           `retarget-pr [-b|--branch=<branch>] [--ignore-if-missing] [-U|--update-related-descriptions]`
               Set the base of the current (or specified) branch's PR to upstream (parent) branch, as seen by git machete (see `git machete show up`).
 
               If after changing the base the PR ends up stacked atop another PR, the PR description posted to GitHub will include
@@ -761,7 +761,7 @@ long_docs: Dict[str, str] = {
               -U, --update-related-descriptions  Update the generated sections ("intros") of PR descriptions that list the upstream and/or downstream PRs.
                                                  See help for `git machete github update-pr-descriptions --related` for details.
 
-           `sync`:
+           `sync`
               <b>Deprecated.</b> Use `github checkout-prs --mine`, `delete-unmanaged` and `slide-out --removed-from-remote`.
 
               Synchronize with the remote repository:
@@ -771,7 +771,7 @@ long_docs: Dict[str, str] = {
                * delete unmanaged branches,
                * delete untracked managed branches that have no downstream branch.
 
-           `update-pr-descriptions [--all | --by=<github-login> | --mine | --related]`:
+           `update-pr-descriptions [--all | --by=<github-login> | --mine | --related]`
               Update the generated sections ("intros") of PR descriptions that list the upstream and/or downstream PRs
               (depending on `machete.github.prDescriptionIntroStyle` git config key).
 
@@ -787,9 +787,9 @@ long_docs: Dict[str, str] = {
 
               --related            Update PR descriptions for all PRs both upstream and downstream of the PR for the current branch (the entire stack). This is the default if no flag is given.
 
-        <b>Git config keys:</b>
+        <b>Git config keys</b>
 
-           `machete.github.{remote,domain,organization,repository}` (all subcommands):
+           `machete.github.{remote,domain,organization,repository}` (all subcommands)
              `machete.github.remote`
                 The name of the git remote (as in `git remote`) that git-machete pushes the head branch to.
                 Unless both `machete.github.organization` and `machete.github.repository` are set, this remote's URL is also inspected
@@ -815,18 +815,18 @@ long_docs: Dict[str, str] = {
              For example, in a typical usage of GitHub Enterprise, it should be enough to just set `machete.github.domain`.
              Only `machete.github.organization` and `machete.github.repository` must be specified together.
 
-           `machete.github.annotateWithUrls` (all subcommands):
+           `machete.github.annotateWithUrls` (all subcommands)
              Setting this config key to `true` will cause all commands that write GitHub PR numbers into annotations
              to not only include PR number and author (if different from the current user), but also the full URL of the PR.
 
              The affected (sub)commands clearly include `anno --sync-github-prs` and `github anno-prs`,
              but also `github checkout-prs`, `github create-pr`, `github retarget-pr` and `github restack-pr`.
 
-           `machete.github.forceDescriptionFromCommitMessage` (`create-pr` only):
+           `machete.github.forceDescriptionFromCommitMessage` (`create-pr` only)
              Setting this config key to `true` will force `git machete github create-pr` to take PR description
              from the message body of the first unique commit of the branch, even if `.git/info/description` and/or `.github/pull_request_template.md` is present.
 
-           `machete.github.prDescriptionIntroStyle` (`create-pr`, `restack-pr` and `retarget-pr`):
+           `machete.github.prDescriptionIntroStyle` (`create-pr`, `restack-pr` and `retarget-pr`)
              Select the style of the generated section ("intro") added to the PR description:
               * `full`                — include both a chain of upstream PRs (typically leading to `main`, `master`, `develop` etc.) and a tree of downstream PRs
               * `full-no-branches`    — same as `full`, but no branch names are included (only PR numbers & titles)
@@ -834,13 +834,13 @@ long_docs: Dict[str, str] = {
               * `up-only-no-branches` — same as `up-only`, but no branch names are included (only PR numbers & titles)
               * `none`                — prepend no intro to the PR description at all
 
-        <b>Environment variables (all subcommands):</b>
+        <b>Environment variables (all subcommands)</b>
 
            `GITHUB_TOKEN`
               GitHub API token.
    """,
     "gitlab": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete gitlab <subcommand></b>
 
         where `<subcommand>` is one of: `anno-mrs`, `checkout-mrs`, `create-mr`, `restack-mr`, `retarget-mr` or `update-mr-descriptions`.
@@ -873,9 +873,9 @@ long_docs: Dict[str, str] = {
                 glpat-myothertoken_for_git_example_org git.example.org
                 glpat-yetanothertoken_for_git_example_com git.example.com
         </dim>
-        <b>Subcommands:</b>
+        <b>Subcommands</b>
 
-           `anno-mrs [--with-urls]`:
+           `anno-mrs [--with-urls]`
               Annotate the branches based on their corresponding GitLab MR numbers and authors.
               Any existing annotations are overwritten for the branches that have an opened MR; annotations for the other branches remain untouched.
               Equivalent to `git machete anno --sync-gitlab-mrs`.
@@ -887,7 +887,7 @@ long_docs: Dict[str, str] = {
 
               --with-urls                   Also include full MR URLs in the annotations (rather than just MR number).
 
-           `checkout-mrs [--all | --by=<gitlab-login> | --mine | <MR-number-1> ... <MR-number-N>]`:
+           `checkout-mrs [--all | --by=<gitlab-login> | --mine | <MR-number-1> ... <MR-number-N>]`
               Check out the source branch of the given merge requests (specified by numbers or by a flag),
               also traverse chain of merge requests upwards, adding branches one by one to git-machete and check them out locally.
               Once the specified merge requests are checked out locally, annotate local branches with corresponding merge request numbers.
@@ -908,7 +908,7 @@ long_docs: Dict[str, str] = {
 
               `<MR-number-1> ... <MR-number-N>`    Merge request numbers to checkout.
 
-           `create-mr [--draft] [--title=<title>] [-U|--update-related-descriptions] [-y|--yes]`:
+           `create-mr [--draft] [--title=<title>] [-U|--update-related-descriptions] [-y|--yes]`
               Create an MR for the current branch, using the upstream (parent) branch as the MR source branch.
               Once the MR is successfully created, annotate the current branch with the new MR's number.
 
@@ -937,7 +937,7 @@ long_docs: Dict[str, str] = {
 
               -y, --yes                          Do not ask for confirmation whether to push the branch.
 
-           `restack-mr [-U|--update-related-descriptions]`:
+           `restack-mr [-U|--update-related-descriptions]`
               Perform the following sequence of actions:
 
                * If the MR for the current branch is ready for review, it gets converted into a draft.
@@ -953,7 +953,7 @@ long_docs: Dict[str, str] = {
               -U, --update-related-descriptions  Update the generated sections ("intros") of MR descriptions that list the upstream and/or downstream MRs.
                                                  See help for `git machete gitlab update-mr-descriptions --related` for details.
 
-           `retarget-mr [-b|--branch=<branch>] [--ignore-if-missing] [-U|--update-related-descriptions]`:
+           `retarget-mr [-b|--branch=<branch>] [--ignore-if-missing] [-U|--update-related-descriptions]`
               Set the target of the current (or specified) branch's MR to upstream (parent) branch, as seen by git machete (see `git machete show up`).
 
               If after changing the base the MR ends up stacked atop another MR, the MR description posted to GitLab will include
@@ -970,7 +970,7 @@ long_docs: Dict[str, str] = {
               -U, --update-related-descriptions  Update the generated sections ("intros") of MR descriptions that list the upstream and/or downstream MRs.
                                                  See help for `git machete gitlab update-mr-descriptions --related` for details.
 
-           `update-mr-descriptions [--all | --by=<gitlab-login> | --mine | --related]`:
+           `update-mr-descriptions [--all | --by=<gitlab-login> | --mine | --related]`
               Update the generated sections ("intros") of MR descriptions that list the upstream and/or downstream MRs
               (depending on `machete.gitlab.mrDescriptionIntroStyle` git config key).
 
@@ -986,9 +986,9 @@ long_docs: Dict[str, str] = {
 
               --related            Update MR descriptions for all MRs both upstream and downstream of the MR for the current branch (the entire stack). This is the default if no flag is given.
 
-        <b>Git config keys:</b>
+        <b>Git config keys</b>
 
-           `machete.gitlab.{remote,domain,namespace,project}` (all subcommands):
+           `machete.gitlab.{remote,domain,namespace,project}` (all subcommands)
              `machete.gitlab.remote`
                 The name of the git remote (as in `git remote`) that git-machete pushes the source branch to.
                 Unless both `machete.gitlab.namespace` and `machete.gitlab.project` are set, this remote's URL is also inspected
@@ -1014,18 +1014,18 @@ long_docs: Dict[str, str] = {
              For example, in a typical usage for GitLab self-managed instance, it should be enough to just set `machete.gitlab.domain`.
              Only `machete.gitlab.namespace` and `machete.gitlab.project` must be specified together.
 
-           `machete.gitlab.annotateWithUrls` (all subcommands):
+           `machete.gitlab.annotateWithUrls` (all subcommands)
              Setting this config key to `true` will cause all commands that write GitLab MR numbers into annotations
              to not only include MR number and author (if different from the current user), but also the full URL of the MR.
 
              The affected (sub)commands clearly include `anno --sync-gitlab-mrs` and `gitlab anno-mrs`,
              but also `gitlab checkout-mrs`, `gitlab create-mr`, `gitlab retarget-mr` and `gitlab restack-mr`.
 
-           `machete.gitlab.forceDescriptionFromCommitMessage` (`create-mr` only):
+           `machete.gitlab.forceDescriptionFromCommitMessage` (`create-mr` only)
              Setting this config key to `true` will force `git machete gitlab create-mr` to take MR description
              from the message body of the first unique commit of the branch, even if `.git/info/description` and/or `.gitlab/merge_request_templates/Default.md` is present.
 
-           `machete.gitlab.mrDescriptionIntroStyle` (`create-mr`, `restack-mr` and `retarget-mr`):
+           `machete.gitlab.mrDescriptionIntroStyle` (`create-mr`, `restack-mr` and `retarget-mr`)
              Select the style of the generated section ("intro") added to the MR description:
               * `full`                — include both a chain of upstream MRs (typically leading to `main`, `master`, `develop` etc.) and a tree of downstream MRs
               * `full-no-branches`    — same as `full`, but no branch names are included (only MR numbers & titles)
@@ -1033,20 +1033,20 @@ long_docs: Dict[str, str] = {
               * `up-only-no-branches` — same as `up-only`, but no branch names are included (only MR numbers & titles)
               * `none`                — prepend no intro to the MR description at all
 
-        <b>Environment variables (all subcommands):</b>
+        <b>Environment variables (all subcommands)</b>
 
            `GITLAB_TOKEN`
               GitLab API token.
    """,
     "go": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete g[o] [<direction>]</b>
 
         where <direction> is one of: `d[own]`, `f[irst]`, `l[ast]`, `n[ext]`, `p[rev]`, `r[oot]`, `u[p]`
 
         If `<direction>` is not provided, an interactive mode is launched where you can navigate the branch tree using arrow keys and select a branch to check out.
 
-        <b>Interactive mode controls:</b>
+        <b>Interactive mode controls</b>
 
            * <b>↑/↓</b>: Navigate up/down through branches
            * <b>Shift+↑</b>: Jump to the first branch
@@ -1081,7 +1081,7 @@ long_docs: Dict[str, str] = {
         This is roughly equivalent to `git checkout $(git machete show <direction>)`.
    """,
     "help": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete help [<command>]</b>
 
         Print a summary of this tool, or a detailed info on a command if provided.
@@ -1092,7 +1092,7 @@ long_docs: Dict[str, str] = {
 
         Note: `hooks` is not a command as such, just a help topic (there is no `git machete hooks` command).
 
-        <b>Hooks:</b>
+        <b>Hooks</b>
 
            `machete-post-slide-out <new-upstream> <lowest-slid-out-branch> [<new-downstreams>...]`
               The hook that is executed after a branch (or possibly multiple branches, in case of `slide-out`)
@@ -1154,7 +1154,7 @@ long_docs: Dict[str, str] = {
         An example of using the standard git `post-commit hook` to `git machete add` branches automatically is also included.
    """,
     "is-managed": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete is-managed [<branch>]</b>
 
         Return with zero exit code if the given branch (or current branch, if none specified) is <b>managed</b> by git machete (that is, listed in .git/machete).
@@ -1166,7 +1166,7 @@ long_docs: Dict[str, str] = {
            * the <branch> isn't provided and there's no current branch (detached HEAD).
    """,
     "list": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete list <category></b>
 
         where <category> is one of: `addable`, `childless`, `managed`, `slidable`, `slidable-after <branch>`, `unmanaged`, `with-overridden-fork-point`.
@@ -1194,7 +1194,7 @@ long_docs: Dict[str, str] = {
         This command is generally not meant for a day-to-day use, it's mostly needed for branch name completion in shell.
    """,
     "log": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete l[og] [<branch>] [-- <pass-through-arguments>]</b>
 
         Run `git log` for the range of commits from tip of the given branch (or current branch, if none specified) back to its fork point.
@@ -1202,13 +1202,13 @@ long_docs: Dict[str, str] = {
 
         Note: the branch in question does not need to occur in the branch layout file.
 
-        <b>Options:</b>
+        <b>Options</b>
 
            <b>-- <pass-through-arguments></b>
               Arguments to pass directly to the underlying `git log`, for example `git machete log -- --patch`.
    """,
     "reapply": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete reapply [-f|--fork-point=<fork-point-commit>]</b>
 
         Interactively rebase the current branch on the top of its computed fork point.
@@ -1221,19 +1221,19 @@ long_docs: Dict[str, str] = {
         Tip: `reapply` can be used for squashing the commits on the current branch to make history more condensed before push to the remote,
         but there is also dedicated `squash` command that achieves the same goal without running `git rebase`.
 
-        <b>Options:</b>
+        <b>Options</b>
 
            <b>-f</b>, <b>--fork-point=<fork-point-commit></b>
               Specifies the alternative fork point commit after which the rebased part of history is meant to start.
 
-        <b>Environment variables:</b>
+        <b>Environment variables</b>
 
            `GIT_MACHETE_REBASE_OPTS`
               Extra options to pass to the underlying `git rebase` invocations, space-separated.
               Example: `GIT_MACHETE_REBASE_OPTS="--keep-empty --rebase-merges" git machete <command>`.
    """,
     "rename": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete rename [-b|--branch=<branch>] [--repoint-tracking] <new-name></b>
 
         Renames the given branch (or the current branch, if `-b`/`--branch` is not specified) to `<new-name>`
@@ -1247,7 +1247,7 @@ long_docs: Dict[str, str] = {
         Note: `rename` does <b>not</b> rename the branch on the remote — it only renames the local branch.
         The remote branch is left intact and can still be pushed to under its original name.
 
-        <b>Options:</b>
+        <b>Options</b>
 
            <b>-b</b>, <b>--branch=<branch></b>
               Branch to rename; if not given, the current branch is renamed.
@@ -1259,7 +1259,7 @@ long_docs: Dict[str, str] = {
               branch it pointed to before (for example `origin/old-name`).
    """,
     "show": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete show <direction> [<branch>]</b>
 
         where <direction> is one of: `c[urrent]`, `d[own]`, `f[irst]`, `l[ast]`, `n[ext]`, `p[rev]`, `r[oot]`, `u[p]`
@@ -1288,7 +1288,7 @@ long_docs: Dict[str, str] = {
            * `up`:      the direct parent/upstream branch of the given branch.
    """,
     "slide-out": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete slide-out --removed-from-remote [--delete]
            git machete slide-out [-d|--down-fork-point=<down-fork-point-commit>] [--delete]
                                  [-M|--merge] [-n|--no-edit-merge|--no-interactive-rebase]
@@ -1337,7 +1337,7 @@ long_docs: Dict[str, str] = {
         Note: if a child branch is annotated with `rebase=no` qualifier, the rebase is not performed.
         See help for `traverse` for more details on the qualifiers.
 
-        <b>Options:</b>
+        <b>Options</b>
 
            <b>-d</b>, <b>--down-fork-point=<down-fork-point-commit></b>
               If updating by rebase, specify the alternative fork point for downstream branches for the operation.
@@ -1377,14 +1377,14 @@ long_docs: Dict[str, str] = {
                  * those whose remote tracking branches still exist (not deleted remotely),
                  * those that have at least one downstream (child) branch.
 
-        <b>Environment variables:</b>
+        <b>Environment variables</b>
 
            `GIT_MACHETE_REBASE_OPTS`
               Extra options to pass to the underlying `git rebase` invocations, space-separated.
               Example: `GIT_MACHETE_REBASE_OPTS="--keep-empty --rebase-merges" git machete <command>`.
    """,
     "squash": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete squash [-f|--fork-point=<fork-point-commit>]</b>
 
         Squash the commits belonging uniquely to the current branch into a single commit.
@@ -1399,13 +1399,13 @@ long_docs: Dict[str, str] = {
         Note: `squash` does <b>not</b> run `git rebase` under the hood.
         For more complex scenarios that require rewriting the history of current branch, see `reapply` and `update`.
 
-        <b>Options:</b>
+        <b>Options</b>
 
            <b>-f</b>, <b>--fork-point=<fork-point-commit></b>
               Specify the alternative fork point commit after which the squashed part of history is meant to start.
    """,
     "status": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete s[tatus] [--color=WHEN]
                                 [-l|--list-commits] [-L|--list-commits-with-hashes]
                                 [--squash-merge-detection=MODE]</b>
@@ -1487,7 +1487,7 @@ long_docs: Dict[str, str] = {
            │
            └─ feature_branch2
         </dim>
-        <b>Options:</b>
+        <b>Options</b>
 
            <b>--color=WHEN</b>
               Colorize the output; WHEN can be `always`, `auto` (default: colorize only if stdout is a terminal), or `never`.
@@ -1508,9 +1508,9 @@ long_docs: Dict[str, str] = {
               `MODE` can be `none` (fastest, no squash merges are detected), `simple` (default) or `exact` (slowest).
               See the below paragraph on `machete.squashMergeDetection` git config key for more details.
 
-        <b>Git config keys:</b>
+        <b>Git config keys</b>
 
-           `machete.squashMergeDetection`:
+           `machete.squashMergeDetection`
               Select the algorithm used to detect squash merges. Possible values are:
 
               * `none`: Fastest mode, with no squash merge/rebase detection. Only strict (fast-forward or 2-parent) merges are detected.
@@ -1527,12 +1527,12 @@ long_docs: Dict[str, str] = {
               * whether a gray edge is displayed in `status`,
               * whether `traverse` suggests to slide out the branch.
 
-           `machete.status.extraSpaceBeforeBranchName`:
+           `machete.status.extraSpaceBeforeBranchName`
               To make it easier to select branch name from the `status` output on certain terminals (like `Alacritty),
               you can add an extra space between └─ and branch name by setting `git config machete.status.extraSpaceBeforeBranchName true`.
    """,
     "traverse": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete t[raverse] [-F|--fetch] [-l|--list-commits] [-M|--merge]
                                   [-n|--no-edit-merge|--no-interactive-rebase] [--[no-]push] [--[no-]push-untracked]
                                   [--return-to=WHERE] [--squash-merge-detection=MODE] [--start-from=WHERE] [--stop-after=BRANCH]
@@ -1614,7 +1614,7 @@ long_docs: Dict[str, str] = {
         If a branch is not checked out in any worktree, by default `traverse` will change directory to the main worktree before checking out the branch.
         This behavior can be customized using `machete.traverse.whenBranchNotCheckedOutInAnyWorktree` git config key (see below).
 
-        <b>Options:</b>
+        <b>Options</b>
 
            <b>-F</b>, <b>--fetch</b>
               Fetch the remotes of all managed branches at the beginning of traversal (no `git pull` involved, only `git fetch`).
@@ -1698,9 +1698,9 @@ long_docs: Dict[str, str] = {
            <b>-y</b>, <b>--yes</b>
               Don't ask for any interactive input, including confirmation of rebase/push/pull. Implies `-n`.
 
-        <b>Git config keys:</b>
+        <b>Git config keys</b>
 
-           `machete.squashMergeDetection`:
+           `machete.squashMergeDetection`
               Select the algorithm used to detect squash merges. Possible values are:
 
               * `none`: Fastest mode, with no squash merge/rebase detection. Only strict (fast-forward or 2-parent) merges are detected.
@@ -1717,18 +1717,18 @@ long_docs: Dict[str, str] = {
               * whether a gray edge is displayed in `status`,
               * whether `traverse` suggests to slide out the branch.
 
-           `machete.traverse.fetch.<remote>`:
+           `machete.traverse.fetch.<remote>`
               Configure the behavior of `git machete traverse` command for the given remote when `--fetch` flag is used.
               If set to `false`, this remote will not be fetched before the traversal.
               The default value of this key is `true`.
               This is useful for excluding remotes that are temporarily offline, or take a long time to respond.
 
-           `machete.traverse.push`:
+           `machete.traverse.push`
               Set to `false` to change the behavior of `git machete traverse` so that it doesn't push branches by default.
               The default value of this key is `true`.
               Configuration key value can be overridden by the presence of the `--push` or `--push-untracked` flags.
 
-           `machete.traverse.whenBranchNotCheckedOutInAnyWorktree`:
+           `machete.traverse.whenBranchNotCheckedOutInAnyWorktree`
               Controls the behavior of `git machete traverse` when it needs to act on a branch that is not currently checked out in any worktree.
 
               Allowed values:
@@ -1742,14 +1742,14 @@ long_docs: Dict[str, str] = {
                 and remove this temporary worktree once `traverse` moves on to the next branch (or finishes).
                 This ensures that no existing (non-temporary) worktree has its checked-out branch changed by `traverse`.
 
-        <b>Environment variables:</b>
+        <b>Environment variables</b>
 
            `GIT_MACHETE_REBASE_OPTS`
               Extra options to pass to the underlying `git rebase` invocations, space-separated.
               Example: `GIT_MACHETE_REBASE_OPTS="--keep-empty --rebase-merges" git machete <command>`.
    """,
     "update": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete update [-f|--fork-point=<fork-point-commit>] [-M|--merge] [-n|--no-edit-merge|--no-interactive-rebase]</b>
 
         Synchronize the current branch with its upstream (parent) branch either by rebase (default) or by merge (if `--merge` option passed).
@@ -1761,7 +1761,7 @@ long_docs: Dict[str, str] = {
 
         If updating by merge, merges the upstream (parent) branch into the current branch.
 
-        <b>Options:</b>
+        <b>Options</b>
 
            <b>-f</b>, <b>--fork-point=<fork-point-commit></b>
               If updating by rebase, specifies the alternative fork point commit after which the rebased
@@ -1782,14 +1782,14 @@ long_docs: Dict[str, str] = {
               If updating by rebase, run `git rebase` in non-interactive mode (without `-i/--interactive` flag).
               Not allowed if updating by merge.
 
-        <b>Environment variables:</b>
+        <b>Environment variables</b>
 
            `GIT_MACHETE_REBASE_OPTS`
               Extra options to pass to the underlying `git rebase` invocations, space-separated.
               Example: `GIT_MACHETE_REBASE_OPTS="--keep-empty --rebase-merges" git machete <command>`.
    """,
     "version": """
-        <b>Usage:</b><b>
+        <b>Usage</b><b>
            git machete version</b>
 
         Print the version and exit.

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -31,7 +31,7 @@ class TestHelp(BaseTest):
             if command not in help_topics:
                 output, e = launch_command_capturing_output_and_exception(command, "--help")
                 assert output is not None
-                assert "Usage:" in output
+                assert "Usage" in output
                 assert type(e) is SystemExit
                 assert e.code == ExitCode.SUCCESS
             else:


### PR DESCRIPTION
Headers in the docs no longer end with a colon: config keys, subcommand signatures, environment variable names
and bold section titles such as **Usage**, **Options** and **Git config keys**.
A header reads as a label on its own, so the trailing colon was just visual noise.

Add `ci/checks/prohibit-colon-after-header-in-rst.sh` (wired into `run-all-checks.sh`) to keep them colon-free going forward.

Update `docs/generate_py_docs.py` to key off the colon-less markers (the `**Usage**` heading and the bold section titles),
and regenerate `git_machete/generated_docs.py` and the Unix man page accordingly.