### PR TITLE
Fix misleading `<this worktree>` label in traverse's status output

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@
 - fixed: `git machete discover` no longer produces a different branch tree depending on which worktree it is run from;
   the fresh-branch recency ranking now aggregates HEAD reflogs across all worktrees rather than only the current one (reported by @jasonoura, contributed by @earfman)
 - fixed: when run from a branch being slid out, `git machete slide-out` no longer checks out that branch's new parent if a child branch is going to be checked out right afterwards anyway for the rebase/merge
+- fixed: the statuses printed by `git machete traverse` no longer use the `[<this worktree>]` label, which pointed at whichever worktree `traverse` had most recently changed directory into rather than the one the user's shell is in;
+  each worktree is now named explicitly, with `traverse`'s own temporary worktree (see `machete.traverse.whenBranchNotCheckedOutInAnyWorktree`) labeled `[<temporary worktree>]`
 
 ## New in git-machete 3.44.1
 

--- a/git_machete/client/status.py
+++ b/git_machete/client/status.py
@@ -410,6 +410,12 @@ class StatusMacheteClient(MacheteClient):
                 print("", file=sys.stderr)
                 warn(warning_msg)
 
+    def _current_worktree_label(self) -> Optional[str]:
+        """The literal label for the worktree that the *process* is standing in, or `None` to have that
+        worktree named just like any other one. `<this worktree>` is only honest for commands that keep
+        running in the directory they were launched from - `traverse`, which `chdir`s mid-run, overrides this."""
+        return "<this worktree>"
+
     def _compute_worktree_label_by_branch(self) -> Dict[LocalBranchShortName, str]:
         """For each managed branch checked out in a worktree, derive a short label naming that worktree
         (rendered in `status` after the annotation).
@@ -418,18 +424,18 @@ class StatusMacheteClient(MacheteClient):
         fires, so users see one consistent piece of info per branch rather than guessing why some
         branches carry a label and others don't. Concretely:
 
-        * branch in the current worktree (whether main or linked) -> the literal `<this worktree>` -
-          self-explanatory so users encountering the label for the first time can interpret it without
-          having to read any PSA in the status output,
+        * branch in the current worktree (whether main or linked) -> the literal returned by
+          `_current_worktree_label` (`<this worktree>` by default) - self-explanatory so users encountering
+          the label for the first time can interpret it without having to read any PSA in the status output,
         * branch in the main worktree, but the user is standing in a linked worktree -> `<main worktree>`,
         * branch in any other linked worktree -> that worktree's stripped-prefix label
           (`strip_longest_common_path_prefix` collapses sibling linked worktrees to plain basenames,
           so typical layouts like `~/worktrees/wt1`, `~/worktrees/wt2`, ... render as `wt1`, `wt2`, ...).
 
-        The main worktree gets a literal `<main worktree>` label rather than participating in the prefix
-        computation, because mixing it in could artificially lengthen every linked-worktree label
-        (e.g. when the main worktree lives in the user's home dir but linked worktrees sit under `/tmp` -
-        the only shared component would be `/`, leaving every label as a full absolute path).
+        Worktrees carrying a literal label stay out of the prefix computation, because mixing them in could
+        artificially lengthen every remaining label (e.g. when the main worktree lives in the user's home dir
+        but linked worktrees sit under `/tmp` - the only shared component would be `/`, leaving every label
+        as a full absolute path).
 
         The whole feature is gated on at least one linked worktree existing: in a plain single-worktree
         repo we don't want a `[<this worktree>]` tag stuck on the current branch of every status output,
@@ -441,6 +447,7 @@ class StatusMacheteClient(MacheteClient):
 
         main_path = self._git.get_main_worktree_root_dir()
         current_path = self._git.get_current_worktree_root_dir()
+        current_label = self._current_worktree_label()
 
         # `.keys()` covers detached-HEAD linked worktrees too - this is what makes the gate fire
         # in repos whose only linked worktree happens to be detached.
@@ -448,8 +455,9 @@ class StatusMacheteClient(MacheteClient):
         if not linked_paths:
             return {}
 
-        stripped = strip_longest_common_path_prefix([str(p) for p in linked_paths])
-        label_by_linked_path = dict(zip(linked_paths, stripped))
+        paths_to_derive_label_for = [p for p in linked_paths if p != current_path or current_label is None]
+        stripped = strip_longest_common_path_prefix([str(p) for p in paths_to_derive_label_for])
+        label_by_linked_path = dict(zip(paths_to_derive_label_for, stripped))
 
         # For the same-branch-in-multiple-worktrees foot-gun, multiple iterations write to
         # `labels[branch]` - the last write wins. Since porcelain emits main first and linked
@@ -460,8 +468,8 @@ class StatusMacheteClient(MacheteClient):
         for path, branch in branch_by_worktree_path.items():
             if branch is None:
                 continue
-            if path == current_path:
-                labels[branch] = "<this worktree>"
+            if path == current_path and current_label is not None:
+                labels[branch] = current_label
             elif path == main_path:
                 labels[branch] = "<main worktree>"
             else:

--- a/git_machete/client/traverse.py
+++ b/git_machete/client/traverse.py
@@ -54,6 +54,20 @@ class TraverseMacheteClient(MacheteClientWithCodeHosting):
         self.__temporary_worktree_path: Optional[AbsPath] = None
         self.__dir_before_temporary_worktree: Optional[AbsPath] = None
 
+    def _current_worktree_label(self) -> Optional[str]:
+        """`traverse` `chdir`s between worktrees as it walks the branch tree, so the process' current
+        directory drifts away from the one the user's shell is standing in. `<this worktree>` would then
+        point at whichever worktree `traverse` most recently hopped into - which reads as if the user
+        were there - so every status printed during a traversal names the current worktree explicitly
+        (`<main worktree>` or its stripped-prefix label) instead.
+
+        The exception is the temporary worktree (see `machete.traverse.whenBranchNotCheckedOutInAnyWorktree`),
+        which is by construction always the *current* one: `_switch_branch` creates it, `chdir`s into it and
+        clears this field before `chdir`ing back out. Its randomly-generated `git-machete-worktree-*` basename
+        would be pure noise, so it's named for what it is instead.
+        """
+        return "<temporary worktree>" if self.__temporary_worktree_path is not None else None
+
     def _find_worktree_for_branch(self, branch: LocalBranchShortName) -> Optional[AbsPath]:
         # Fresh porcelain query on each call - `git worktree list --porcelain` is cheap (a single
         # subprocess with tiny output) and traverse only hits this method on each `_switch_branch`,

--- a/tests/test_traverse_worktrees.py
+++ b/tests/test_traverse_worktrees.py
@@ -87,7 +87,7 @@ class TestTraverseWorktrees(BaseTest):
 
               develop [<main worktree>]
               |
-              x-feature-1 * [<this worktree>] (ahead of origin)
+              x-feature-1 * [{feature_1_label}] (ahead of origin)
                 |
                 x-feature-2 [{feature_2_label}]
 
@@ -102,7 +102,7 @@ class TestTraverseWorktrees(BaseTest):
               |
               o-feature-1 [{feature_1_label}]
                 |
-                x-feature-2 * [<this worktree>]
+                x-feature-2 * [{feature_2_label}]
 
             Rebasing feature-2 onto feature-1...
 
@@ -113,7 +113,7 @@ class TestTraverseWorktrees(BaseTest):
               |
               o-feature-1 [{feature_1_label}]
                 |
-                o-feature-2 * [<this worktree>]
+                o-feature-2 * [{feature_2_label}]
 
             Reached branch feature-2 which has no successor; nothing left to update
             Warn: branch feature-2 is checked out in worktree at {normalized_feature_2_worktree}
@@ -135,7 +135,11 @@ class TestTraverseWorktrees(BaseTest):
         assert "feature-1 additional commit" in feature_2_log
 
     def test_traverse_cd_from_linked_to_main_worktree(self) -> None:
-        """Test traverse cd from linked worktree to main worktree for non-checked-out branch."""
+        """Test traverse cd from linked worktree to main worktree for non-checked-out branch.
+
+        Also pins down that no status printed by traverse ever says `<this worktree>`: traverse `chdir`s
+        into the main worktree here, while the user's shell stays in the linked worktree it was launched
+        from, so `<this worktree>` would name a directory the user isn't standing in."""
         (local_path, _) = create_repo_with_remote()
         new_branch("root")
         commit()
