### PR TITLE
Add unit tests for the local KW and UTF Flake8 checkers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
           command: ci/checks/run-all-checks.sh
       - run:
           name: Check code style
-          command: tox -e isort-check,flake8-check,typos-check,vulture-check,cyclic-import-check
+          command: tox -e isort-check,flake8-check,flake8-checker-tests,typos-check,vulture-check,cyclic-import-check
       - run:
           name: Verify docs
           command: tox -e py-docs-check,sphinx-man-check,sphinx-html

--- a/flake8/test_keyword_argument_checker.py
+++ b/flake8/test_keyword_argument_checker.py
@@ -1,0 +1,58 @@
+from flake8_plugin_utils import assert_error, assert_not_error
+from keyword_argument_checker import ArgumentShouldBeKeyword, KeywordArgumentVisitor, RepeatedArgumentType
+
+
+def test_opt_prefix_must_be_keyword_only() -> None:
+    assert_error(
+        KeywordArgumentVisitor,
+        "def discover(self, opt_yes: str) -> None: ...",
+        ArgumentShouldBeKeyword,
+        function_name="discover",
+        argument_name="opt_yes",
+        reason="an 'opt_...'",
+    )
+
+
+def test_bool_must_be_keyword_only() -> None:
+    assert_error(
+        KeywordArgumentVisitor,
+        "def go(self, recache: bool) -> None: ...",
+        ArgumentShouldBeKeyword,
+        function_name="go",
+        argument_name="recache",
+        reason="a bool",
+    )
+
+
+def test_repeated_effective_str_types_must_be_keyword_only() -> None:
+    assert_error(
+        KeywordArgumentVisitor,
+        "def pair(self, left: str, right: str) -> None: ...",
+        RepeatedArgumentType,
+        function_name="pair",
+        repeated_type="str",
+    )
+
+
+def test_branch_name_annotations_count_as_str() -> None:
+    assert_error(
+        KeywordArgumentVisitor,
+        "def wire(self, parent: LocalBranchShortName, child: LocalBranchShortName) -> None: ...",
+        RepeatedArgumentType,
+        function_name="wire",
+        repeated_type="str",
+    )
+
+
+def test_keyword_only_opt_and_bool_are_ok() -> None:
+    assert_not_error(
+        KeywordArgumentVisitor,
+        "def discover(self, *, opt_yes: bool) -> None: ...",
+    )
+
+
+def test_distinct_positional_types_are_ok() -> None:
+    assert_not_error(
+        KeywordArgumentVisitor,
+        "def pair(self, left: str, right: int) -> None: ...",
+    )

--- a/flake8/test_utf8_open_checker.py
+++ b/flake8/test_utf8_open_checker.py
@@ -1,0 +1,46 @@
+import ast
+
+from flake8_plugin_utils import assert_error, assert_not_error
+from utf8_open_checker import TextFileShouldBeOpenedAsUtf8, TextFileWriteShouldPinNewline, Utf8OpenVisitor
+
+
+def test_missing_encoding_on_read() -> None:
+    assert_error(Utf8OpenVisitor, 'open("layout")', TextFileShouldBeOpenedAsUtf8)
+
+
+def test_write_without_encoding_or_newline_reports_both() -> None:
+    visitor = Utf8OpenVisitor()
+    visitor.visit(ast.parse('open(".git/machete", "w")'))
+    assert [type(error) for error in visitor.errors] == [TextFileShouldBeOpenedAsUtf8, TextFileWriteShouldPinNewline]
+
+
+def test_non_utf8_encoding() -> None:
+    assert_error(Utf8OpenVisitor, 'open("layout", encoding="cp1252")', TextFileShouldBeOpenedAsUtf8)
+
+
+def test_utf8_read_is_ok() -> None:
+    assert_not_error(Utf8OpenVisitor, 'open("layout", encoding="utf-8")')
+
+
+def test_utf8_alias_read_is_ok() -> None:
+    assert_not_error(Utf8OpenVisitor, 'open("layout", encoding="UTF_8")')
+
+
+def test_binary_write_is_ok() -> None:
+    assert_not_error(Utf8OpenVisitor, 'open("layout", "wb")')
+
+
+def test_write_with_utf8_but_missing_newline() -> None:
+    assert_error(Utf8OpenVisitor, 'open("layout", "w", encoding="utf-8")', TextFileWriteShouldPinNewline)
+
+
+def test_append_with_utf8_but_missing_newline() -> None:
+    assert_error(Utf8OpenVisitor, 'open("layout", "a", encoding="utf-8")', TextFileWriteShouldPinNewline)
+
+
+def test_write_with_lf_newline_is_ok() -> None:
+    assert_not_error(Utf8OpenVisitor, 'open("layout", "w", encoding="utf-8", newline="\\n")')
+
+
+def test_write_with_untranslated_newline_is_ok() -> None:
+    assert_not_error(Utf8OpenVisitor, 'io.open("layout", "w", encoding="utf-8", newline="")')

