### PR TITLE
Fix advance green-edge detection when parent is behind remote

### DIFF
--- a/git_machete/client/advance.py
+++ b/git_machete/client/advance.py
@@ -16,14 +16,13 @@ class AdvanceMacheteClient(MacheteClient):
             raise MacheteException(
                 f"<b>{branch}</b> does not have any downstream (child) branches to advance towards")
 
-        def connected_with_green_edge(child: LocalBranchShortName) -> bool:
-            return bool(
-                not self._is_merged_to_parent(child, opt_squash_merge_detection=SquashMergeDetection.NONE) and
-                self._git.is_ancestor_or_equal(branch.full_name(), child.full_name()) and
-                (self._get_overridden_fork_point(child) or
-                 self._git.get_commit_hash_by_revision(branch) == self.fork_point(child, use_overrides=False)))
-
-        candidate_children = list(filter(connected_with_green_edge, children))
+        candidate_children = [
+            child for child in children
+            if self.is_connected_with_green_edge(
+                parent=branch,
+                child=child,
+                opt_squash_merge_detection=SquashMergeDetection.NONE)
+        ]
         if not candidate_children:
             raise MacheteException(
                 f"No downstream (child) branch of <b>{branch}</b> is connected to "

--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -350,6 +350,47 @@ class MacheteClient:
         except MacheteException:
             return None
 
+    def _is_fork_point_inferred_by_parent_remote_counterpart(
+            self,
+            *,
+            parent_branch: LocalBranchShortName,
+            inferring_branches: List[BranchPair]) -> bool:
+        # Suppresses the spurious yellow edge that appears when the parent branch is merely behind its remote counterpart
+        # and the child branch was forked from the remote tip.
+        # We only fire here for parents that have a remote counterpart at all (otherwise the "behind remote" situation cannot arise),
+        # and only if `parent_branch` appears among the inferring branches -
+        # either directly as `parent_remote`, or as the `local_branch` side of a `BranchPair(parent_branch, parent_branch)` entry
+        # produced when the inferred commit survives on `parent_branch`'s own filtered reflog after the push.
+        parent_remote = self._git.get_combined_counterpart_for_fetching_of_branch(parent_branch)
+        if parent_remote is None:
+            return False
+        return any(p.local_branch == parent_branch for p in inferring_branches)
+
+    def is_connected_with_green_edge(
+            self,
+            *,
+            parent: LocalBranchShortName,
+            child: LocalBranchShortName,
+            opt_squash_merge_detection: SquashMergeDetection) -> bool:
+        if self.is_merged_to(
+                branch=child,
+                parent=parent,
+                opt_squash_merge_detection=opt_squash_merge_detection):
+            return False
+        if not self._git.is_ancestor_or_equal(parent.full_name(), child.full_name()):
+            return False
+        if self._get_overridden_fork_point(child):
+            return True
+        try:
+            fork_point, inferring_branches = self.fork_point_and_inferring_branch_pairs(child, use_overrides=True)
+        except MacheteException:
+            return False
+        if self._git.get_commit_hash_by_revision(parent) == fork_point:
+            return True
+        return self._is_fork_point_inferred_by_parent_remote_counterpart(
+            parent_branch=parent,
+            inferring_branches=inferring_branches)
+
     def check_that_fork_point_is_ancestor_or_equal_to_tip_of_branch(
             self, *, fork_point: AnyRevision, branch: AnyBranchName) -> None:
         if not self._git.is_ancestor_or_equal(

--- a/git_machete/client/status.py
+++ b/git_machete/client/status.py
@@ -251,22 +251,6 @@ class StatusMacheteClient(MacheteClient):
             )
         return f"{first_part}.\n\n{second_part}."
 
-    def _is_fork_point_inferred_by_parent_remote_counterpart(
-            self,
-            *,
-            parent_branch: LocalBranchShortName,
-            inferring_branches: List[BranchPair]) -> bool:
-        # Suppresses the spurious yellow edge that appears when the parent branch is merely behind its remote counterpart
-        # and the child branch was forked from the remote tip.
-        # We only fire here for parents that have a remote counterpart at all (otherwise the "behind remote" situation cannot arise),
-        # and only if `parent_branch` appears among the inferring branches -
-        # either directly as `parent_remote`, or as the `local_branch` side of a `BranchPair(parent_branch, parent_branch)` entry
-        # produced when the inferred commit survives on `parent_branch`'s own filtered reflog after the push.
-        parent_remote = self._git.get_combined_counterpart_for_fetching_of_branch(parent_branch)
-        if parent_remote is None:
-            return False
-        return any(p.local_branch == parent_branch for p in inferring_branches)
-
     def compute_status_data(self, *, flags: StatusFlags) -> StatusData:
         managed_branches: List[ManagedBranchName] = self._state.managed_branches  # already returns a copy
 
@@ -294,25 +278,13 @@ class StatusMacheteClient(MacheteClient):
                 sync_to_parent_status[branch] = SyncToParentStatus.MERGED_TO_PARENT
             elif not self._git.is_ancestor_or_equal(parent_branch.full_name(), branch.full_name()):
                 sync_to_parent_status[branch] = SyncToParentStatus.OUT_OF_SYNC
-            elif self._get_overridden_fork_point(branch):
+            elif self.is_connected_with_green_edge(
+                    parent=parent_branch,
+                    child=branch,
+                    opt_squash_merge_detection=flags.opt_squash_merge_detection):
                 sync_to_parent_status[branch] = SyncToParentStatus.IN_SYNC
             else:
-                fp = fork_point_hash(branch)
-                # `fork_point_hash` only returns None when `fork_point_and_inferring_branch_pairs` raises
-                # `MacheteException`, which in turn requires reflog inference to fail AND one of:
-                # parent is missing, parent commit is unresolvable, or parent is not an ancestor of branch
-                # with no common merge-base (unrelated histories). All of these are ruled out by reaching
-                # this branch: parent exists (the early `continue` above) and parent is an ancestor of branch
-                # (the preceding `elif` would have classified it as OUT_OF_SYNC otherwise).
-                assert fp is not None
-                if self._git.get_commit_hash_by_revision(parent_branch) == fp:
-                    sync_to_parent_status[branch] = SyncToParentStatus.IN_SYNC
-                elif self._is_fork_point_inferred_by_parent_remote_counterpart(
-                        parent_branch=parent_branch,
-                        inferring_branches=fork_point_branches_cached[branch]):
-                    sync_to_parent_status[branch] = SyncToParentStatus.IN_SYNC
-                else:
-                    sync_to_parent_status[branch] = SyncToParentStatus.IN_SYNC_BUT_FORK_POINT_OFF
+                sync_to_parent_status[branch] = SyncToParentStatus.IN_SYNC_BUT_FORK_POINT_OFF
 
         currently_bisected_branch = self._git.get_currently_bisected_branch_or_none()
         currently_rebased_branch = self._git.get_currently_rebased_branch_or_none()

--- a/tests/test_advance.py
+++ b/tests/test_advance.py
@@ -10,7 +10,7 @@ from tests.cli_runner import (assert_failure, assert_success, launch_command, la
                               rewrite_branch_layout_file)
 from tests.git_repository import (check_out, commit, create_repo, create_repo_with_remote, fetch, get_commit_hash, get_current_commit_hash,
                                   new_branch, push, reset_to, wait_to_bump_commit_timestamp)
-from tests.mockers import mock_input_returning, mock_input_returning_y
+from tests.mockers import fixed_author_and_committer_date_in_past, mock_input_returning, mock_input_returning_y
 
 
 class TestAdvance(BaseTest):
@@ -47,6 +47,64 @@ class TestAdvance(BaseTest):
         rewrite_branch_layout_file("master\n  develop")
 
         assert_failure(["advance"], "No downstream (child) branch of master is connected to master with a green edge")
+
+    def test_advance_when_parent_behind_remote_and_child_forked_from_remote(self) -> None:
+        # Reproduces a common false-positive yellow edge fixed in status 3.41.0: the parent branch is just
+        # behind its remote counterpart, but the child branch was forked from the remote tip.
+        # Advance must treat such a child as connected with a green edge, same as status does.
+        with fixed_author_and_committer_date_in_past():
+            create_repo_with_remote()
+            new_branch("master")
+            commit("master commit 1")
+            push()
+            commit("master commit 2")
+            push()
+            new_branch("develop")
+            commit("develop commit")
+            check_out("master")
+            reset_to("HEAD~")  # master is now behind origin/master
+
+        rewrite_branch_layout_file(
+            """
+            master
+                develop
+            """
+        )
+
+        check_out("master")
+        launch_command("advance", "-y")
+
+        assert get_commit_hash("master") == get_commit_hash("develop")
+        assert "develop" not in launch_command("status")
+
+    def test_advance_when_parent_behind_remote_and_multiple_green_edge_children(self) -> None:
+        with fixed_author_and_committer_date_in_past():
+            create_repo_with_remote()
+            new_branch("master")
+            commit("master commit 1")
+            push()
+            commit("master commit 2")
+            push()
+            new_branch("develop-from-remote")
+            commit("develop-from-remote commit")
+            check_out("master")
+            reset_to("HEAD~")  # master is now behind origin/master
+            new_branch("develop-from-local")
+            commit("develop-from-local commit")
+            check_out("master")
+
+        rewrite_branch_layout_file(
+            """
+            master
+                develop-from-remote
+                develop-from-local
+            """
+        )
+
+        assert_failure(
+            ["advance", "-y"],
+            "More than one downstream (child) branch of master "
+            "is connected to master with a green edge and -y/--yes option is specified")
 
     def test_advance_with_immediate_cancel(self, mocker: MockerFixture) -> None:
         create_repo()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,10 +1,13 @@
+from pytest_mock import MockerFixture
+
 from git_machete.annotation import Annotation
 from git_machete.client.base import MacheteClient
 from git_machete.config import SquashMergeDetection
 from git_machete.git import LocalBranchShortName
+from git_machete.utils.exceptions import MacheteException
 from tests.base_test import BaseTest
 from tests.cli_runner import launch_command, read_branch_layout_file, rewrite_branch_layout_file
-from tests.git_repository import (check_out, commit, create_repo, create_repo_with_remote, get_current_commit_hash, new_branch, push,
+from tests.git_repository import (check_out, commit, create_repo, create_repo_with_remote, get_current_commit_hash, merge, new_branch, push,
                                   reset_to)
 from tests.mockers import fixed_author_and_committer_date_in_past
 
@@ -217,6 +220,53 @@ class TestClient(BaseTest):
         )
 
         machete_client = MacheteClient()
+        assert not machete_client.is_connected_with_green_edge(
+            parent=LocalBranchShortName.of("master"),
+            child=LocalBranchShortName.of("develop"),
+            opt_squash_merge_detection=SquashMergeDetection.NONE)
+
+    def test_is_connected_with_green_edge_false_when_child_merged_to_parent(self) -> None:
+        create_repo()
+        new_branch("master")
+        commit("master commit")
+        new_branch("feature")
+        commit("feature commit")
+        check_out("master")
+        merge("feature")
+
+        rewrite_branch_layout_file(
+            """
+            master
+                feature
+            """
+        )
+
+        machete_client = MacheteClient()
+        assert not machete_client.is_connected_with_green_edge(
+            parent=LocalBranchShortName.of("master"),
+            child=LocalBranchShortName.of("feature"),
+            opt_squash_merge_detection=SquashMergeDetection.NONE)
+
+    def test_is_connected_with_green_edge_false_when_fork_point_cannot_be_determined(self, mocker: MockerFixture) -> None:
+        create_repo()
+        new_branch("master")
+        commit("master commit")
+        new_branch("develop")
+        commit("develop commit")
+        check_out("master")
+
+        rewrite_branch_layout_file(
+            """
+            master
+                develop
+            """
+        )
+
+        machete_client = MacheteClient()
+        mocker.patch.object(
+            machete_client,
+            "fork_point_and_inferring_branch_pairs",
+            side_effect=MacheteException("Fork point not found for branch <b>develop</b>"))
         assert not machete_client.is_connected_with_green_edge(
             parent=LocalBranchShortName.of("master"),
             child=LocalBranchShortName.of("develop"),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,9 +1,12 @@
 from git_machete.annotation import Annotation
 from git_machete.client.base import MacheteClient
+from git_machete.config import SquashMergeDetection
 from git_machete.git import LocalBranchShortName
 from tests.base_test import BaseTest
-from tests.cli_runner import read_branch_layout_file, rewrite_branch_layout_file
-from tests.git_repository import check_out, commit, create_repo_with_remote, new_branch, push
+from tests.cli_runner import launch_command, read_branch_layout_file, rewrite_branch_layout_file
+from tests.git_repository import (check_out, commit, create_repo, create_repo_with_remote, get_current_commit_hash, new_branch, push,
+                                  reset_to)
+from tests.mockers import fixed_author_and_committer_date_in_past
 
 
 class TestClient(BaseTest):
@@ -170,3 +173,51 @@ class TestClient(BaseTest):
 
         assert '#' not in read_branch_layout_file()
         assert read_branch_layout_file() == "master\n"
+
+    def test_is_connected_with_green_edge_when_child_has_overridden_fork_point(self) -> None:
+        create_repo()
+        new_branch("master")
+        commit("master commit 1")
+        fork_point_hash = get_current_commit_hash()
+        commit("master commit 2")
+        new_branch("develop")
+        commit("develop commit")
+        check_out("master")
+
+        rewrite_branch_layout_file(
+            """
+            master
+                develop
+            """
+        )
+        launch_command("fork-point", "develop", "--override-to", fork_point_hash)
+
+        machete_client = MacheteClient()
+        assert machete_client.is_connected_with_green_edge(
+            parent=LocalBranchShortName.of("master"),
+            child=LocalBranchShortName.of("develop"),
+            opt_squash_merge_detection=SquashMergeDetection.NONE)
+
+    def test_is_connected_with_green_edge_not_inferred_by_parent_without_remote(self) -> None:
+        with fixed_author_and_committer_date_in_past():
+            create_repo()
+            new_branch("master")
+            commit("master commit 1")
+            commit("master commit 2")
+            new_branch("develop")
+            commit("develop commit")
+            check_out("master")
+            reset_to("HEAD~")
+
+        rewrite_branch_layout_file(
+            """
+            master
+                develop
+            """
+        )
+
+        machete_client = MacheteClient()
+        assert not machete_client.is_connected_with_green_edge(
+            parent=LocalBranchShortName.of("master"),
+            child=LocalBranchShortName.of("develop"),
+            opt_squash_merge_detection=SquashMergeDetection.NONE)


### PR DESCRIPTION
<!-- start git-machete generated -->

## Tree of downstream PRs as of 2026-07-21

* **PR #1751 (THIS ONE)**:
  `develop` ← `fix/green-edge-advance`

    * PR #1753:
      `fix/green-edge-advance` ← `fix/green-edge-traverse`

<!-- end git-machete generated -->

## Summary
- Extract shared `is_connected_with_green_edge()` on `MacheteClient` so `advance` and `status` use the same green-edge criteria.
- Fixes a leftover from 3.41.0: when the parent branch is behind its remote counterpart and a child was forked from the remote tip, `status` already renders a green edge but `advance` only considered children whose fork point equals the parent's local tip.
- Add regression tests for the parent-behind-remote scenario (single and multiple green-edge children).

## Test plan
- [x] `tox -e py -- tests/test_advance.py`
- [x] `tox -e py -- tests/test_advance.py tests/test_status.py -k "advance_when_parent_behind_remote or no_yellow_edge_when_parent_behind_remote"`
- [x] `tox -e mypy`
- [x] Verified manually in `rules_scala`: `advance -y` on `master` now sees both green-edge children (ambiguous advance) instead of only the one whose fork point equals local `master`.