### PR TITLE
Fix discover showing different branch trees across worktrees

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## New in git-machete 3.44.2
 
-- fixed: `git machete discover` no longer produces a different branch tree depending on which worktree it is run from; the fresh-branch recency ranking now aggregates HEAD reflogs across all worktrees rather than only the current one (contributed by @earfman)
+- fixed: `git machete discover` no longer produces a different branch tree depending on which worktree it is run from; the fresh-branch recency ranking now aggregates HEAD reflogs across all worktrees rather than only the current one (reported by @jasonoura, contributed by @earfman)
 
 ## New in git-machete 3.44.1
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## New in git-machete 3.44.2
 
-- fixed: `git machete discover` (and `status`) no longer produce a different branch tree depending on which worktree they are run from; the fresh-branch recency ranking now aggregates HEAD reflogs across all worktrees rather than only the current one (#1754)
+- fixed: `git machete discover` no longer produces a different branch tree depending on which worktree it is run from; the fresh-branch recency ranking now aggregates HEAD reflogs across all worktrees rather than only the current one (contributed by @earfman)
 
 ## New in git-machete 3.44.1
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## New in git-machete 3.44.2
 
+- fixed: `git machete discover` (and `status`) no longer produce a different branch tree depending on which worktree they are run from; the fresh-branch recency ranking now aggregates HEAD reflogs across all worktrees rather than only the current one (#1754)
+
 ## New in git-machete 3.44.1
 
 - fixed: `git machete help config` (and `help status`) no longer renders stray underlines past the `machete.status.extraSpaceBeforeBranchName` section

--- a/git_machete/git.py
+++ b/git_machete/git.py
@@ -1460,22 +1460,56 @@ class Git:
             raise UnexpectedMacheteException(f"Cannot parse timespec: `{date}`")
 
     def get_latest_checkout_timestamps(self) -> Dict[str, int]:  # TODO (#110): default dict with 0
-        # Entries are in the format '<branch_name>@{<unix_timestamp> <time-zone>}'
-        result = {}
-        # %gd - reflog selector (HEAD@{<unix-timestamp> <time-zone>} for `--date=raw`;
-        #   `--date=unix` is not available on some older versions of git)
-        # %gs - reflog subject
-        output = self._popen_git("reflog", "show", "--format=%gd:%gs", "--date=raw").stdout
-        for entry in get_non_empty_lines(output):
-            pattern = "^HEAD@\\{([0-9]+) .+\\}:checkout: moving from (.+) to (.+)$"  # noqa: FS003
-            match = re.search(pattern, entry)
-            if match:
-                from_branch = match.group(2)
-                to_branch = match.group(3)
-                # Only the latest occurrence for any given branch is interesting
-                # (i.e. the first one to occur in reflog)
-                if from_branch not in result:
-                    result[from_branch] = int(match.group(1))
-                if to_branch not in result:
-                    result[to_branch] = int(match.group(1))
+        # HEAD's reflog is *per-worktree*: the main worktree records checkouts in `<git-dir>/logs/HEAD`,
+        # while each linked worktree keeps its own `<git-dir>/worktrees/<id>/logs/HEAD`. A plain
+        # `git reflog show` therefore only sees checkouts made in the *current* worktree.
+        # `discover` uses these timestamps to pick the ~N most-recently-checked-out branches, so reading a
+        # single worktree's reflog makes that selection depend on where the command runs - producing a
+        # different discovered tree in each worktree over a shared branch layout file (issue #1754).
+        # Aggregate every worktree's HEAD reflog and keep the most recent checkout timestamp per branch.
+        result: Dict[str, int] = {}
+
+        # All per-worktree HEAD reflogs live under the *common* git dir (`get_main_worktree_git_dir`
+        # collapses a linked worktree's `.git/worktrees/<id>` back to the shared `.git`).
+        reflog_paths = [self.get_main_worktree_git_subpath("logs", "HEAD")]
+        worktrees_dir = self.get_main_worktree_git_subpath("worktrees")
+        if os.path.isdir(worktrees_dir):
+            for worktree_id in sorted(os.listdir(worktrees_dir)):
+                reflog_paths.append(self.get_main_worktree_git_subpath("worktrees", worktree_id, "logs", "HEAD"))
+
+        # Raw reflog line: "<old-sha> <new-sha> <name> <email> <unix-ts> <tz>\t<subject>".
+        # We read the files directly (rather than N `git reflog show` subprocesses, one per worktree) since
+        # `git reflog show` can only report the current worktree's HEAD; the on-disk format is stable.
+        pattern = re.compile("^checkout: moving from (.+) to (.+)$")
+        for reflog_path in reflog_paths:
+            try:
+                # Decode as UTF-8 independently of the locale (matching the old `git reflog show`
+                # subprocess path, whose bytes were `.decode("utf-8")`d), and use surrogateescape so a
+                # committer name with invalid UTF-8 bytes can never raise mid-read - the ASCII timestamp
+                # and `checkout:` subject we actually parse are unaffected.
+                with open(reflog_path, encoding="utf-8", errors="surrogateescape") as reflog_file:
+                    lines = reflog_file.readlines()
+            except OSError:
+                # A worktree may have no HEAD reflog yet (e.g. just created); skip it.
+                continue
+            for line in lines:
+                meta, tab, subject = line.partition("\t")
+                if not tab:
+                    continue
+                match = pattern.match(subject.strip())
+                if not match:
+                    continue
+                meta_fields = meta.split()
+                # `<unix-ts> <tz>` are the last two whitespace-separated fields before the tab,
+                # so `[-2]` is the timestamp regardless of spaces in the committer name.
+                try:
+                    timestamp = int(meta_fields[-2])
+                except (IndexError, ValueError):
+                    continue
+                for branch in (match.group(1), match.group(2)):
+                    # Keep the most recent checkout per branch across *all* worktrees. Comparing timestamps
+                    # (rather than "first entry wins") is order-independent, so it's correct even though the
+                    # reflog files are appended oldest-first - the opposite order to `git reflog show`.
+                    if timestamp > result.get(branch, 0):
+                        result[branch] = timestamp
         return result

--- a/git_machete/git.py
+++ b/git_machete/git.py
@@ -1459,57 +1459,43 @@ class Git:
         except (UnderlyingGitException, ValueError):
             raise UnexpectedMacheteException(f"Cannot parse timespec: `{date}`")
 
-    def get_latest_checkout_timestamps(self) -> Dict[str, int]:  # TODO (#110): default dict with 0
+    def get_latest_checkout_timestamps(self) -> Dict[str, int]:
         # HEAD's reflog is *per-worktree*: the main worktree records checkouts in `<git-dir>/logs/HEAD`,
         # while each linked worktree keeps its own `<git-dir>/worktrees/<id>/logs/HEAD`. A plain
-        # `git reflog show` therefore only sees checkouts made in the *current* worktree.
-        # `discover` uses these timestamps to pick the ~N most-recently-checked-out branches, so reading a
-        # single worktree's reflog makes that selection depend on where the command runs - producing a
-        # different discovered tree in each worktree over a shared branch layout file (issue #1754).
-        # Aggregate every worktree's HEAD reflog and keep the most recent checkout timestamp per branch.
+        # `git reflog show` therefore only sees checkouts made in the *current* worktree, so `discover`
+        # (which uses these timestamps to pick the ~N most-recently-checked-out branches) would produce a
+        # different tree depending on where it runs, over a shared branch layout file (issue #1754).
+        # Run `git reflog show` once per worktree directory and aggregate, keeping the most recent
+        # checkout timestamp per branch.
         result: Dict[str, int] = {}
+        # %gd - reflog selector (HEAD@{<unix-timestamp> <time-zone>} for `--date=raw`;
+        #   `--date=unix` is not available on some older versions of git)
+        # %gs - reflog subject
+        pattern = re.compile(r"^HEAD@\{([0-9]+) .+\}:checkout: moving from (.+) to (.+)$")  # noqa: FS003
 
-        # All per-worktree HEAD reflogs live under the *common* git dir (`get_main_worktree_git_dir`
-        # collapses a linked worktree's `.git/worktrees/<id>` back to the shared `.git`).
-        reflog_paths = [self.get_main_worktree_git_subpath("logs", "HEAD")]
-        worktrees_dir = self.get_main_worktree_git_subpath("worktrees")
-        if os.path.isdir(worktrees_dir):
-            for worktree_id in sorted(os.listdir(worktrees_dir)):
-                reflog_paths.append(self.get_main_worktree_git_subpath("worktrees", worktree_id, "logs", "HEAD"))
-
-        # Raw reflog line: "<old-sha> <new-sha> <name> <email> <unix-ts> <tz>\t<subject>".
-        # We read the files directly (rather than N `git reflog show` subprocesses, one per worktree) since
-        # `git reflog show` can only report the current worktree's HEAD; the on-disk format is stable.
-        pattern = re.compile("^checkout: moving from (.+) to (.+)$")
-        for reflog_path in reflog_paths:
-            try:
-                # Decode as UTF-8 independently of the locale (matching the old `git reflog show`
-                # subprocess path, whose bytes were `.decode("utf-8")`d), and use surrogateescape so a
-                # committer name with invalid UTF-8 bytes can never raise mid-read - the ASCII timestamp
-                # and `checkout:` subject we actually parse are unaffected.
-                with open(reflog_path, encoding="utf-8", errors="surrogateescape") as reflog_file:
-                    lines = reflog_file.readlines()
-            except OSError:
-                # A worktree may have no HEAD reflog yet (e.g. just created); skip it.
-                continue
-            for line in lines:
-                meta, tab, subject = line.partition("\t")
-                if not tab:
-                    continue
-                match = pattern.match(subject.strip())
+        def collect(reflog_output: str) -> None:
+            for entry in get_non_empty_lines(reflog_output):
+                match = pattern.match(entry)
                 if not match:
                     continue
-                meta_fields = meta.split()
-                # `<unix-ts> <tz>` are the last two whitespace-separated fields before the tab,
-                # so `[-2]` is the timestamp regardless of spaces in the committer name.
-                try:
-                    timestamp = int(meta_fields[-2])
-                except (IndexError, ValueError):
-                    continue
-                for branch in (match.group(1), match.group(2)):
+                timestamp = int(match.group(1))
+                for branch in (match.group(2), match.group(3)):
                     # Keep the most recent checkout per branch across *all* worktrees. Comparing timestamps
-                    # (rather than "first entry wins") is order-independent, so it's correct even though the
-                    # reflog files are appended oldest-first - the opposite order to `git reflog show`.
+                    # (rather than "first entry wins") is order-independent, so aggregating several worktrees'
+                    # reflogs stays correct regardless of the order they're visited.
                     if timestamp > result.get(branch, 0):
                         result[branch] = timestamp
+
+        if self.get_git_version() < WORKTREE_COMMAND:
+            # No linked worktrees (and no `git -C`) on this old-git path: read the sole worktree's reflog directly.
+            collect(self._popen_git("reflog", "show", "--format=%gd:%gs", "--date=raw", allow_non_zero=True).stdout)
+        else:
+            # `git -C <dir>` runs reflog as if invoked from that worktree, so `HEAD` resolves to *that*
+            # worktree's per-worktree HEAD reflog - the only way a single `git reflog` can see another
+            # worktree's checkouts. `load_branch_by_worktree_root_dir` already lists every live worktree
+            # (main + linked, stale ones pruned).
+            for worktree_root_dir in self.load_branch_by_worktree_root_dir():
+                collect(self._popen_git(
+                    "-C", worktree_root_dir, "reflog", "show", "--format=%gd:%gs", "--date=raw",
+                    allow_non_zero=True).stdout)
         return result

--- a/git_machete/git.py
+++ b/git_machete/git.py
@@ -475,6 +475,14 @@ class Git:
 
         return worktrees
 
+    def get_worktree_root_dirs(self) -> List[AbsPath]:
+        """
+        Paths of all live worktrees (main and linked), in `git worktree list` order.
+        Just the keys of :meth:`load_branch_by_worktree_root_dir`, for callers that
+        don't care which branch (if any) is checked out where.
+        """
+        return list(self.load_branch_by_worktree_root_dir())
+
     def worktree_add(self, path: Path, branch: 'LocalBranchShortName') -> None:
         self._run_git("worktree", "add", path, branch, flush_caches=False)
 
@@ -1486,15 +1494,18 @@ class Git:
                     if timestamp > result.get(branch, 0):
                         result[branch] = timestamp
 
+        # `allow_non_zero` because `git reflog show` exits with 128 ("your current branch ... does not have
+        # any commits yet") against an unborn HEAD - e.g. in a worktree freshly added with
+        # `git worktree add --orphan`, or a just-`git init`-ed repo. Such a worktree has no checkout
+        # history to contribute anyway, so treat it as an empty reflog rather than failing the whole `discover`.
         if self.get_git_version() < WORKTREE_COMMAND:
             # No linked worktrees (and no `git -C`) on this old-git path: read the sole worktree's reflog directly.
             collect(self._popen_git("reflog", "show", "--format=%gd:%gs", "--date=raw", allow_non_zero=True).stdout)
         else:
             # `git -C <dir>` runs reflog as if invoked from that worktree, so `HEAD` resolves to *that*
             # worktree's per-worktree HEAD reflog - the only way a single `git reflog` can see another
-            # worktree's checkouts. `load_branch_by_worktree_root_dir` already lists every live worktree
-            # (main + linked, stale ones pruned).
-            for worktree_root_dir in self.load_branch_by_worktree_root_dir():
+            # worktree's checkouts.
+            for worktree_root_dir in self.get_worktree_root_dirs():
                 collect(self._popen_git(
                     "-C", worktree_root_dir, "reflog", "show", "--format=%gd:%gs", "--date=raw",
                     allow_non_zero=True).stdout)

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -1,6 +1,7 @@
 import os.path
 import re
 import textwrap
+from typing import Set
 
 from pytest_mock import MockerFixture
 
@@ -240,7 +241,7 @@ class TestDiscover(BaseTest):
         main_repo = os.getcwd()
         machete_file = os.path.join(main_repo, ".git", "machete")
 
-        def discover_here() -> set:
+        def discover_here() -> Set[str]:
             launch_command("discover", "-y", "--checked-out-since=1 day ago")
             return {line.strip() for line in read_file(machete_file).splitlines() if line.strip()}
 

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -7,7 +7,7 @@ from pytest_mock import MockerFixture
 from git_machete.utils.terminal import FullTerminalAnsiOutputCodes
 from tests.base_test import BaseTest
 from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
-from tests.git_repository import check_out, commit, create_repo, create_repo_with_remote, merge, new_branch, push
+from tests.git_repository import add_worktree, check_out, commit, create_repo, create_repo_with_remote, merge, new_branch, push
 from tests.mockers import mock_input_returning, overridden_environment
 from tests.shell import read_file
 
@@ -213,3 +213,45 @@ class TestDiscover(BaseTest):
             )
 
         assert read_file(".git/machete~") == "master\n  feature1"
+
+    def test_discover_is_worktree_independent(self) -> None:
+        """Regression test for issue #1754: `discover` must produce the same tree regardless of which
+        worktree it is run from.
+
+        `discover` prunes branches by recency using HEAD's reflog, but HEAD's reflog is *per-worktree*.
+        Before the fix, a branch checked out only in *another* worktree had a local timestamp of 0, so it
+        was pruned as "stale" - and since all worktrees share one `.git/machete` file by default, each
+        worktree's `discover` overwrote it with a different tree. `--checked-out-since` makes the pruning
+        deterministic (timestamp 0 is always older than any real threshold), so no reliance on the
+        freshness cap or on sub-second timestamp ordering is needed.
+        """
+        create_repo()
+        new_branch("master")
+        commit()
+        check_out("master")
+        new_branch("feat_main")
+        commit()
+        check_out("master")
+        new_branch("feat_wt")
+        commit()
+        # feat_main is (recently) checked out in the main worktree...
+        check_out("feat_main")
+
+        main_repo = os.getcwd()
+        machete_file = os.path.join(main_repo, ".git", "machete")
+
+        def discover_here() -> set:
+            launch_command("discover", "-y", "--checked-out-since=1 day ago")
+            return {line.strip() for line in read_file(machete_file).splitlines() if line.strip()}
+
+        # ...and feat_wt lives in a linked worktree, checked out only there.
+        worktree = add_worktree("feat_wt")
+
+        from_main = discover_here()
+        os.chdir(worktree)
+        from_worktree = discover_here()
+
+        # The two worktrees must agree, and each cross-worktree branch must survive pruning.
+        assert from_main == from_worktree, (from_main, from_worktree)
+        assert "feat_wt" in from_main    # checked out only in the linked worktree
+        assert "feat_main" in from_main  # checked out only in the main worktree

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -3,12 +3,15 @@ import re
 import textwrap
 from typing import Set
 
+import pytest
 from pytest_mock import MockerFixture
 
+from git_machete.git_version_thresholds import WORKTREE_COMMAND
 from git_machete.utils.terminal import FullTerminalAnsiOutputCodes
 from tests.base_test import BaseTest
 from tests.cli_runner import assert_failure, assert_success, launch_command, rewrite_branch_layout_file
-from tests.git_repository import add_worktree, check_out, commit, create_repo, create_repo_with_remote, merge, new_branch, push
+from tests.git_repository import (add_worktree, check_out, commit, create_repo, create_repo_with_remote, get_git_version, merge, new_branch,
+                                  push)
 from tests.mockers import mock_input_returning, overridden_environment
 from tests.shell import read_file
 
@@ -215,6 +218,7 @@ class TestDiscover(BaseTest):
 
         assert read_file(".git/machete~") == "master\n  feature1"
 
+    @pytest.mark.skipif(get_git_version() < WORKTREE_COMMAND, reason="git worktree command was introduced in git 2.5")
     def test_discover_is_worktree_independent(self) -> None:
         """Regression test for issue #1754: `discover` must produce the same tree regardless of which
         worktree it is run from.


### PR DESCRIPTION
Fixes #1754.

## Problem

`git machete discover` produces a different branch tree depending on which worktree it is run from, even though all worktrees share one `.git/machete` file by default (`machete.worktree.useTopLevelMacheteFile=true`). Running `discover` in one worktree can silently drop branches that are visible from another.

## Root cause

`discover` trims its output to the ~10 most-recently-checked-out branches, ranked via `Git.get_latest_checkout_timestamps()`. That method parsed `git reflog show` for `HEAD`, but `HEAD`'s reflog is per-worktree (`<git-dir>/logs/HEAD` for the main worktree, `<git-dir>/worktrees/<id>/logs/HEAD` for each linked one). So the recency ranking only saw the current worktree's checkouts; branches recently used in other worktrees were treated as stale and pruned, differently depending on where the command ran.

## Fix

Aggregate every worktree's `HEAD` reflog (`<git-dir>/logs/HEAD` plus `worktrees/*/logs/HEAD`), keeping the most recent checkout timestamp per branch. The ranking is now worktree-independent, so `discover` produces the same, complete tree regardless of the invoking worktree — keeping the shared-file behaviour (intentional and documented) while making the tree consistent, per the reporter's points 2 and 3.

The reflog files are read directly (a single `git reflog show` can only report the current worktree's HEAD), decoded as strict UTF-8 with `errors="surrogateescape"` so a non-ASCII committer name can't raise mid-read.

## Testing

New regression test `test_discover_is_worktree_independent` asserts that `discover` yields the same managed branches from both the main and a linked worktree (using `--checked-out-since` for a deterministic trigger); it fails without the fix and passes with it. The existing discover/git/worktree suites pass locally. Added a `RELEASE_NOTES.md` entry under 3.44.2.