### PR TITLE
Fix traverse parent-sync detection for parent-behind-remote green edges

### DIFF
--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -27,6 +27,13 @@ class PickRoot(Enum):
     LAST = auto()
 
 
+class SyncToParentStatus(Enum):
+    IN_SYNC = auto()
+    IN_SYNC_BUT_FORK_POINT_OFF = auto()
+    OUT_OF_SYNC = auto()
+    MERGED_TO_PARENT = auto()
+
+
 class MacheteClient:
 
     # === Initialization ===
@@ -390,6 +397,26 @@ class MacheteClient:
         return self._is_fork_point_inferred_by_parent_remote_counterpart(
             parent_branch=parent,
             inferring_branches=inferring_branches)
+
+    def sync_to_parent_status(
+            self,
+            *,
+            branch: LocalBranchShortName,
+            parent: LocalBranchShortName,
+            opt_squash_merge_detection: SquashMergeDetection) -> SyncToParentStatus:
+        if self.is_merged_to(
+                branch=branch,
+                parent=parent,
+                opt_squash_merge_detection=opt_squash_merge_detection):
+            return SyncToParentStatus.MERGED_TO_PARENT
+        if not self._git.is_ancestor_or_equal(parent.full_name(), branch.full_name()):
+            return SyncToParentStatus.OUT_OF_SYNC
+        if self.is_connected_with_green_edge(
+                parent=parent,
+                child=branch,
+                opt_squash_merge_detection=opt_squash_merge_detection):
+            return SyncToParentStatus.IN_SYNC
+        return SyncToParentStatus.IN_SYNC_BUT_FORK_POINT_OFF
 
     def check_that_fork_point_is_ancestor_or_equal_to_tip_of_branch(
             self, *, fork_point: AnyRevision, branch: AnyBranchName) -> None:

--- a/git_machete/client/status.py
+++ b/git_machete/client/status.py
@@ -3,11 +3,10 @@
 import io
 import os
 import sys
-from enum import Enum, auto
 from typing import Dict, List, NamedTuple, Optional, Tuple
 
 from git_machete.annotation import Annotation
-from git_machete.client.base import MacheteClient
+from git_machete.client.base import MacheteClient, SyncToParentStatus
 from git_machete.client.state import ManagedBranchName
 from git_machete.config import SquashMergeDetection
 from git_machete.git import BranchPair, FullCommitHash, GitLogEntry, LocalBranchShortName, SyncToRemoteStatus
@@ -18,13 +17,6 @@ from git_machete.utils.debug_log import debug
 from git_machete.utils.exceptions import MacheteException
 from git_machete.utils.markup import escape_markup, print_fmt, warn
 from git_machete.utils.paths import Path, strip_longest_common_path_prefix
-
-
-class SyncToParentStatus(Enum):
-    IN_SYNC = auto()
-    IN_SYNC_BUT_FORK_POINT_OFF = auto()
-    OUT_OF_SYNC = auto()
-    MERGED_TO_PARENT = auto()
 
 
 class StatusFlags(NamedTuple):
@@ -271,20 +263,10 @@ class StatusMacheteClient(MacheteClient):
             parent_branch = self._state.get_parent(branch)
             if parent_branch is None:
                 continue
-            if self.is_merged_to(
-                    branch=branch,
-                    parent=parent_branch,
-                    opt_squash_merge_detection=flags.opt_squash_merge_detection):
-                sync_to_parent_status[branch] = SyncToParentStatus.MERGED_TO_PARENT
-            elif not self._git.is_ancestor_or_equal(parent_branch.full_name(), branch.full_name()):
-                sync_to_parent_status[branch] = SyncToParentStatus.OUT_OF_SYNC
-            elif self.is_connected_with_green_edge(
-                    parent=parent_branch,
-                    child=branch,
-                    opt_squash_merge_detection=flags.opt_squash_merge_detection):
-                sync_to_parent_status[branch] = SyncToParentStatus.IN_SYNC
-            else:
-                sync_to_parent_status[branch] = SyncToParentStatus.IN_SYNC_BUT_FORK_POINT_OFF
+            sync_to_parent_status[branch] = self.sync_to_parent_status(
+                branch=branch,
+                parent=parent_branch,
+                opt_squash_merge_detection=flags.opt_squash_merge_detection)
 
         currently_bisected_branch = self._git.get_currently_bisected_branch_or_none()
         currently_rebased_branch = self._git.get_currently_rebased_branch_or_none()

