### PR TITLE
Emit github/gitlab draft, retarget and description requests as `... OK` progress messages

### DIFF
--- a/git_machete/client/traverse.py
+++ b/git_machete/client/traverse.py
@@ -425,10 +425,11 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
                         ans_intro + f"Retargeting {pr.display_text()} to <b>{parent}</b>...",
                         opt_yes=opt_yes)
                     if ans in ('y', 'yes', 'yq'):
-                        self.code_hosting_client.set_base_of_pull_request(pr.number, base=parent)
                         print_fmt(
-                            f'{spec.base_branch_name.capitalize()} branch of {pr.display_text()} '
-                            f'has been switched to <b>{parent}</b>')
+                            f'Switching {spec.base_branch_name} branch of {pr.display_text()} '
+                            f'to <b>{parent}</b>... ', newline=False)
+                        self.code_hosting_client.set_base_of_pull_request(pr.number, base=parent)
+                        print_fmt(green_ok())
                         pr.base = parent
 
                         anno = self._state.get_annotation(branch)
@@ -439,18 +440,20 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
 
                         new_description = self._get_updated_pull_request_description(pr)
                         if pr.description != new_description:
+                            print_fmt(f'Updating description of {pr.display_text()}... ', newline=False)
                             self.code_hosting_client.set_description_of_pull_request(pr.number, description=new_description)
-                            print_fmt(f'Description of {pr.display_text()} has been updated')
+                            print_fmt(green_ok())
                             pr.description = new_description
 
                         applicable_prs: List[PullRequest] = self._get_applicable_pull_requests(related_to=pr)
                         for pr in applicable_prs:
                             new_description = self._get_updated_pull_request_description(pr)
                             if pr.description != new_description:
+                                print_fmt(f'Updating description of {pr.display_text()} '
+                                          f'(<b>{pr.head} <rarrow/> {pr.base}</b>)... ', newline=False)
                                 self.code_hosting_client.set_description_of_pull_request(pr.number, description=new_description)
                                 pr.description = new_description
-                                print_fmt(f'Description of {pr.display_text()} '
-                                          f'(<b>{pr.head} <rarrow/> {pr.base}</b>) has been updated')
+                                print_fmt(green_ok())
 
                         if ans == 'yq':
                             return

--- a/git_machete/client/with_code_hosting.py
+++ b/git_machete/client/with_code_hosting.py
@@ -456,9 +456,9 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
                     f'Branch <b>{current_branch}</b> is marked as `push=no`; aborting the restack.\n'
                     f'Did you want to just use `git machete {spec.git_machete_command} {subcommand}`?\n')
 
+            print_fmt(f'Temporarily marking {pr.display_text()} as draft... ', newline=False)
             converted_to_draft = self.code_hosting_client.set_draft_status_of_pull_request(pr.number, target_draft_status=True)
