### PR TITLE
Fix stray underlines in help config/status output

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## New in git-machete 3.44.1
 
+- fixed: `git machete help config` (and `help status`) no longer renders stray underlines past the `machete.status.extraSpaceBeforeBranchName` section
+
 ## New in git-machete 3.44.0
 
 - added: `machete.github.{baseRemote,baseOrganization,baseRepository}` and `machete.gitlab.{baseRemote,baseNamespace,baseProject}` git config keys

--- a/docs/generate_py_docs.py
+++ b/docs/generate_py_docs.py
@@ -38,14 +38,22 @@ def rst2txt(rst: str) -> str:
             lne = indent + lne[1:]
         elif lne.startswith('* ') or lne.startswith('  '):
             lne = indent + lne
-        lne = re.sub('---', '—', lne)
-        lne = re.sub(':ref:`([^<`]+)(<[^>]+>)?`', r'`\1`', lne)
-        lne = re.sub('`(.*) <.*>`_', r'\1', lne)
-        lne = re.sub('``', '`', lne)
-        lne = re.sub(r'\*\*(.*)\*\*', r'<b>\1</b>', lne)
-        lne = re.sub(r' \*([^ ])', r' \1', lne)
-        lne = re.sub(r'([^ ])\*([ .])', r'\1\2', lne)
-        lne = re.sub(r':([a-z]+):`([^`]+)`', r'<\1>\2</\1>', lne)
+        # RST triple hyphen (em dash in prose)  ->  Unicode em dash.
+        lne = re.sub('---',                               '—',                  lne)              # noqa: E241
+        # Sphinx :ref:`name` or :ref:`name<target>`  ->  inline code `name`.
+        lne = re.sub(':ref:`([^<`]+)(<[^>]+>)?`',        r'`\1`',               lne)              # noqa: E241
+        # RST hyperlink `text <url>`_  ->  plain text (skip ``literal`` spans via lookbehind/lookahead).
+        lne = re.sub('(?<!`)`(?!`)(.*?) <[^>]+>`_',      r'\1',                 lne)              # noqa: E241
+        # RST double-backtick literal ``code``  ->  single-backtick inline code `code`.
+        lne = re.sub('``',                                '`',                  lne)              # noqa: E241
+        # RST **bold**  ->  <b>bold</b>.
+        lne = re.sub(r'\*\*(.*)\*\*',                   r'<b>\1</b>',           lne)              # noqa: E241
+        # RST italic marker (space before *)  ->  plain text without the asterisk.
+        lne = re.sub(r' \*([^ ])',                      r' \1',                 lne)              # noqa: E241
+        # RST italic marker (* before space or dot)  ->  plain text without the asterisk.
+        lne = re.sub(r'([^ ])\*([ .])',                 r'\1\2',                lne)              # noqa: E241
+        # Sphinx :role:`text`  ->  <role>text</role>.
+        lne = re.sub(r':([a-z]+):`([^`]+)`',            r'<\1>\2</\1>',         lne)              # noqa: E241
         return lne
 
     def is_section_header(lne: str) -> bool:

--- a/git_machete/generated_docs.py
+++ b/git_machete/generated_docs.py
@@ -402,7 +402,7 @@ long_docs: Dict[str, str] = {
               * whether `traverse` suggests to slide out the branch.
 
            `machete.status.extraSpaceBeforeBranchName`
-              To make it easier to select branch name from the `status` output on certain terminals (like `Alacritty),
+              To make it easier to select branch name from the `status` output on certain terminals (like Alacritty),
               you can add an extra space between └─ and branch name by setting `git config machete.status.extraSpaceBeforeBranchName true`.
 
               For example, by default the status is displayed as:
@@ -1552,7 +1552,7 @@ long_docs: Dict[str, str] = {
           |
           m-<branch4>     # gray (merged to parent)
         </dim>
-        To make it easier to select branch name from the `status` output on certain terminals (like `Alacritty),
+        To make it easier to select branch name from the `status` output on certain terminals (like Alacritty),
         you can add an extra space between └─ and branch name by setting `git config machete.status.extraSpaceBeforeBranchName true`.
 
         For example, by default the status is displayed as:
@@ -1612,7 +1612,7 @@ long_docs: Dict[str, str] = {
               * whether `traverse` suggests to slide out the branch.
 
            `machete.status.extraSpaceBeforeBranchName`
-              To make it easier to select branch name from the `status` output on certain terminals (like `Alacritty),
+              To make it easier to select branch name from the `status` output on certain terminals (like Alacritty),
               you can add an extra space between └─ and branch name by setting `git config machete.status.extraSpaceBeforeBranchName true`.
    """,
     "traverse": """


### PR DESCRIPTION
A greedy RST-hyperlink conversion in docs/generate_py_docs.py left an unclosed backtick when a hyperlink shared a line with an inline code span, which made _fmt underline everything after it in help config and help status.