### PR TITLE
Always open text files as UTF-8 so Windows locale encoding cannot corrupt layout annotations.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,7 +303,7 @@ only_special_branches: &only_special_branches
   filters:
     branches:
       only:
-        - "/.*(aur|ci[/-]|cross-platform|dependabot.pip|deploy|dry.run|homebrew|hotfix|macos|nix|publish|release|windows).*/"
+        - "/.*(aur|ci[/-]|cross-platform|dependabot.pip|deploy|dry.run|homebrew|hotfix|macos|nix|publish|release|utf.?8|windows).*/"
         - "develop"
         - "master"
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## New in git-machete 3.45.1
 
 - fixed: `git machete discover` preserves full annotations on rediscovered branches, rather than only their traversal qualifiers (contributed by @be-student)
+- fixed: branch layout files are now always read and written as UTF-8 rather than the process locale encoding, so annotations with non-ASCII characters no longer break on Windows
 
 ## New in git-machete 3.45.0
 

--- a/docs/generate_py_docs.py
+++ b/docs/generate_py_docs.py
@@ -10,7 +10,7 @@ def resolve_includes(rst_content: str, docs_source_dir: str) -> str:
     # example match:
     #     .. include:: status.extraSpaceBeforeBranchName.rst
     for include_indent, included_file in matches:
-        with open(f'{docs_source_dir}/{included_file}', 'r') as handle:
+        with open(f'{docs_source_dir}/{included_file}', 'r', encoding='utf-8') as handle:
             include_text = handle.read()
         replace_from = f'{include_indent}.. include:: {included_file}'
         replace_to = indent(dedent(include_text), include_indent)
@@ -143,7 +143,7 @@ if __name__ == '__main__':
     # build short docs
     output_text += 'short_docs: Dict[str, str] = {\n'
     short_docs_rst_file = docs_source_path + '/short_docs.rst'
-    with open(short_docs_rst_file, 'r') as f:
+    with open(short_docs_rst_file, 'r', encoding='utf-8') as f:
         rst = f.read()
     for line in rst.splitlines():
         if line.startswith('* :ref:'):
@@ -156,7 +156,7 @@ if __name__ == '__main__':
     commands_and_file_paths = {f.split('.')[0]: join(path, f) for f in sorted(os.listdir(path)) if isfile(join(path, f))}
 
     for command, file in commands_and_file_paths.items():
-        with open(file, 'r') as f:
+        with open(file, 'r', encoding='utf-8') as f:
             rst = f.read()
         rst = resolve_includes(rst_content=rst, docs_source_dir=docs_source_path)
         plain_text = rst2txt(rst).rstrip()

--- a/flake8/utf8_open_checker.py
+++ b/flake8/utf8_open_checker.py
@@ -1,0 +1,57 @@
+import ast
+from typing import Optional
+
+from flake8_plugin_utils import Error, Plugin, Visitor
+
+
+class TextFileShouldBeOpenedAsUtf8(Error):
+    code = "UTF100"
+    message = "Text files must be opened with encoding='utf-8'"
+
+
+class Utf8OpenVisitor(Visitor):
+
+    @staticmethod
+    def _string_value(node: Optional[ast.AST]) -> Optional[str]:
+        value = getattr(node, "value", None)
+        if isinstance(value, str):
+            return value
+        legacy_value = getattr(node, "s", None)
+        return legacy_value if isinstance(legacy_value, str) else None
+
+    @staticmethod
+    def _is_open_call(node: ast.Call) -> bool:
+        return (
+            isinstance(node.func, ast.Name) and node.func.id == "open"
+        ) or (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "io"
+            and node.func.attr == "open"
+        )
+
+    @staticmethod
+    def _keyword_value(node: ast.Call, keyword_name: str):
+        return next((keyword.value for keyword in node.keywords if keyword.arg == keyword_name), None)
+
+    @classmethod
+    def _is_binary_mode(cls, node: ast.Call) -> bool:
+        mode = node.args[1] if len(node.args) > 1 else cls._keyword_value(node, "mode")
+        mode_value = cls._string_value(mode)
+        return mode_value is not None and "b" in mode_value
+
+    @classmethod
+    def _is_utf8_encoding(cls, node: ast.Call) -> bool:
+        encoding = node.args[3] if len(node.args) > 3 else cls._keyword_value(node, "encoding")
+        encoding_value = cls._string_value(encoding)
+        return encoding_value is not None and encoding_value.lower().replace("_", "-") == "utf-8"
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if self._is_open_call(node) and not self._is_binary_mode(node) and not self._is_utf8_encoding(node):
+            self.error_from_node(TextFileShouldBeOpenedAsUtf8, node)
+        self.generic_visit(node)
+
+
+class Utf8OpenChecker(Plugin):
+    name = "Utf8OpenChecker"
+    visitors = [Utf8OpenVisitor]

--- a/flake8/utf8_open_checker.py
+++ b/flake8/utf8_open_checker.py
@@ -9,6 +9,11 @@ class TextFileShouldBeOpenedAsUtf8(Error):
     message = "Text files must be opened with encoding='utf-8'"
 
 