-            if converted_to_draft:
-                print_fmt(f'{pr.display_text()} has been temporarily marked as draft')
+            print_fmt(green_ok() if converted_to_draft else green_ok() + ' (already a draft)')
 
             # Note that retarget should happen BEFORE push, see issue #1222
             self.retarget_pull_request(opt_branch=head, opt_ignore_if_missing=False,
@@ -494,8 +494,9 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             self._ensure_blank_separator()
 
             if converted_to_draft:
+                print_fmt(f'Marking {pr.display_text()} as ready for review again... ', newline=False)
                 self.code_hosting_client.set_draft_status_of_pull_request(pr.number, target_draft_status=False)
-                print_fmt(f'{pr.display_text()} has been marked as ready for review again')
+                print_fmt(green_ok())
 
         else:
             if s == SyncToRemoteStatus.BEHIND_REMOTE:
@@ -554,9 +555,10 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
 
         pr_with_original_base = pr.copy()
         if pr.base != new_base:
-            self.code_hosting_client.set_base_of_pull_request(pr.number, base=new_base)
             print_fmt(
-                f'{spec.base_branch_name.capitalize()} branch of {pr.display_text()} has been switched to <b>{new_base}</b>')
+                f'Switching {spec.base_branch_name} branch of {pr.display_text()} to <b>{new_base}</b>... ', newline=False)
+            self.code_hosting_client.set_base_of_pull_request(pr.number, base=new_base)
+            print_fmt(green_ok())
             pr.base = new_base
         else:
             print_fmt(
@@ -564,8 +566,9 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
 
         new_description = self._get_updated_pull_request_description(pr)
         if pr.description != new_description:
+            print_fmt(f'Updating description of {pr.display_text()}... ', newline=False)
             self.code_hosting_client.set_description_of_pull_request(pr.number, description=new_description)
-            print_fmt(f'Description of {pr.display_text()} has been updated')
+            print_fmt(green_ok())
 
         current_user: Optional[str] = self.code_hosting_client.get_current_user_login()
         anno = self._state.get_annotation(head)
@@ -582,9 +585,10 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
             for pr in applicable_prs:
                 new_description = self._get_updated_pull_request_description(pr)
                 if (pr.description or '').rstrip() != new_description.rstrip():
+                    print_fmt(f'Updating description of {pr.display_text()} (<b>{pr.head} <rarrow/> {pr.base}</b>)... ', newline=False)
                     self.code_hosting_client.set_description_of_pull_request(pr.number, description=new_description)
                     pr.description = new_description
-                    print_fmt(f'Description of {pr.display_text()} (<b>{pr.head} <rarrow/> {pr.base}</b>) has been updated')
+                    print_fmt(green_ok())
 
     def __derive_code_hosting_domain(self) -> str:
         spec = self.code_hosting_spec
@@ -823,9 +827,10 @@ class MacheteClientWithCodeHosting(StatusMacheteClient):
         for pr in applicable_prs:
             new_description = self._get_updated_pull_request_description(pr)
             if pr.description != new_description:
+                print_fmt(f'Updating description of {pr.display_text()} (<b>{pr.head} <rarrow/> {pr.base}</b>)... ', newline=False)
                 self.code_hosting_client.set_description_of_pull_request(pr.number, description=new_description)
                 pr.description = new_description
-                print_fmt(f'Description of {pr.display_text()} (<b>{pr.head} <rarrow/> {pr.base}</b>) has been updated')
+                print_fmt(green_ok())
 
     def checkout_pull_requests(
         self,

--- a/git_machete/github.py
+++ b/git_machete/github.py
@@ -215,6 +215,7 @@ class GitHubApi(CodeHostingApi):
                 if 'A pull request already exists for' in error_reason:
                     raise MacheteException(error_reason)
                 elif 'Reviews may only be requested from collaborators.' in error_reason:
+                    # Break off the dangling `Adding ... as reviewer(s) to ...` in-progress line before warning.
                     print()
                     warn("there are some invalid reviewers (non-collaborators) in .git/info/reviewers file.\n"
                          "Skipped adding reviewers to the pull request.")
@@ -264,6 +265,9 @@ class GitHubApi(CodeHostingApi):
                         'Update your remote repository manually via: `git remote set-url <remote_name> <new_repository_url>`.')
                 new_path = re.sub("https://[^/]+", "", location)
                 result = self.__fire_github_api_request(method=method, path=new_path, request_body=request_body)
+                # Break off the dangling `... ` in-progress line before warning
+                # (the 307 is only reachable for mutations, each preceded by such a line).
+                print()
                 warn(f'GitHub API returned `{err.code}` HTTP status with error message: `{err.reason}`.\n'
                      'It looks like the organization or repository name got changed recently and is outdated.\n'
                      f'New organization is <b>{new_org}</b> and new repository is <b>{new_repo}</b>.\n'

--- a/tests/test_github_create_pr.py
+++ b/tests/test_github_create_pr.py
@@ -241,8 +241,8 @@ class TestGitHubCreatePR(BaseTest):
             Adding foo, bar as reviewers to PR #6... OK
             Updating descriptions of other PRs...
             Checking for open GitHub PRs... OK
-            Description of PR #3 (ignore-trailing -> hotfix/add-trigger) has been updated
-            Description of PR #5 (chore/fields -> ignore-trailing) has been updated
+            Updating description of PR #3 (ignore-trailing -> hotfix/add-trigger)... OK
+            Updating description of PR #5 (chore/fields -> ignore-trailing)... OK
             """
         )
         pr5 = github_api_state.get_pull_by_number(5)

--- a/tests/test_github_restack_pr.py
+++ b/tests/test_github_restack_pr.py
@@ -78,8 +78,8 @@ class TestGitHubRestackPR(BaseTest):
         assert_success(
             ['github', 'restack-pr'],
             """
-            Base branch of PR #15 has been switched to master
-            Description of PR #15 has been updated
+            Switching base branch of PR #15 to master... OK
+            Updating description of PR #15... OK
             """
         )
         pr = github_api_state.get_pull_by_number(15)
@@ -110,7 +110,8 @@ class TestGitHubRestackPR(BaseTest):
         assert_success(
             ['github', 'restack-pr'],
             """
-            Base branch of PR #14 has been switched to master
+            Temporarily marking PR #14 as draft... OK (already a draft)
+            Switching base branch of PR #14 to master... OK
             Pushing untracked branch feature_1 to origin...
 
               master (untracked)
@@ -150,9 +151,9 @@ class TestGitHubRestackPR(BaseTest):
         assert_success(
             ['github', 'restack-pr'],
             """
-            PR #15 has been temporarily marked as draft
-            Base branch of PR #15 has been switched to master
-            Description of PR #15 has been updated
+            Temporarily marking PR #15 as draft... OK
+            Switching base branch of PR #15 to master... OK
+            Updating description of PR #15... OK
             Branch feature diverged from (and has newer commits than) its remote counterpart origin/feature.
             Pushing feature with force-with-lease to origin...
 
@@ -160,7 +161,7 @@ class TestGitHubRestackPR(BaseTest):
               |
               o-feature *  PR #15 (some_other_user)
 
-            PR #15 has been marked as ready for review again
+            Marking PR #15 as ready for review again... OK
             """
         )
         pr = github_api_state.get_pull_by_number(15)
@@ -193,16 +194,16 @@ class TestGitHubRestackPR(BaseTest):
         assert_success(
             ['github', 'restack-pr'],
             """
-            PR #15 has been temporarily marked as draft
-            Base branch of PR #15 has been switched to master
-            Description of PR #15 has been updated
+            Temporarily marking PR #15 as draft... OK
+            Switching base branch of PR #15 to master... OK
+            Updating description of PR #15... OK
             Pushing feature to origin...
 
               master (untracked)
               |
               o-feature *  PR #15 (some_other_user)
 
-            PR #15 has been marked as ready for review again
+            Marking PR #15 as ready for review again... OK
             """
         )
         pr = github_api_state.get_pull_by_number(15)
@@ -247,16 +248,16 @@ class TestGitHubRestackPR(BaseTest):
         assert_success(
             ['github', 'restack-pr'],
             """
-            PR #15 has been temporarily marked as draft
-            Base branch of PR #15 has been switched to master
-            Description of PR #15 has been updated
+            Temporarily marking PR #15 as draft... OK
+            Switching base branch of PR #15 to master... OK
+            Updating description of PR #15... OK
             Pushing feature to origin...
 
               master (untracked)
               |
               o-feature *  PR #15 (some_other_user)
 
-            PR #15 has been marked as ready for review again
+            Marking PR #15 as ready for review again... OK
             """
         )
         pr = github_api_state.get_pull_by_number(15)
@@ -289,8 +290,8 @@ class TestGitHubRestackPR(BaseTest):
             """
             Warn: branch feature is behind its remote counterpart. Consider using git pull.
 
-            Base branch of PR #15 has been switched to master
-            Description of PR #15 has been updated
+            Switching base branch of PR #15 to master... OK
+            Updating description of PR #15... OK
             """
         )
 
@@ -322,8 +323,8 @@ class TestGitHubRestackPR(BaseTest):
             """
             Warn: branch feature is diverged from and older than its remote counterpart. Consider using git reset --keep.
 
-            Base branch of PR #15 has been switched to master
-            Description of PR #15 has been updated
+            Switching base branch of PR #15 to master... OK
+            Updating description of PR #15... OK
             """
         )
         pr = github_api_state.get_pull_by_number(15)

