### PR TITLE
Preserve branch annotations during discovery

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## New in git-machete 3.45.1
 
+- fixed: `git machete discover` preserves full annotations on rediscovered branches, rather than only their traversal qualifiers
+
 ## New in git-machete 3.45.0
 
 - added: `GIT_MACHETE_PUSH_OPTS` environment variable forwards arbitrary extra options to every `git push` invocation (contributed by @HWiese1980)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## New in git-machete 3.45.1
 
-- fixed: `git machete discover` preserves full annotations on rediscovered branches, rather than only their traversal qualifiers
+- fixed: `git machete discover` preserves full annotations on rediscovered branches, rather than only their traversal qualifiers (contributed by @be-student)
 
 ## New in git-machete 3.45.0
 

--- a/docs/man/git-machete.1
+++ b/docs/man/git-machete.1
@@ -785,7 +785,8 @@ and asks whether to overwrite the existing branch layout file with the new disco
 If confirmed with a \fBy[es]\fP or \fBe[dit]\fP reply, backs up the current branch layout file (if it exists) as \fB$GIT_DIR/machete~\fP
 and saves the new tree under the usual \fB$GIT_DIR/machete\fP path.
 If the reply was \fBe[dit]\fP, additionally an editor is opened (as in: \fBgit machete\fP edit) after saving the new branch layout file.
-\fBdiscover\fP retains the existing branch qualifiers used by \fBgit machete traverse\fP (see help for traverse).
+\fBdiscover\fP retains existing annotations for branches included in the discovered tree,
+including the branch qualifiers used by \fBgit machete traverse\fP (see help for traverse).
 .sp
 \fBOptions\fP
 .INDENT 0.0

--- a/docs/source/cli/discover.rst
+++ b/docs/source/cli/discover.rst
@@ -13,7 +13,8 @@ and asks whether to overwrite the existing branch layout :ref:`file` with the ne
 If confirmed with a ``y[es]`` or ``e[dit]`` reply, backs up the current branch layout file (if it exists) as ``$GIT_DIR/machete~``
 and saves the new tree under the usual ``$GIT_DIR/machete`` path.
 If the reply was ``e[dit]``, additionally an editor is opened (as in: ``git machete`` :ref:`edit`) after saving the new branch layout file.
-``discover`` retains the existing branch qualifiers used by ``git machete traverse`` (see help for :ref:`traverse`).
+``discover`` retains existing annotations for branches included in the discovered tree,
+including the branch qualifiers used by ``git machete traverse`` (see help for :ref:`traverse`).
 
 **Options**
 

--- a/git_machete/client/discover.py
+++ b/git_machete/client/discover.py
@@ -44,10 +44,6 @@ class DiscoverMacheteClient(StatusMacheteClient):
                 initial_roots.append(LocalBranchShortName.of("main"))
             if "develop" in self._git.get_local_branches():
                 initial_roots.append(LocalBranchShortName.of("develop"))
-        for managed in self._state.managed_branches:
-            anno = self._state.get_annotation(managed)
-            if anno is not None:
-                self._state.set_annotation(managed, anno._replace(text_without_qualifiers=''))
         self._state.reset_tree(initial_roots)
 
         root_of = dict((branch, branch) for branch in all_local_branches)