@@ -192,7 +196,7 @@ class TestTraverseWorktrees(BaseTest):
               |
               o-branch-1 [{branch_1_label}]
               |
-              o-branch-2 * [<this worktree>] (untracked)
+              o-branch-2 * [<main worktree>] (untracked)
 
             Pushing untracked branch branch-2 to origin...
 
@@ -200,7 +204,7 @@ class TestTraverseWorktrees(BaseTest):
               |
               o-branch-1 [{branch_1_label}]
               |
-              o-branch-2 * [<this worktree>]
+              o-branch-2 * [<main worktree>]
 
             Reached branch branch-2 which has no successor; nothing left to update
             Warn: branch branch-2 is checked out in worktree at {normalized_local_path}
@@ -215,7 +219,7 @@ class TestTraverseWorktrees(BaseTest):
         now in the main worktree, not `root`). This exercises the live re-query of
         `git worktree list --porcelain` inside `_find_worktree_for_branch`/`_compute_worktree_label_by_branch`
         - any stale snapshot would still report `root` as the branch held by the main worktree
-        and the `[<this worktree>]` label would land on the wrong row."""
+        and the `[<main worktree>]` label would land on the wrong row."""
         (local_path, _) = create_repo_with_remote()
         new_branch("root")
         commit()
@@ -246,7 +250,7 @@ class TestTraverseWorktrees(BaseTest):
         # 2. Visit branch-1 (in linked worktree, no action needed - don't cd).
         # 3. Visit branch-2 (not checked out anywhere) - checkout branch-2 in main worktree.
         # The post-checkout status block (printed after the rebase/push step) must show
