### PR TITLE
Apply minor fixes before releasing v3.45.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,14 +2,13 @@
 
 ## New in git-machete 3.45.0
 
-- added: `GIT_MACHETE_PUSH_OPTS` environment variable forwards arbitrary extra options to every `git push` invocation
-  made by `advance`, `github create-pr`/`restack-pr`, `gitlab create-mr`/`restack-mr` and `traverse`
-  (e.g. `GIT_MACHETE_PUSH_OPTS="--push-option=ci.skip" git machete traverse`), analogous to the existing `GIT_MACHETE_REBASE_OPTS`
-  (contributed by @HWiese1980)
+- added: `GIT_MACHETE_PUSH_OPTS` environment variable forwards arbitrary extra options to every `git push` invocation (contributed by @HWiese1980)
 - fixed: `git machete discover` no longer produces a different branch tree depending on which worktree it is run from;
   the fresh-branch recency ranking now aggregates HEAD reflogs across all worktrees rather than only the current one (reported by @jasonoura, contributed by @earfman)
-- fixed: when run from a branch being slid out, `git machete slide-out` no longer checks out that branch's new parent if a child branch is going to be checked out right afterwards anyway for the rebase/merge
-- fixed: the statuses printed by `git machete traverse` no longer use the `[<this worktree>]` label, which pointed at whichever worktree `traverse` had most recently changed directory into rather than the one the user's shell is in;
+- fixed: when run from a branch being slid out, `git machete slide-out` no longer checks out that branch's new parent
+  if a child branch is going to be checked out right afterwards anyway for the rebase/merge
+- fixed: the statuses printed by `git machete traverse` no longer use the `[<this worktree>]` label,
+  which pointed at whichever worktree `traverse` had most recently changed directory into rather than the one the user's shell is in;
   each worktree is now named explicitly, with `traverse`'s own temporary worktree (see `machete.traverse.whenBranchNotCheckedOutInAnyWorktree`) labeled `[<temporary worktree>]`
 - fixed: `git machete status`/`go` with `--squash-merge-detection=exact` no longer crash with `UnicodeDecodeError` when a captured diff contains non-UTF-8 bytes (reported by @mcitoler)
 

--- a/docs/man/git-machete.1
+++ b/docs/man/git-machete.1
@@ -1302,7 +1302,7 @@ from the message body of the first unique commit of the branch, even if \fB\&.gi
 GitHub API token.
 .UNINDENT
 .sp
-\fBEnvironment variables (\(ga\(gacreate\-pr\(ga\(ga and \(ga\(garestack\-pr\(ga\(ga only)\fP
+\fBEnvironment variables (create\-pr and restack\-pr only)\fP
 .INDENT 0.0
 .TP
 .B \fBGIT_MACHETE_PUSH_OPTS\fP
@@ -1605,7 +1605,7 @@ from the message body of the first unique commit of the branch, even if \fB\&.gi
 GitLab API token.
 .UNINDENT
 .sp
-\fBEnvironment variables (\(ga\(gacreate\-mr\(ga\(ga and \(ga\(garestack\-mr\(ga\(ga only)\fP
+\fBEnvironment variables (create\-mr and restack\-mr only)\fP
 .INDENT 0.0
 .TP
 .B \fBGIT_MACHETE_PUSH_OPTS\fP

--- a/docs/source/cli/github.rst
+++ b/docs/source/cli/github.rst
@@ -182,7 +182,7 @@ Create, check out and manage GitHub PRs while keeping them reflected in branch l
 ``GITHUB_TOKEN``
     GitHub API token.
 
-**Environment variables (``create-pr`` and ``restack-pr`` only)**
+**Environment variables (create-pr and restack-pr only)**
 
 ``GIT_MACHETE_PUSH_OPTS``
     .. include:: env-vars/git_machete_push_opts.rst

--- a/docs/source/cli/gitlab.rst
+++ b/docs/source/cli/gitlab.rst
@@ -173,7 +173,7 @@ Create, check out and manage GitLab MRs while keeping them reflected in branch l
 ``GITLAB_TOKEN``
     GitLab API token.
 
-**Environment variables (``create-mr`` and ``restack-mr`` only)**
+**Environment variables (create-mr and restack-mr only)**
 
 ``GIT_MACHETE_PUSH_OPTS``
     .. include:: env-vars/git_machete_push_opts.rst

--- a/git_machete/generated_docs.py
+++ b/git_machete/generated_docs.py
@@ -914,7 +914,7 @@ long_docs: Dict[str, str] = {
            `GITHUB_TOKEN`
               GitHub API token.
 
-        <b>Environment variables (`create-pr` and `restack-pr` only)</b>
+        <b>Environment variables (create-pr and restack-pr only)</b>
 
            `GIT_MACHETE_PUSH_OPTS`
               Extra options to pass to the underlying `git push` invocations, space-separated.
@@ -1140,7 +1140,7 @@ long_docs: Dict[str, str] = {
            `GITLAB_TOKEN`
               GitLab API token.
 
-        <b>Environment variables (`create-mr` and `restack-mr` only)</b>
+        <b>Environment variables (create-mr and restack-mr only)</b>
 
            `GIT_MACHETE_PUSH_OPTS`
               Extra options to pass to the underlying `git push` invocations, space-separated.


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1770

## Chain of upstream PRs as of 2026-09-05

* PR #1770:
  `master` ← `develop`

  * **PR #1771 (THIS ONE)**:
    `develop` ← `fix/minor-3.45.0`

<!-- end git-machete generated -->
