### PR TITLE
Set empty Dependabot commit-message prefix to drop build(deps):

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
       default-days: 7
     reviewers:
       - PawelLipski
+    commit-message:
+      prefix: ""
     target-branch: develop
     groups:
       deps:


### PR DESCRIPTION
## Summary
- Add an explicit empty `commit-message.prefix` to `.github/dependabot.yml` so Dependabot stops auto-detecting `build(deps):` from prior merges.
- Grouped pip update PRs on `develop` should now be titled like `Bump the deps group across N directories with M updates`.

## Test plan
- [ ] Merge and wait for the next Dependabot version-update PR on `develop` to confirm the title has no `build(deps):` prefix.