-        # `branch-2 * [<this worktree>]` because the main worktree now holds branch-2.
+        # `branch-2 * [<main worktree>]` because the main worktree now holds branch-2.
         #
         # Note: branch-2 was created on top of branch-1, so it appears yellow (?) - the fork
         # point inference sees that branch-2 doesn't contain branch-1.
@@ -259,7 +263,7 @@ class TestTraverseWorktrees(BaseTest):
               |
               o-branch-1 [{branch_1_label}]
               |
-              ?-branch-2 * [<this worktree>] (untracked)
+              ?-branch-2 * [<main worktree>] (untracked)
 
             Warn: yellow edge indicates that fork point for branch-2 is probably incorrectly inferred,
             or that some extra branch should be between root and branch-2.
@@ -274,7 +278,7 @@ class TestTraverseWorktrees(BaseTest):
               |
               o-branch-1 [{branch_1_label}]
               |
-              o-branch-2 * [<this worktree>]
+              o-branch-2 * [<main worktree>]
 
             Reached branch branch-2 which has no successor; nothing left to update
             """
@@ -376,6 +380,8 @@ class TestTraverseWorktrees(BaseTest):
         self.patch_symbol(mocker, 'builtins.input', mock_input_returning("q"))
 
         normalized_branch_1_worktree = AbsPath(branch_1_worktree)
+        # Single linked worktree: strip_longest_common_path_prefix falls back to the basename.
+        branch_1_label = os.path.basename(normalized_branch_1_worktree)
 
         # This corner case tests that when user quits mid-traverse,
         # the final warning is shown if ended in a different worktree
@@ -386,7 +392,7 @@ class TestTraverseWorktrees(BaseTest):
 
               root [<main worktree>]
               |
-              x-branch-1 * [<this worktree>]
+              x-branch-1 * [{branch_1_label}]
 
             Rebase branch-1 onto root? (y, N, q, yq)
             Warn: branch branch-1 is checked out in worktree at {normalized_branch_1_worktree}
@@ -454,7 +460,7 @@ class TestTraverseWorktrees(BaseTest):
 
               root [{root_label}] (untracked)
               |
-              x-branch-1 * [<this worktree>]
+              x-branch-1 * [<main worktree>]
               |
               x-branch-2 [{branch_2_label}]
 
@@ -466,7 +472,7 @@ class TestTraverseWorktrees(BaseTest):
               |
               x-branch-1 [<main worktree>]
               |
-              x-branch-2 * [<this worktree>]
+              x-branch-2 * [{branch_2_label}]
 
             Rebase branch-2 onto root? (y, N, q, yq)
 
@@ -474,7 +480,7 @@ class TestTraverseWorktrees(BaseTest):
               |
               x-branch-1 [<main worktree>]
               |
-              x-branch-2 * [<this worktree>]
+              x-branch-2 * [{branch_2_label}]
 
             Reached branch branch-2 which has no successor; nothing left to update
             Warn: branch branch-2 is checked out in worktree at {normalized_branch_2_worktree}
@@ -506,7 +512,7 @@ class TestTraverseWorktrees(BaseTest):
 
               root (untracked)
               |
-              x-branch-1 * [<this worktree>]
+              x-branch-1 * [{root_label}]
               |
               x-branch-2 [{branch_2_label}]
 
@@ -518,7 +524,7 @@ class TestTraverseWorktrees(BaseTest):
               |
               x-branch-1 [{root_label}]
               |
-              x-branch-2 * [<this worktree>]
+              x-branch-2 * [{branch_2_label}]
 
             Rebase branch-2 onto root? (y, N, q, yq)
 
@@ -526,7 +532,7 @@ class TestTraverseWorktrees(BaseTest):
               |
               x-branch-1 [{root_label}]
               |
-              x-branch-2 * [<this worktree>]
+              x-branch-2 * [{branch_2_label}]
 
             Reached branch branch-2 which has no successor; nothing left to update
             Warn: branch branch-2 is checked out in worktree at {normalized_branch_2_worktree}
@@ -576,9 +582,9 @@ class TestTraverseWorktrees(BaseTest):
         # branch-to-worktree mapping and `root` ends up labeled with `root_worktree`'s basename.
         root_label = os.path.basename(normalized_root_worktree)
 
-        # The temp worktree gets a random `git-machete-worktree-XXXX` basename, but it's also the
-        # *current* worktree (traverse cd's into it), so its label collapses to the literal
-        # `<this worktree>` -- which keeps this whole assertion deterministic.
+        # The temp worktree gets a random `git-machete-worktree-XXXX` basename, but it's always the
+        # *current* worktree (traverse cd's into it), so it's labeled `<temporary worktree>` for what it is
+        # rather than by path -- which keeps this whole assertion deterministic.
         self.patch_symbol(mocker, 'builtins.input', mock_input_returning("n", "n", "n"))
         assert_success(
             ["traverse"],
@@ -589,7 +595,7 @@ class TestTraverseWorktrees(BaseTest):
 
               root [{root_label}] (untracked)
               |
-              x-branch-1 * [<this worktree>]
+              x-branch-1 * [<temporary worktree>]
               |
               x-branch-2
 
@@ -602,7 +608,7 @@ class TestTraverseWorktrees(BaseTest):
               |
               x-branch-1
               |
-              x-branch-2 * [<this worktree>]
+              x-branch-2 * [<temporary worktree>]
 
             Rebase branch-2 onto root? (y, N, q, yq)
 
@@ -610,7 +616,7 @@ class TestTraverseWorktrees(BaseTest):
               |
               x-branch-1
               |
-              x-branch-2 * [<this worktree>]
+              x-branch-2 * [<temporary worktree>]
 
             Reached branch branch-2 which has no successor; nothing left to update
             Removing the temporary worktree; changing directory back to {normalized_root_worktree}
@@ -651,6 +657,8 @@ class TestTraverseWorktrees(BaseTest):
 
         normalized_local_path = AbsPath(local_path)
 
+        # The temporary worktree is the repo's only linked worktree here, and it's enough to make the
+        # worktree labels fire at all - so `root` gets tagged as living in the main worktree.
         assert_success(
             ["traverse", "-y"],
             f"""