+class TextFileWriteShouldPinNewline(Error):
+    code = "UTF101"
+    message = "Text files opened for writing must set newline='\\n' or newline=''"
+
+
 class Utf8OpenVisitor(Visitor):
 
     @staticmethod
@@ -31,14 +36,23 @@ class Utf8OpenVisitor(Visitor):
         )
 
     @staticmethod
-    def _keyword_value(node: ast.Call, keyword_name: str):
+    def _keyword_value(node: ast.Call, keyword_name: str) -> Optional[ast.AST]:
         return next((keyword.value for keyword in node.keywords if keyword.arg == keyword_name), None)
 
     @classmethod
-    def _is_binary_mode(cls, node: ast.Call) -> bool:
+    def _mode_value(cls, node: ast.Call) -> Optional[str]:
         mode = node.args[1] if len(node.args) > 1 else cls._keyword_value(node, "mode")
-        mode_value = cls._string_value(mode)
+        return cls._string_value(mode)
+
+    @classmethod
+    def _is_binary_mode(cls, node: ast.Call) -> bool:
+        mode_value = cls._mode_value(node)
         return mode_value is not None and "b" in mode_value
+
+    @classmethod
+    def _is_write_mode(cls, node: ast.Call) -> bool:
+        mode_value = cls._mode_value(node)
+        return mode_value is not None and any(flag in mode_value for flag in "wax+")
 
     @classmethod
     def _is_utf8_encoding(cls, node: ast.Call) -> bool:
@@ -46,9 +60,18 @@ class Utf8OpenVisitor(Visitor):
         encoding_value = cls._string_value(encoding)
         return encoding_value is not None and encoding_value.lower().replace("_", "-") == "utf-8"
 
+    @classmethod
+    def _has_pinned_newline(cls, node: ast.Call) -> bool:
+        newline = node.args[5] if len(node.args) > 5 else cls._keyword_value(node, "newline")
+        newline_value = cls._string_value(newline)
+        return newline_value in ("\n", "")
+
     def visit_Call(self, node: ast.Call) -> None:
-        if self._is_open_call(node) and not self._is_binary_mode(node) and not self._is_utf8_encoding(node):
-            self.error_from_node(TextFileShouldBeOpenedAsUtf8, node)
+        if self._is_open_call(node) and not self._is_binary_mode(node):
+            if not self._is_utf8_encoding(node):
+                self.error_from_node(TextFileShouldBeOpenedAsUtf8, node)
+            if self._is_write_mode(node) and not self._has_pinned_newline(node):
+                self.error_from_node(TextFileWriteShouldPinNewline, node)
         self.generic_visit(node)
 
 

--- a/flake8/utf8_open_checker.py
+++ b/flake8/utf8_open_checker.py
@@ -24,10 +24,10 @@ class Utf8OpenVisitor(Visitor):
         return (
             isinstance(node.func, ast.Name) and node.func.id == "open"
         ) or (
-            isinstance(node.func, ast.Attribute)
-            and isinstance(node.func.value, ast.Name)
-            and node.func.value.id == "io"
-            and node.func.attr == "open"
+            isinstance(node.func, ast.Attribute) and
+            isinstance(node.func.value, ast.Name) and
+            node.func.value.id == "io" and
+            node.func.attr == "open"
         )
 
     @staticmethod

--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -58,7 +58,7 @@ class MacheteClient:
             # We're opening in "append" and not "write" mode to avoid a race condition:
             # if other process writes to the file between we check the result of `os.path.exists` and call `open`,
             # then open(..., "w") would result in us clearing up the file contents, while open(..., "a") has no effect.
-            with open(self._branch_layout_file_path, "a"):
+            with open(self._branch_layout_file_path, "a", encoding='utf-8'):
                 pass
         elif os.path.isdir(self._branch_layout_file_path):
             # Extremely unlikely case, basically checking if anybody tampered with the repository.

--- a/git_machete/client/base.py
+++ b/git_machete/client/base.py
@@ -58,7 +58,7 @@ class MacheteClient:
             # We're opening in "append" and not "write" mode to avoid a race condition:
             # if other process writes to the file between we check the result of `os.path.exists` and call `open`,
             # then open(..., "w") would result in us clearing up the file contents, while open(..., "a") has no effect.
-            with open(self._branch_layout_file_path, "a", encoding='utf-8'):
+            with open(self._branch_layout_file_path, "a", encoding='utf-8', newline='\n'):
                 pass
         elif os.path.isdir(self._branch_layout_file_path):
             # Extremely unlikely case, basically checking if anybody tampered with the repository.

