### PR TITLE
Fix UnicodeDecodeError on non-UTF-8 diffs in exact squash-merge detection

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@
 - fixed: when run from a branch being slid out, `git machete slide-out` no longer checks out that branch's new parent if a child branch is going to be checked out right afterwards anyway for the rebase/merge
 - fixed: the statuses printed by `git machete traverse` no longer use the `[<this worktree>]` label, which pointed at whichever worktree `traverse` had most recently changed directory into rather than the one the user's shell is in;
   each worktree is now named explicitly, with `traverse`'s own temporary worktree (see `machete.traverse.whenBranchNotCheckedOutInAnyWorktree`) labeled `[<temporary worktree>]`
+- fixed: `git machete status`/`go` with `--squash-merge-detection=exact` no longer crash with `UnicodeDecodeError` when a captured diff contains non-UTF-8 bytes (reported by @mcitoler)
 
 ## New in git-machete 3.44.1
 

--- a/git_machete/utils/_subproc.py
+++ b/git_machete/utils/_subproc.py
@@ -32,6 +32,8 @@ def _popen_cmd(cmd: str, *args: str,
     process = subprocess.Popen([cmd] + list(args), stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=stdin, cwd=cwd, env=env)
     stdout_bytes, stderr_bytes = process.communicate(input_bytes)
     exit_code: int = process.returncode  # must be retrieved after process.communicate()
-    stdout: str = stdout_bytes.decode('utf-8')
-    stderr: str = stderr_bytes.decode('utf-8')
+    # Git output (especially `diff` / `log --patch`) can contain arbitrary bytes from file contents;
+    # never crash on non-UTF-8 (see issue #1767).
+    stdout: str = stdout_bytes.decode('utf-8', errors='replace')
+    stderr: str = stderr_bytes.decode('utf-8', errors='replace')
     return PopenResult(exit_code, stdout, stderr)

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -505,6 +505,38 @@ class TestStatus(BaseTest):
         set_git_config_key('machete.squashMergeDetection', 'exact')
         assert_success(['status'], expected_status_output_exact)
 
+    def test_status_exact_squash_merge_detection_with_non_utf8_diff(self) -> None:
+        """Regression for #1767: exact mode runs `git log --patch` / `git diff` and must not crash on non-UTF-8 bytes."""
+        create_repo()
+        new_branch("main")
+        commit("initial commit")
+        new_branch("feature")
+        # Non-UTF-8 on the child: exercised by `git diff` inside `is_equivalent_patch_reachable`.
+        execute("printf 'feature with invalid utf8: \\xff\\xfe end\\n' > feature-binaryish.txt")
+        execute("git add feature-binaryish.txt")
+        execute('git commit -m "add feature file with invalid UTF-8 bytes"')
+        check_out("main")
+        # Non-UTF-8 on the parent: exercised by `git log --patch` inside `__get_patch_ids_for_commits_between`.
+        execute("printf 'main with invalid utf8: \\xff\\xfe end\\n' > main-binaryish.txt")
+        execute("git add main-binaryish.txt")
+        execute('git commit -m "add main file with invalid UTF-8 bytes"')
+
+        body: str = \
+            """
+            main
+                feature
+            """
+        rewrite_branch_layout_file(body)
+
+        expected_status_output = (
+            """
+            main *
+            |
+            x-feature
+            """
+        )
+        assert_success(['status', '--squash-merge-detection=exact'], expected_status_output)
+
     def test_status_invalid_squash_merge_detection(self) -> None:
         create_repo()
         assert_failure(["status", "--squash-merge-detection=invalid"],


### PR DESCRIPTION
## Summary
- Fixes #1767: `status`/`go` with `--squash-merge-detection=exact` no longer crashes with `UnicodeDecodeError` when a captured `git diff` / `git log --patch` contains non-UTF-8 file bytes.
- Decode subprocess stdout/stderr in `_popen_cmd` with `errors='replace'` (the only production path that captures and decodes git output, including both patch-id inputs used by exact mode).
- Adds a regression test that puts invalid UTF-8 on both parent and child branches so both the `git diff` and `git log --patch` paths are exercised.

## Test plan
- [x] `tox -e py -- tests/test_status.py::TestStatus::test_status_exact_squash_merge_detection_with_non_utf8_diff` (failed before the fix, passes after)
- [x] Related exact squash-merge tests still pass (`test_status_for_squash_merge_and_commits_in_between`, `test_is_equivalent_tree_or_patch_*`)
- [x] `tox -e mypy`, `tox -e isort`