@@ -658,7 +666,7 @@ class TestTraverseWorktrees(BaseTest):
 
               root [<main worktree>]
               |
-              x-feature * [<this worktree>]
+              x-feature * [<temporary worktree>]
 
             Rebasing feature onto root...
 
@@ -667,7 +675,7 @@ class TestTraverseWorktrees(BaseTest):
 
               root [<main worktree>]
               |
-              o-feature * [<this worktree>]
+              o-feature * [<temporary worktree>]
 
             Reached branch feature which has no successor; nothing left to update
             Removing the temporary worktree; changing directory back to {normalized_local_path}
@@ -728,7 +736,7 @@ class TestTraverseWorktrees(BaseTest):
 
               root [<main worktree>]
               |
-              x-feature * [<this worktree>]
+              x-feature * [<temporary worktree>]
 
             Rebasing feature onto root...
 
@@ -737,7 +745,7 @@ class TestTraverseWorktrees(BaseTest):
 
               root [<main worktree>]
               |
-              o-feature * [<this worktree>]
+              o-feature * [<temporary worktree>]
 
             Reached branch feature which has no successor; nothing left to update
             Removing the temporary worktree; changing directory back to {normalized_local_path}
@@ -774,6 +782,8 @@ class TestTraverseWorktrees(BaseTest):
         check_out("base")
         feature_worktree = add_worktree("feature")
         normalized_feature_worktree = AbsPath(feature_worktree)