--- a/tests/test_github_retarget_pr.py
+++ b/tests/test_github_retarget_pr.py
@@ -72,11 +72,12 @@ class TestGitHubRetargetPR(BaseTest):
         assert_success(
             ['github', 'retarget-pr'],
             """
+            Switching base branch of PR #15 to develop...
             Warn: GitHub API returned 307 HTTP status with error message: Temporary redirect.
             It looks like the organization or repository name got changed recently and is outdated.
             New organization is example-org and new repository is example-repo.
             You can update your remote repository via: git remote set-url <remote_name> <new_repository_url>.
-            Base branch of PR #15 has been switched to develop
+            OK
             """
         )
 
@@ -163,7 +164,7 @@ class TestGitHubRetargetPR(BaseTest):
 
         assert_success(
             ['github', 'retarget-pr', '--branch', 'feature'],
-            'Base branch of PR #15 has been switched to branch-1\n'
+            'Switching base branch of PR #15 to branch-1... OK\n'
         )
 
         expected_status_output = """
@@ -252,9 +253,9 @@ class TestGitHubRetargetPR(BaseTest):
 
         assert_success(
             ['github', 'retarget-pr'],
-            'Base branch of PR #20 has been switched to feature\n'
+            'Switching base branch of PR #20 to feature... OK\n'
             'Checking for open GitHub PRs... OK\n'
-            'Description of PR #20 has been updated\n'
+            'Updating description of PR #20... OK\n'
         )
         pr20 = github_api_state.get_pull_by_number(20)
         assert pr20 is not None
@@ -300,8 +301,8 @@ class TestGitHubRetargetPR(BaseTest):
         set_git_config_key("machete.github.prDescriptionIntroStyle", "none")
         assert_success(
             ['github', 'retarget-pr'],
-            'Base branch of PR #25 has been switched to feature\n'
-            'Description of PR #25 has been updated\n'
+            'Switching base branch of PR #25 to feature... OK\n'
+            'Updating description of PR #25... OK\n'
         )
         pr25 = github_api_state.get_pull_by_number(25)
         assert pr25 is not None
@@ -328,9 +329,9 @@ class TestGitHubRetargetPR(BaseTest):
         unset_git_config_key("machete.github.prDescriptionIntroStyle")
         assert_success(
             ['github', 'retarget-pr'],
-            'Base branch of PR #30 has been switched to feature_2\n'
+            'Switching base branch of PR #30 to feature_2... OK\n'
             'Checking for open GitHub PRs... OK\n'
-            'Description of PR #30 has been updated\n'
+            'Updating description of PR #30... OK\n'
         )
         pr30 = github_api_state.get_pull_by_number(30)
         assert pr30 is not None
@@ -368,9 +369,9 @@ class TestGitHubRetargetPR(BaseTest):
 
         assert_success(
             ['github', 'retarget-pr'],
-            'Base branch of PR #30 has been switched to feature\n'
+            'Switching base branch of PR #30 to feature... OK\n'
             'Checking for open GitHub PRs... OK\n'
-            'Description of PR #30 has been updated\n'
+            'Updating description of PR #30... OK\n'
         )
         pr30 = github_api_state.get_pull_by_number(30)
         assert pr30 is not None
@@ -405,8 +406,8 @@ class TestGitHubRetargetPR(BaseTest):
 
         assert_success(
             ['github', 'retarget-pr'],
-            'Base branch of PR #30 has been switched to root\n'
-            'Description of PR #30 has been updated\n'
+            'Switching base branch of PR #30 to root... OK\n'
+            'Updating description of PR #30... OK\n'
         )
         pr30 = github_api_state.get_pull_by_number(30)
         assert pr30 is not None
@@ -419,12 +420,12 @@ class TestGitHubRetargetPR(BaseTest):
         assert_success(
             ['github', 'retarget-pr', '-U'],
             """