--- a/git_machete/generated_docs.py
+++ b/git_machete/generated_docs.py
@@ -526,7 +526,8 @@ long_docs: Dict[str, str] = {
         If confirmed with a `y[es]` or `e[dit]` reply, backs up the current branch layout file (if it exists) as `$GIT_DIR/machete~`
         and saves the new tree under the usual `$GIT_DIR/machete` path.
         If the reply was `e[dit]`, additionally an editor is opened (as in: `git machete` `edit`) after saving the new branch layout file.
-        `discover` retains the existing branch qualifiers used by `git machete traverse` (see help for `traverse`).
+        `discover` retains existing annotations for branches included in the discovered tree,
+        including the branch qualifiers used by `git machete traverse` (see help for `traverse`).
 
         <b>Options</b>
 

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -18,7 +18,8 @@ from tests.shell import read_file
 
 class TestDiscover(BaseTest):
 
-    def test_discover(self) -> None:
+    @pytest.mark.parametrize('annotation', ['annotation', 'review #123: café'])
+    def test_discover(self, annotation: str) -> None:
         create_repo_with_remote()
         assert_failure(['discover'], "No local branches found")
 
@@ -37,25 +38,33 @@ class TestDiscover(BaseTest):
         commit()
 
         body: str = \
-            """
-            master
+            f"""
+            master root {annotation}
             feature1
-            feature2 annotation
-            feature3 annotation rebase=no push=no
+            feature2 {annotation}
+            feature3 {annotation} rebase=no push=no
             """
         rewrite_branch_layout_file(body)
+        original_layout = read_file(".git/machete")
         launch_command('discover', '-y')
-        assert os.path.exists(".git/machete~")
+        assert read_file(".git/machete~") == original_layout
+        assert read_file(".git/machete") == (
+            f"master root {annotation}\n"
+            "  feature1\n"
+            f"    feature2 {annotation}\n"
+            f"  feature3 {annotation} rebase=no push=no\n"
+            "    feature4\n"
+        )
 
         expected_status_output = (
-            """
-            master
+            f"""
+            master  root {annotation}
             |
             o-feature1 (untracked)
             | |
-            | o-feature2 (untracked)
+            | o-feature2  {annotation} (untracked)
             |
-            o-feature3  rebase=no push=no
+            o-feature3  {annotation} rebase=no push=no
               |
               o-feature4 * (untracked)
             """
@@ -63,16 +72,16 @@ class TestDiscover(BaseTest):
         assert_success(['status'], expected_status_output)
 
         expected_discover_output = (
-            """
+            f"""
             Discovered tree of branch dependencies:
 
               feature1 (untracked)
               |
-              o-feature2 (untracked)
+              o-feature2  {annotation} (untracked)
 
-              master
+              master  root {annotation}
               |
-              o-feature3  rebase=no push=no
+              o-feature3  {annotation} rebase=no push=no
                 |
                 o-feature4 * (untracked)
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -85,7 +85,7 @@ class TestGitHub(BaseTest):
 
         launch_command('github', 'checkout-prs', '--all')
         launch_command('discover', '--checked-out-since=1 day ago')
-        expected_status_output = 'develop *\n' + '\n'.join([f'|\no-feature_{i:02d}  rebase=no push=no'
+        expected_status_output = 'develop *  *\n' + '\n'.join([f'|\no-feature_{i:02d}  PR #{i} (some_other_user) rebase=no push=no'
                                                             for i in range(self.PR_COUNT_FOR_TEST_GITHUB_API_PAGINATION)]) + '\n'
         assert_success(['status'], expected_status_output)
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -85,8 +85,14 @@ class TestGitHub(BaseTest):
 
         launch_command('github', 'checkout-prs', '--all')
         launch_command('discover', '--checked-out-since=1 day ago')
-        expected_status_output = 'develop *  *\n' + '\n'.join([f'|\no-feature_{i:02d}  PR #{i} (some_other_user) rebase=no push=no'
-                                                            for i in range(self.PR_COUNT_FOR_TEST_GITHUB_API_PAGINATION)]) + '\n'
+        expected_status_output = (
+            'develop *  *\n'
+            + '\n'.join([
+                f'|\no-feature_{i:02d}  PR #{i} (some_other_user) rebase=no push=no'
+                for i in range(self.PR_COUNT_FOR_TEST_GITHUB_API_PAGINATION)
+            ])
+            + '\n'
+        )
         assert_success(['status'], expected_status_output)
 
     def test_github_enterprise_domain_unauthorized_without_token(self, mocker: MockerFixture) -> None:

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -85,14 +85,14 @@ class TestGitHub(BaseTest):
 
         launch_command('github', 'checkout-prs', '--all')
         launch_command('discover', '--checked-out-since=1 day ago')
-        expected_status_output = (
-            'develop *  *\n'
-            + '\n'.join([
+        expected_status_output = ''.join([
+            'develop *  *\n',
+            '\n'.join([
                 f'|\no-feature_{i:02d}  PR #{i} (some_other_user) rebase=no push=no'
                 for i in range(self.PR_COUNT_FOR_TEST_GITHUB_API_PAGINATION)
-            ])
-            + '\n'
-        )
+            ]),
+            '\n',
+        ])
         assert_success(['status'], expected_status_output)
 
     def test_github_enterprise_domain_unauthorized_without_token(self, mocker: MockerFixture) -> None:

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -86,14 +86,14 @@ class TestGitLab(BaseTest):
 
         launch_command('gitlab', 'checkout-mrs', '--all')
         launch_command('discover', '--checked-out-since=1 day ago')
-        expected_status_output = (
-            'develop *  *\n'
-            + '\n'.join([
+        expected_status_output = ''.join([
+            'develop *  *\n',
+            '\n'.join([
                 f'|\no-feature_{i:02d}  MR !{i} (some_other_user) rebase=no push=no'
                 for i in range(self.MR_COUNT_FOR_TEST_GITLAB_API_PAGINATION)
-            ])
-            + '\n'
-        )
+            ]),
+            '\n',
+        ])
         assert_success(['status'], expected_status_output)
 
     def test_gitlab_enterprise_domain_unauthorized_without_token(self, mocker: MockerFixture) -> None:

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -86,7 +86,7 @@ class TestGitLab(BaseTest):
 
         launch_command('gitlab', 'checkout-mrs', '--all')
         launch_command('discover', '--checked-out-since=1 day ago')
-        expected_status_output = 'develop *\n' + '\n'.join([f'|\no-feature_{i:02d}  rebase=no push=no'
+        expected_status_output = 'develop *  *\n' + '\n'.join([f'|\no-feature_{i:02d}  MR !{i} (some_other_user) rebase=no push=no'
                                                             for i in range(self.MR_COUNT_FOR_TEST_GITLAB_API_PAGINATION)]) + '\n'
         assert_success(['status'], expected_status_output)
 

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -86,8 +86,14 @@ class TestGitLab(BaseTest):
 
         launch_command('gitlab', 'checkout-mrs', '--all')
         launch_command('discover', '--checked-out-since=1 day ago')
-        expected_status_output = 'develop *  *\n' + '\n'.join([f'|\no-feature_{i:02d}  MR !{i} (some_other_user) rebase=no push=no'
-                                                            for i in range(self.MR_COUNT_FOR_TEST_GITLAB_API_PAGINATION)]) + '\n'
+        expected_status_output = (
+            'develop *  *\n'
+            + '\n'.join([
+                f'|\no-feature_{i:02d}  MR !{i} (some_other_user) rebase=no push=no'
+                for i in range(self.MR_COUNT_FOR_TEST_GITLAB_API_PAGINATION)
+            ])
+            + '\n'
+        )
         assert_success(['status'], expected_status_output)
 
     def test_gitlab_enterprise_domain_unauthorized_without_token(self, mocker: MockerFixture) -> None:


### PR DESCRIPTION
Fixes #547.

`discover` currently strips free-text annotations while rebuilding the branch tree. Preserve the existing annotations for branches included in the discovered tree, including root annotations, PR/MR references, and traversal qualifiers.

The discovery regression covers plain and Unicode annotations, the saved layout, an unchanged backup, status output, and a second discovery with explicit roots. GitHub/GitLab pagination tests now verify that checkout annotations survive discovery. Update the command documentation, generated help/man page, and release notes.

Validation: all 7 discovery tests and 3 affected CLI/GitHub/GitLab integration tests pass through tox. Tox formatting, isort, mypy, generated-help checks, and Sphinx HTML/man builds pass. Repository static checks pass; the optional remark link check was skipped because remark is unavailable. Flake8/vulture are left to CI as directed by AGENTS.md.