--- a/git_machete/client/branch_layout.py
+++ b/git_machete/client/branch_layout.py
@@ -19,7 +19,7 @@ def parse(path: AbsPath, *, display_path: Optional[Path] = None) -> Tuple[Machet
     useful when `path` is an absolute internal location and the caller wants a more compact cwd-relative form shown to the user.
     """
     msg_path: Path = display_path if display_path is not None else path
-    with open(path) as f:
+    with open(path, encoding='utf-8') as f:
         lines: List[str] = [line.rstrip() for line in f.readlines()]
 
     state = MacheteState()
@@ -103,5 +103,5 @@ def render(state: MacheteState, indent: str) -> List[str]:
 
 def save(path: AbsPath, state: MacheteState, *, indent: str) -> None:
     """Write *state* to the branch layout file at *path*."""
-    with open(path, "w") as f:
+    with open(path, "w", encoding='utf-8', newline='\n') as f:
         f.write("\n".join(render(state, indent)) + "\n")

--- a/git_machete/git.py
+++ b/git_machete/git.py
@@ -1073,7 +1073,7 @@ class Git:
             return
 
         debug(f"reading merge-base cache from {cache_path}")
-        with open(cache_path, 'r') as f:
+        with open(cache_path, 'r', encoding='utf-8') as f:
             for line_num, line in enumerate(f, start=1):
                 line = line.strip()
                 if not line:
@@ -1108,7 +1108,7 @@ class Git:
     def __save_merge_base_cache_entry(self, *, hash1: FullCommitHash, hash2: FullCommitHash, merge_base: Optional[FullCommitHash]) -> None:
         """Append a merge-base cache entry to the cache file."""
         cache_path = self.__get_merge_base_cache_path()
-        with open(cache_path, 'a') as f:
+        with open(cache_path, 'a', encoding='utf-8', newline='\n') as f:
             debug(f"writing merge-base cache entry to {cache_path}: {hash1} {hash2} {merge_base or '(no merge-base)'}")
             if merge_base is not None:
                 f.write(f"{hash1} {hash2}  {merge_base}\n")
@@ -1366,12 +1366,12 @@ class Git:
                     return f"{line.rstrip()}'\n" if faulty_line_regex.fullmatch(line) else line
 
                 def get_all_lines_fixed() -> Iterator[str]:
-                    with open(author_script) as f_read:
+                    with open(author_script, encoding='utf-8') as f_read:
                         return map(fix_if_needed, f_read.readlines())
 
                 fixed_lines = get_all_lines_fixed()  # must happen before we open for writing
                 # See https://github.com/VirtusLab/git-machete/issues/935 for why author-script needs to be saved in this manner
-                io.open(author_script, "w", newline="").write("".join(fixed_lines))
+                io.open(author_script, "w", encoding='utf-8', newline="").write("".join(fixed_lines))
 
     # === Commits & log/diff display ===
 

--- a/git_machete/utils/fs.py
+++ b/git_machete/utils/fs.py
@@ -54,5 +54,5 @@ def find_executable(executable: str) -> Optional[AbsPath]:
 
 
 def slurp_file(path: Path) -> str:
-    with open(path, 'r') as file:
+    with open(path, 'r', encoding='utf-8') as file:
         return file.read()

--- a/tests/cli_runner.py
+++ b/tests/cli_runner.py
@@ -84,11 +84,11 @@ def assert_argument_error(cmd_and_args: Iterable[str], expected_output: str) -> 
 
 
 def read_branch_layout_file() -> str:
-    with open(".git/machete") as def_file:
+    with open(".git/machete", encoding='utf-8') as def_file:
         return def_file.read()
 
 
 def rewrite_branch_layout_file(new_body: str) -> None:
     new_body = textwrap.dedent(new_body)
-    with open(".git/machete", 'w') as def_file:
+    with open(".git/machete", 'w', encoding='utf-8', newline='\n') as def_file:
         def_file.writelines(new_body)

--- a/tests/shell.py
+++ b/tests/shell.py
@@ -23,7 +23,7 @@ def write_to_file(file_path: str, file_content: str) -> None:
     dirname = os.path.dirname(file_path)
     if dirname:
         os.makedirs(dirname, exist_ok=True)
-    with open(file_path, 'w', encoding='utf-8') as f:
+    with open(file_path, 'w', encoding='utf-8', newline='\n') as f:
         f.write(file_content)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -134,6 +134,7 @@ show-source = True
 [flake8:local-plugins]
 extension =
   KW = keyword_argument_checker:KeywordArgumentChecker
+  UTF = utf8_open_checker:Utf8OpenChecker
 paths = flake8
 
 # Set isort configuration options which are used by the `isort` command in [testenv:isort] and [testenv:isort-check].


### PR DESCRIPTION
## Summary
- Pin `encoding='utf-8'` (and LF newlines on writes) on every text-file `open()`/`io.open()` so Windows cp1252 cannot write `café` as `0xe9` into `.git/machete`.
- Add Flake8 `UTF100` so a missing encoding on `open()` is rejected at lint time, including the original `rewrite_branch_layout_file` helper.

## Test plan
- [x] `tox -e py -- tests/test_discover.py tests/test_git.py tests/test_edit.py`
- [ ] Windows CircleCI `windows tests` job (the original `UnicodeDecodeError` on `test_discover`)
- [ ] `tox -e flake8-check` on CI (UTF100)