-            Base branch of PR #15 has been switched to branch-1
+            Switching base branch of PR #15 to branch-1... OK
             Updating descriptions of other PRs...
             Checking for open GitHub PRs... OK
-            Description of PR #20 (feature_1 -> feature) has been updated
-            Description of PR #25 (feature_2 -> feature) has been updated
-            Description of PR #35 (feature_4 -> feature) has been updated
+            Updating description of PR #20 (feature_1 -> feature)... OK
+            Updating description of PR #25 (feature_2 -> feature)... OK
+            Updating description of PR #35 (feature_4 -> feature)... OK
             """
         )
         pr15 = github_api_state.get_pull_by_number(15)
@@ -438,7 +439,7 @@ class TestGitHubRetargetPR(BaseTest):
             """
             Base branch of PR #15 is already branch-1
             Checking for open GitHub PRs... OK
-            Description of PR #15 has been updated
+            Updating description of PR #15... OK
             Updating descriptions of other PRs...
             """
         )

--- a/tests/test_github_update_pr_descriptions.py
+++ b/tests/test_github_update_pr_descriptions.py
@@ -78,9 +78,9 @@ class TestGitHubUpdatePRDescriptions(BaseTest):
             ['github', 'update-pr-descriptions', '--related'],
             """
             Checking for open GitHub PRs... OK
-            Description of PR #1 (branch1 -> root) has been updated
-            Description of PR #2 (branch2 -> branch1) has been updated
-            Description of PR #3 (branch3 -> branch2) has been updated
+            Updating description of PR #1 (branch1 -> root)... OK
+            Updating description of PR #2 (branch2 -> branch1)... OK
+            Updating description of PR #3 (branch3 -> branch2)... OK
             """
         )
 
@@ -122,15 +122,15 @@ class TestGitHubUpdatePRDescriptions(BaseTest):
             """)
         check_out('branch2')
         # `full` style ensures every PR in the stack (incl. the topmost) has an intro
-        # to add, so all three of the related PRs surface a "has been updated" line.
+        # to add, so all three of the related PRs surface an "Updating description of ..." line.
         set_git_config_key("machete.github.prDescriptionIntroStyle", "full")
 
         assert_success(
             ['github', 'update-pr-descriptions'],
             """
             Checking for open GitHub PRs... OK
-            Description of PR #1 (branch1 -> root) has been updated
-            Description of PR #2 (branch2 -> branch1) has been updated
+            Updating description of PR #1 (branch1 -> root)... OK
+            Updating description of PR #2 (branch2 -> branch1)... OK
             """
         )
 
@@ -223,7 +223,7 @@ class TestGitHubUpdatePRDescriptions(BaseTest):
             ['github', 'update-pr-descriptions', '--mine'],
             """
             Checking for open GitHub PRs... OK
-            Description of PR #17 (restrict_access -> allow-ownership-link) has been updated
+            Updating description of PR #17 (restrict_access -> allow-ownership-link)... OK
             """
         )
 