--- a/requirements/flake8-check.txt
+++ b/requirements/flake8-check.txt
@@ -2,4 +2,3 @@ flake8==7.3.0
 flake8-plugin-utils==1.3.3
 flake8-unused-arguments==0.0.14
 flake8-use-fstring==1.4
-pytest==8.3.5

--- a/requirements/flake8-check.txt
+++ b/requirements/flake8-check.txt
@@ -2,3 +2,4 @@ flake8==7.3.0
 flake8-plugin-utils==1.3.3
 flake8-unused-arguments==0.0.14
 flake8-use-fstring==1.4
+pytest==8.3.5

--- a/requirements/flake8-checker-tests.txt
+++ b/requirements/flake8-checker-tests.txt
@@ -1,0 +1,3 @@
+-r flake8-check.txt
+
+pytest==8.3.5

--- a/tox.ini
+++ b/tox.ini
@@ -118,7 +118,9 @@ commands =
 description = "Check code style"
 deps =
   -r{[requirements]dir}/flake8-check.txt
-commands = flake8 --enable-extensions=FS003
+commands =
+  flake8 --enable-extensions=FS003
+  python -m pytest flake8/test_keyword_argument_checker.py flake8/test_utf8_open_checker.py
 
 # Set flake8 configuration options which are used by the `flake8` command in [testenv:flake8-check]
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ commands =
   sh -c "rm -f {toxinidir}/.coverage.*"
 
 [coverage:run]
-omit = tests/*,git_machete/bin.py
+omit = tests/*,git_machete/bin.py,flake8/*
 relative_files = True
 
 [coverage:report]
@@ -100,6 +100,7 @@ commands =
 
 [pytest]
 markers = completion_e2e
+testpaths = tests
 
 
 ## CODE STYLE

--- a/tox.ini
+++ b/tox.ini
@@ -119,9 +119,13 @@ commands =
 description = "Check code style"
 deps =
   -r{[requirements]dir}/flake8-check.txt
-commands =
-  flake8 --enable-extensions=FS003
-  python -m pytest flake8/test_keyword_argument_checker.py flake8/test_utf8_open_checker.py
+commands = flake8 --enable-extensions=FS003
+
+[testenv:flake8-checker-tests]
+description = "Test local Flake8 checkers"
+deps =
+  -r{[requirements]dir}/flake8-checker-tests.txt
+commands = python -m pytest flake8/test_keyword_argument_checker.py flake8/test_utf8_open_checker.py
 
 # Set flake8 configuration options which are used by the `flake8` command in [testenv:flake8-check]
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -125,7 +125,7 @@ commands = flake8 --enable-extensions=FS003
 description = "Test local Flake8 checkers"
 deps =
   -r{[requirements]dir}/flake8-checker-tests.txt
-commands = python -m pytest flake8/test_keyword_argument_checker.py flake8/test_utf8_open_checker.py
+commands = python -m pytest flake8/
 
 # Set flake8 configuration options which are used by the `flake8` command in [testenv:flake8-check]
 [flake8]


### PR DESCRIPTION
## Summary
- Unit-test the local Flake8 visitors (`KW100`/`KW101` and `UTF100`/`UTF101`) via `flake8-plugin-utils`.
- Run those tests in a dedicated `flake8-checker-tests` tox environment, invoked explicitly by CircleCI General checks but excluded from the default local tox envlist and coverage suite.

## Test plan
- [x] `tox -e flake8-check`
- [x] `tox -e flake8-checker-tests` (16 plugin tests)
- [x] `tox -e isort-check`