--- a/git_machete/client/traverse.py
+++ b/git_machete/client/traverse.py
@@ -4,7 +4,7 @@ from enum import auto
 from typing import Callable, List, Optional, Type, Union
 
 from git_machete.annotation import Annotation, Qualifiers
-from git_machete.client.base import PickRoot
+from git_machete.client.base import PickRoot, SyncToParentStatus
 from git_machete.client.with_code_hosting import MacheteClientWithCodeHosting
 from git_machete.code_hosting import CodeHostingSpec, PullRequest
 from git_machete.config import SquashMergeDetection, TraverseWhenBranchNotCheckedOutInAnyWorktree
@@ -277,14 +277,20 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
                     skipping_parent_sync = bool(parent)
                 elif use_merge:
                     needs_parent_sync = bool(
-                        parent and not self._git.is_ancestor_or_equal(parent.full_name(), branch.full_name()))
+                        parent and
+                        self.sync_to_parent_status(
+                            branch=branch,
+                            parent=parent,
+                            opt_squash_merge_detection=opt_squash_merge_detection) == SyncToParentStatus.OUT_OF_SYNC)
                 else:  # using rebase
                     needs_parent_sync = bool(
                         parent and
-                        not (self._git.is_ancestor_or_equal(parent.full_name(), branch.full_name()) and
-                             (self._git.get_commit_hash_by_revision(parent) ==
-                              self.fork_point(branch, use_overrides=True)))
-                    )
+                        self.sync_to_parent_status(
+                            branch=branch,
+                            parent=parent,
+                            opt_squash_merge_detection=opt_squash_merge_detection) in (
+                            SyncToParentStatus.OUT_OF_SYNC,
+                            SyncToParentStatus.IN_SYNC_BUT_FORK_POINT_OFF))
                     if needs_parent_sync and branch_anno is not None:
                         needs_parent_sync = branch_anno.qualifiers.rebase
 

--- a/tests/test_traverse.py
+++ b/tests/test_traverse.py
@@ -2142,6 +2142,41 @@ class TestTraverse(BaseTest):
             """)
         )
 
+    def test_traverse_no_parent_sync_when_parent_behind_remote_and_child_forked_from_remote(self) -> None:
+        # Reproduces the parent-behind-remote green-edge case fixed in status 3.41.0: traverse must not
+        # offer to rebase a child that status already renders with a green edge onto its parent.
+        with fixed_author_and_committer_date_in_past():
+            create_repo_with_remote()
+            new_branch("master")
+            commit("master commit 1")
+            push()
+            commit("master commit 2")
+            push()
+            new_branch("develop")
+            commit("develop commit")
+            check_out("master")
+            reset_to("HEAD~")  # master is now behind origin/master
+            check_out("develop")
+
+        rewrite_branch_layout_file(
+            """
+            master
+                develop
+            """
+        )
+
+        assert_success(
+            ["traverse", "-y", "--no-push-untracked"],
+            """
+
+              master (behind origin)
+              |
+              o-develop * (untracked)
+
+            Reached branch develop which has no successor; nothing left to update
+            """,
+        )
+
     # The expected error message includes `--empty=drop` which is only passed on git >= 2.26.0.
     @pytest.mark.skipif(get_git_version() < REBASE_EMPTY_DROP, reason="--empty=drop is only passed to git rebase since git 2.26.0")
     def test_traverse_rebase_conflict(self) -> None:


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1751

## Chain of upstream PRs as of 2026-07-21

* PR #1751:
  `develop` ← `fix/green-edge-advance`

  * **PR #1753 (THIS ONE)**:
    `fix/green-edge-advance` ← `fix/green-edge-traverse`

<!-- end git-machete generated -->

## Summary
- Extract shared `SyncToParentStatus` and `sync_to_parent_status()` on `MacheteClient`, used by both `status` and `traverse`.
- Fix the same parent-behind-remote green-edge gap that `advance` had: `traverse` no longer offers to rebase a child that `status` already renders with a green edge.
- Add regression test `test_traverse_no_parent_sync_when_parent_behind_remote_and_child_forked_from_remote`.

Stacked on #1751.

## Test plan
- [x] `tox -e py -- tests/test_traverse.py::TestTraverse::test_traverse_no_parent_sync_when_parent_behind_remote_and_child_forked_from_remote` (fails before fix with unwanted `Rebasing develop onto master...`)
- [x] `tox -e py -- tests/test_traverse.py -k "traverse_yellow_edges or traverse_behind_remote or traverse_no_parent_sync"`
- [x] `tox -e py -- tests/test_status.py -k no_yellow_edge`
- [x] `tox -e mypy`