@@ -231,7 +231,7 @@ class TestGitHubUpdatePRDescriptions(BaseTest):
             ['github', 'update-pr-descriptions', '--by=other_user'],
             """
             Checking for open GitHub PRs... OK
-            Description of PR #12 (allow-ownership-link -> bugfix/feature) has been updated
+            Updating description of PR #12 (allow-ownership-link -> bugfix/feature)... OK
             """
         )
 
@@ -240,7 +240,7 @@ class TestGitHubUpdatePRDescriptions(BaseTest):
             ['github', 'update-pr-descriptions', '--related'],
             """
             Checking for open GitHub PRs... OK
-            Description of PR #18 (chore/redundant_checks -> restrict_access) has been updated
+            Updating description of PR #18 (chore/redundant_checks -> restrict_access)... OK
             """
         )
         set_git_config_key("machete.github.prDescriptionIntroStyle", "full")
@@ -248,9 +248,9 @@ class TestGitHubUpdatePRDescriptions(BaseTest):
             ['github', 'update-pr-descriptions', '--related'],
             """
             Checking for open GitHub PRs... OK
-            Description of PR #6 (bugfix/feature -> enhance/feature) has been updated
-            Description of PR #12 (allow-ownership-link -> bugfix/feature) has been updated
-            Description of PR #17 (restrict_access -> allow-ownership-link) has been updated
+            Updating description of PR #6 (bugfix/feature -> enhance/feature)... OK
+            Updating description of PR #12 (allow-ownership-link -> bugfix/feature)... OK
+            Updating description of PR #17 (restrict_access -> allow-ownership-link)... OK
             """
         )
 
@@ -258,8 +258,8 @@ class TestGitHubUpdatePRDescriptions(BaseTest):
             ['github', 'update-pr-descriptions', '--all'],
             """
             Checking for open GitHub PRs... OK
-            Description of PR #22 (testing/add_user -> bugfix/add_user) has been updated
-            Description of PR #24 (chore/comments -> testing/add_user) has been updated
+            Updating description of PR #22 (testing/add_user -> bugfix/add_user)... OK
+            Updating description of PR #24 (chore/comments -> testing/add_user)... OK
             """
         )
 

--- a/tests/test_gitlab_create_mr.py
+++ b/tests/test_gitlab_create_mr.py
@@ -240,8 +240,8 @@ class TestGitLabCreateMR(BaseTest):
             Adding foo, bar as reviewers to MR !6... OK
             Updating descriptions of other MRs...
             Checking for open GitLab MRs... OK
-            Description of MR !3 (ignore-trailing -> hotfix/add-trigger) has been updated
-            Description of MR !5 (chore/fields -> ignore-trailing) has been updated
+            Updating description of MR !3 (ignore-trailing -> hotfix/add-trigger)... OK
+            Updating description of MR !5 (chore/fields -> ignore-trailing)... OK
         """)
         mr5 = gitlab_api_state.get_mr_by_number(5)
         assert mr5 is not None

--- a/tests/test_gitlab_restack_mr.py
+++ b/tests/test_gitlab_restack_mr.py
@@ -77,8 +77,8 @@ class TestGitLabRestackMR(BaseTest):
         assert_success(
             ['gitlab', 'restack-mr'],
             """
-            Target branch of MR !15 has been switched to master
-            Description of MR !15 has been updated
+            Switching target branch of MR !15 to master... OK
+            Updating description of MR !15... OK
             """
         )
         mr = gitlab_api_state.get_mr_by_number(15)
@@ -109,7 +109,8 @@ class TestGitLabRestackMR(BaseTest):
         assert_success(
             ['gitlab', 'restack-mr'],
             """
-            Target branch of MR !14 has been switched to master
+            Temporarily marking MR !14 as draft... OK (already a draft)
+            Switching target branch of MR !14 to master... OK
             Pushing untracked branch feature_1 to origin...
 
               master (untracked)
@@ -152,9 +153,9 @@ class TestGitLabRestackMR(BaseTest):
         assert_success(
             ['gitlab', 'restack-mr'],
             """
-            MR !15 has been temporarily marked as draft
-            Target branch of MR !15 has been switched to master
-            Description of MR !15 has been updated
+            Temporarily marking MR !15 as draft... OK
+            Switching target branch of MR !15 to master... OK
+            Updating description of MR !15... OK
             Branch feature diverged from (and has newer commits than) its remote counterpart origin/feature.
             Pushing feature with force-with-lease to origin...
 
@@ -162,7 +163,7 @@ class TestGitLabRestackMR(BaseTest):
               |
               o-feature *  MR !15 (some_other_user)
 
-            MR !15 has been marked as ready for review again
+            Marking MR !15 as ready for review again... OK
             """
         )
         mr = gitlab_api_state.get_mr_by_number(15)
