### PR TITLE
fix: washed-out yellow on light-background terminals

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## New in git-machete 3.44.1
 
+- fixed: the yellow used e.g. for the yellow edge in `status`/`traverse` no longer renders as a washed-out, barely-visible color on light/white-background terminals
+
 ## New in git-machete 3.44.0
 
 - added: `machete.github.{baseRemote,baseOrganization,baseRepository}` and `machete.gitlab.{baseRemote,baseNamespace,baseProject}` git config keys

--- a/git_machete/utils/terminal.py
+++ b/git_machete/utils/terminal.py
@@ -86,7 +86,12 @@ class FullTerminalAnsiOutputCodes:
     DIM = '\033[2m'
     UNDERLINE = '\033[4m'
     GREEN = '\033[32m'
-    YELLOW = '\033[33m'
+    # Plain SGR 33 ("dark yellow") renders as a washed-out, barely-visible color on light/white-background
+    # terminals (#380). Gold1 from the 256-color palette reads clearly as "yellow" on both dark and light
+    # backgrounds; it was already used for exactly this reason back in 0b43361 ("Improved visibility on white
+    # terminal backgrounds"), but got silently overwritten by 21f9b8a while that commit was actually only
+    # trying to match a *different* yellow use (the hook-ignored-hook hint below) to git's own advice color.
+    YELLOW = '\033[00;38;5;220m'
     ORANGE = '\033[00;38;5;208m'
     RED = '\033[91m'
     REVERSE_VIDEO = '\033[7m'
@@ -107,5 +112,8 @@ class BasicTerminalAnsiOutputCodes(FullTerminalAnsiOutputCodes):
 
     UNDERLINE = '\033[36m'  # cyan
     ENDC_UNDERLINE = FullTerminalAnsiOutputCodes.ENDC
-    ORANGE = FullTerminalAnsiOutputCodes.YELLOW
+    # The 256-color YELLOW above isn't available on 8-color terminals; keep the plain SGR 33 here (and reuse
+    # it for ORANGE, which isn't available in 8 colors either) instead of inheriting the 256-color escape.
+    YELLOW = '\033[33m'
+    ORANGE = YELLOW
     RED = '\033[31m'  # dark red

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,6 +54,15 @@ class TestUtils(BaseTest):
         expected_ascii = ' red yellow yellow_bold yellow_underlined yellow green  default  dimmed  green green_underlined default'
         assert _fmt(input_string, use_ansi_escapes=False) == expected_ascii
 
+    def test_yellow_is_not_the_washed_out_dark_yellow(self) -> None:
+        # Regression test for #380: plain SGR 33 ("dark yellow") renders as washed-out/barely-visible
+        # on light terminal backgrounds, so full-fledged (256-color) terminals must use a brighter yellow.
+        assert FullTerminalAnsiOutputCodes.YELLOW == '\033[00;38;5;220m'
+        assert FullTerminalAnsiOutputCodes.YELLOW != '\033[33m'
+        # 8-color terminals can't render the 256-color escape above, so they still get plain SGR 33.
+        assert BasicTerminalAnsiOutputCodes.YELLOW == '\033[33m'
+        assert BasicTerminalAnsiOutputCodes.ORANGE == '\033[33m'
+
     def test_get_current_date(self) -> None:
         assert re.fullmatch("20[0-9][0-9]-[0-1][0-9]-[0-3][0-9]", get_current_date())
 


### PR DESCRIPTION
## Summary
`FullTerminalAnsiOutputCodes.YELLOW` used plain SGR 33 ("dark yellow"), which renders as a washed-out, barely-visible color on light/white terminal backgrounds. This color was already fixed once, to the brighter 256-color gold1 (`\033[00;38;5;220m`), in 0b43361 ("Improved visibility on white terminal backgrounds"), but got silently overwritten back to plain SGR 33 by 21f9b8a, which was actually only trying to match a *different* yellow use (the hook-ignored-hook hint) to git's own advice color.

This restores the 256-color gold1 for full-fledged terminals. 8-color terminals (`BasicTerminalAnsiOutputCodes`) can't render the 256-color escape, so they keep plain SGR 33 explicitly rather than inheriting the 256-color value.

Fixes #380

## Test plan
- Added `test_yellow_is_not_the_washed_out_dark_yellow` regression test in `tests/test_utils.py`
- Ran `tests/test_utils.py` — 8 passed, 2 skipped (platform-specific, unrelated)
- Ran the full color-related suite (`test_status.py`, `test_discover.py`, `test_advance.py`, `test_fork_point.py`, `test_go_interactive.py`, `test_traverse.py`) — all pass except 18 pre-existing failures unrelated to this change (verified: identical failures reproduce against unmodified `develop`, caused by `shutil.copytree` failing on a `.git/fsmonitor--daemon.ipc` unix socket in this sandbox, not by this fix)