+        # Single linked worktree: strip_longest_common_path_prefix falls back to the basename.
+        feature_label = os.path.basename(normalized_feature_worktree)
 
         # Make a conflicting change on base
         check_out("base")
@@ -791,7 +801,7 @@ class TestTraverseWorktrees(BaseTest):
 
               base [<main worktree>]
               |
-              x-feature * [<this worktree>]
+              x-feature * [{feature_label}]
 
             Rebasing feature onto base...
             Warn: branch feature is checked out in worktree at {normalized_feature_worktree}
@@ -844,6 +854,8 @@ class TestTraverseWorktrees(BaseTest):
         os.chdir(initial_dir)
 
         normalized_a_worktree = AbsPath(a_worktree)
+        # Single linked worktree: strip_longest_common_path_prefix falls back to the basename.
+        a_label = os.path.basename(normalized_a_worktree)
 
         assert_success(
             ["traverse", "-y"],
@@ -852,7 +864,7 @@ class TestTraverseWorktrees(BaseTest):
 
               main [<main worktree>]
               |
-              m-a * [<this worktree>] (untracked)
+              m-a * [{a_label}] (untracked)
 
             Branch a is merged into main. Sliding a out of the tree of branch dependencies...
 


### PR DESCRIPTION
`status` labels the worktree reported by `git rev-parse --show-toplevel` as `<this worktree>`, which only coincides with the directory the user's shell is in for commands that never change directory.
`traverse` does change directory - into the main worktree, into the linked worktree holding the target branch, or into a temporary one - so from its second status block onward the label pointed at wherever `traverse` had most recently hopped, reading as though the user were standing there.

The literal to use for the worktree the process is standing in is now an overridable `_current_worktree_label`.
`traverse` returns `None` (name that worktree explicitly, like any other) except while inside its temporary worktree, which by construction is always the current one - `_switch_branch` creates it, `chdir`s in, and clears the field before `chdir`ing back out - and which is now labeled `<temporary worktree>` rather than by its randomly-generated `git-machete-worktree-*` basename.
This is an overridable hook rather than a parameter on `status()` because `traverse --sync-github-prs` also reaches status indirectly, via `create_pull_request`.

Worktrees carrying a literal label now stay out of the common-prefix computation, generalizing the rule that already applied to the main worktree: leaving the temporary worktree in could drag the shared prefix down to `/` and render every other label as a full absolute path.
As a side effect, `<this worktree>` no longer pollutes that computation in plain `status` either, which can only shorten the remaining labels.

`traverse` is the only command that `chdir`s, so `status`, `discover`, interactive `go` and the `github`/`gitlab` create-pr/restack-pr flows keep rendering `<this worktree>` and are unaffected.

## Test plan

- [x] Nine assertions across `tests/test_traverse_worktrees.py` moved off `<this worktree>`; `test_traverse_cd_from_linked_to_main_worktree` covers the reported scenario (traverse hops from the linked worktree into main) and its docstring now names the invariant.
- [x] The three temporary-worktree tests pin down the new `[<temporary worktree>]` label.
- [x] Full suite: 481 passed, 1 skipped.
- [x] `tox -e mypy,isort,pep8,typos-check,cyclic-import-check,py-docs-check,sphinx-man-check` all green.