@@ -196,16 +197,16 @@ class TestGitLabRestackMR(BaseTest):
         assert_success(
             ['gitlab', 'restack-mr'],
             """
-            MR !15 has been temporarily marked as draft
-            Target branch of MR !15 has been switched to master
-            Description of MR !15 has been updated
+            Temporarily marking MR !15 as draft... OK
+            Switching target branch of MR !15 to master... OK
+            Updating description of MR !15... OK
             Pushing feature to origin...
 
               master (untracked)
               |
               o-feature *  MR !15 (some_other_user)
 
-            MR !15 has been marked as ready for review again
+            Marking MR !15 as ready for review again... OK
             """
         )
         mr = gitlab_api_state.get_mr_by_number(15)
@@ -250,16 +251,16 @@ class TestGitLabRestackMR(BaseTest):
         assert_success(
             ['gitlab', 'restack-mr'],
             """
-            MR !15 has been temporarily marked as draft
-            Target branch of MR !15 has been switched to master
-            Description of MR !15 has been updated
+            Temporarily marking MR !15 as draft... OK
+            Switching target branch of MR !15 to master... OK
+            Updating description of MR !15... OK
             Pushing feature to origin...
 
               master (untracked)
               |
               o-feature *  MR !15 (some_other_user)
 
-            MR !15 has been marked as ready for review again
+            Marking MR !15 as ready for review again... OK
             """
         )
 
@@ -293,8 +294,8 @@ class TestGitLabRestackMR(BaseTest):
             """
             Warn: branch feature is behind its remote counterpart. Consider using git pull.
 
-            Target branch of MR !15 has been switched to master
-            Description of MR !15 has been updated
+            Switching target branch of MR !15 to master... OK
+            Updating description of MR !15... OK
             """
         )
 
@@ -326,8 +327,8 @@ class TestGitLabRestackMR(BaseTest):
             """
             Warn: branch feature is diverged from and older than its remote counterpart. Consider using git reset --keep.
 
-            Target branch of MR !15 has been switched to master
-            Description of MR !15 has been updated
+            Switching target branch of MR !15 to master... OK
+            Updating description of MR !15... OK
             """
         )
         mr = gitlab_api_state.get_mr_by_number(15)

--- a/tests/test_gitlab_retarget_mr.py
+++ b/tests/test_gitlab_retarget_mr.py
@@ -83,7 +83,7 @@ class TestGitLabRetargetMR(BaseTest):
         set_remote_url('new_origin', 'https://gitlab.com/example-org/example-repo.git')
         assert_success(
             ['gitlab', 'retarget-mr'],
-            "Target branch of MR !15 has been switched to develop\n"
+            "Switching target branch of MR !15 to develop... OK\n"
         )
 
         expected_status_output = """
@@ -169,7 +169,7 @@ class TestGitLabRetargetMR(BaseTest):
 
         assert_success(
             ['gitlab', 'retarget-mr', '--branch', 'feature'],
-            'Target branch of MR !15 has been switched to branch-1\n'
+            'Switching target branch of MR !15 to branch-1... OK\n'
         )
 
         expected_status_output = """
@@ -258,9 +258,9 @@ class TestGitLabRetargetMR(BaseTest):
 
         assert_success(
             ['gitlab', 'retarget-mr'],
-            'Target branch of MR !20 has been switched to feature\n'
+            'Switching target branch of MR !20 to feature... OK\n'
             'Checking for open GitLab MRs... OK\n'
-            'Description of MR !20 has been updated\n'
+            'Updating description of MR !20... OK\n'
         )
         mr20 = gitlab_api_state.get_mr_by_number(20)
         assert mr20 is not None
@@ -305,9 +305,9 @@ class TestGitLabRetargetMR(BaseTest):
 
         assert_success(
             ['gitlab', 'retarget-mr'],
-            'Target branch of MR !25 has been switched to feature\n'
+            'Switching target branch of MR !25 to feature... OK\n'
             'Checking for open GitLab MRs... OK\n'
-            'Description of MR !25 has been updated\n'
+            'Updating description of MR !25... OK\n'
         )
         mr25 = gitlab_api_state.get_mr_by_number(25)
         assert mr25 is not None
@@ -347,9 +347,9 @@ class TestGitLabRetargetMR(BaseTest):
 
         assert_success(
             ['gitlab', 'retarget-mr'],
-            'Target branch of MR !30 has been switched to feature_2\n'
+            'Switching target branch of MR !30 to feature_2... OK\n'
             'Checking for open GitLab MRs... OK\n'
-            'Description of MR !30 has been updated\n'
+            'Updating description of MR !30... OK\n'
         )
         mr30 = gitlab_api_state.get_mr_by_number(30)
         assert mr30 is not None
@@ -387,9 +387,9 @@ class TestGitLabRetargetMR(BaseTest):
 
         assert_success(
             ['gitlab', 'retarget-mr'],
-            'Target branch of MR !30 has been switched to feature\n'
+            'Switching target branch of MR !30 to feature... OK\n'
             'Checking for open GitLab MRs... OK\n'
-            'Description of MR !30 has been updated\n'
+            'Updating description of MR !30... OK\n'
         )
         mr30 = gitlab_api_state.get_mr_by_number(30)
         assert mr30 is not None
@@ -424,8 +424,8 @@ class TestGitLabRetargetMR(BaseTest):
 
         assert_success(
             ['gitlab', 'retarget-mr'],
-            'Target branch of MR !30 has been switched to root\n'
-            'Description of MR !30 has been updated\n'
+            'Switching target branch of MR !30 to root... OK\n'
+            'Updating description of MR !30... OK\n'
         )
         mr30 = gitlab_api_state.get_mr_by_number(30)
         assert mr30 is not None
@@ -438,12 +438,12 @@ class TestGitLabRetargetMR(BaseTest):
         assert_success(
             ['gitlab', 'retarget-mr', '-U'],
             """
-            Target branch of MR !15 has been switched to branch-1
+            Switching target branch of MR !15 to branch-1... OK
             Updating descriptions of other MRs...
             Checking for open GitLab MRs... OK
-            Description of MR !20 (feature_1 -> feature) has been updated
-            Description of MR !25 (feature_2 -> feature) has been updated
-            Description of MR !35 (feature_4 -> feature) has been updated
+            Updating description of MR !20 (feature_1 -> feature)... OK
+            Updating description of MR !25 (feature_2 -> feature)... OK
+            Updating description of MR !35 (feature_4 -> feature)... OK
             """
         )
         mr15 = gitlab_api_state.get_mr_by_number(15)
@@ -457,7 +457,7 @@ class TestGitLabRetargetMR(BaseTest):
             """
             Target branch of MR !15 is already branch-1
             Checking for open GitLab MRs... OK
-            Description of MR !15 has been updated
+            Updating description of MR !15... OK
             Updating descriptions of other MRs...
             """
         )

--- a/tests/test_gitlab_update_mr_descriptions.py
+++ b/tests/test_gitlab_update_mr_descriptions.py
@@ -78,9 +78,9 @@ class TestGitLabUpdateMRDescriptions(BaseTest):
             ['gitlab', 'update-mr-descriptions', '--related'],
             """
             Checking for open GitLab MRs... OK
-            Description of MR !1 (branch1 -> root) has been updated
-            Description of MR !2 (branch2 -> branch1) has been updated
-            Description of MR !3 (branch3 -> branch2) has been updated
+            Updating description of MR !1 (branch1 -> root)... OK
+            Updating description of MR !2 (branch2 -> branch1)... OK
+            Updating description of MR !3 (branch3 -> branch2)... OK
             """
         )
 
@@ -122,15 +122,15 @@ class TestGitLabUpdateMRDescriptions(BaseTest):
             """)
         check_out('branch2')
         # `full` style ensures every MR in the stack (incl. the topmost) has an intro
-        # to add, so all three of the related MRs surface a "has been updated" line.
+        # to add, so all three of the related MRs surface an "Updating description of ..." line.
         set_git_config_key("machete.gitlab.mrDescriptionIntroStyle", "full")
 
         assert_success(
             ['gitlab', 'update-mr-descriptions'],
             """
             Checking for open GitLab MRs... OK
-            Description of MR !1 (branch1 -> root) has been updated
-            Description of MR !2 (branch2 -> branch1) has been updated
+            Updating description of MR !1 (branch1 -> root)... OK
+            Updating description of MR !2 (branch2 -> branch1)... OK
             """
         )
 
@@ -223,7 +223,7 @@ class TestGitLabUpdateMRDescriptions(BaseTest):
             ['gitlab', 'update-mr-descriptions', '--mine'],
             """
             Checking for open GitLab MRs... OK
-            Description of MR !17 (restrict_access -> allow-ownership-link) has been updated
+            Updating description of MR !17 (restrict_access -> allow-ownership-link)... OK
             """
         )
 
@@ -231,7 +231,7 @@ class TestGitLabUpdateMRDescriptions(BaseTest):
             ['gitlab', 'update-mr-descriptions', '--by=other_user'],
             """
             Checking for open GitLab MRs... OK
-            Description of MR !12 (allow-ownership-link -> bugfix/feature) has been updated
+            Updating description of MR !12 (allow-ownership-link -> bugfix/feature)... OK
             """
         )
 
@@ -239,7 +239,7 @@ class TestGitLabUpdateMRDescriptions(BaseTest):
             ['gitlab', 'update-mr-descriptions', '--related'],
             """
             Checking for open GitLab MRs... OK
-            Description of MR !18 (chore/redundant_checks -> restrict_access) has been updated
+            Updating description of MR !18 (chore/redundant_checks -> restrict_access)... OK
             """
         )
         set_git_config_key("machete.gitlab.mrDescriptionIntroStyle", "full")
@@ -247,9 +247,9 @@ class TestGitLabUpdateMRDescriptions(BaseTest):
             ['gitlab', 'update-mr-descriptions', '--related'],
             """
             Checking for open GitLab MRs... OK
-            Description of MR !6 (bugfix/feature -> enhance/feature) has been updated
-            Description of MR !12 (allow-ownership-link -> bugfix/feature) has been updated
-            Description of MR !17 (restrict_access -> allow-ownership-link) has been updated
+            Updating description of MR !6 (bugfix/feature -> enhance/feature)... OK
+            Updating description of MR !12 (allow-ownership-link -> bugfix/feature)... OK
+            Updating description of MR !17 (restrict_access -> allow-ownership-link)... OK
             """
         )
 
@@ -257,8 +257,8 @@ class TestGitLabUpdateMRDescriptions(BaseTest):
             ['gitlab', 'update-mr-descriptions', '--all'],
             """
             Checking for open GitLab MRs... OK
-            Description of MR !22 (testing/add_user -> bugfix/add_user) has been updated
-            Description of MR !24 (chore/comments -> testing/add_user) has been updated
+            Updating description of MR !22 (testing/add_user -> bugfix/add_user)... OK
+            Updating description of MR !24 (chore/comments -> testing/add_user)... OK
             """
         )
 

--- a/tests/test_traverse_github.py
+++ b/tests/test_traverse_github.py
@@ -133,9 +133,9 @@ class TestTraverseGitHub(BaseTest):
 
             Branch build-chain has a different PR base (develop) in GitHub than in machete file (allow-ownership-link).
             Retargeting PR #2 to allow-ownership-link...
-            Base branch of PR #2 has been switched to allow-ownership-link
-            Description of PR #2 has been updated
-            Description of PR #3 (call-ws -> build-chain) has been updated
+            Switching base branch of PR #2 to allow-ownership-link... OK
+            Updating description of PR #2... OK
+            Updating description of PR #3 (call-ws -> build-chain)... OK
 
               develop
               |
@@ -214,7 +214,7 @@ class TestTraverseGitHub(BaseTest):
 
             Branch build-chain has a different PR base (develop) in GitHub than in machete file (allow-ownership-link).
             Retargeting PR #2 to allow-ownership-link...
-            Base branch of PR #2 has been switched to allow-ownership-link
+            Switching base branch of PR #2 to allow-ownership-link... OK
 
               develop
               |

--- a/tests/test_traverse_gitlab.py
+++ b/tests/test_traverse_gitlab.py
@@ -133,9 +133,9 @@ class TestTraverseGitLab(BaseTest):
 
             Branch build-chain has a different MR target (develop) in GitLab than in machete file (allow-ownership-link).
             Retargeting MR !2 to allow-ownership-link...
-            Target branch of MR !2 has been switched to allow-ownership-link
-            Description of MR !2 has been updated
-            Description of MR !3 (call-ws -> build-chain) has been updated
+            Switching target branch of MR !2 to allow-ownership-link... OK
+            Updating description of MR !2... OK
+            Updating description of MR !3 (call-ws -> build-chain)... OK
 
               develop
               |
@@ -215,5 +215,5 @@ class TestTraverseGitLab(BaseTest):
 
             Branch build-chain has a different MR target (develop) in GitLab than in machete file (allow-ownership-link).
             Retarget MR !2 to allow-ownership-link? (y, N, q, yq)
-            Target branch of MR !2 has been switched to allow-ownership-link
+            Switching target branch of MR !2 to allow-ownership-link... OK
             """)


### PR DESCRIPTION
The code-hosting commands used to print draft-toggling, base/target-switching and description-updating results only after the network call returned, as past-tense lines like `PR #15 has been temporarily marked as draft` or `Base branch of PR #15 has been switched to develop`. A slow or stalled request therefore left the terminal seemingly hung with no indication of what was happening.

Switch these to the `<action>... OK` progress pattern already used by `create-{pr,mr}` (milestone/assignee/reviewer/description steps), emitting the in-progress line before the request and completing it with `OK` afterwards, across `restack-{pr,mr}`, `retarget-{pr,mr}`, `update-{pr,mr}-descriptions` and `traverse --sync-{github-prs,gitlab-mrs}`. `restack`'s draft marking additionally reports `OK (already a draft)` when the PR/MR was already a draft (and is hence left as-is).

Since the GitHub 307-redirect notice is now emitted while a `... ` in-progress line is dangling, break it onto its own line with a `print()` first, mirroring the existing invalid-reviewers warning.